### PR TITLE
DT-2951: Improve disease matching test coverage

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatchCasesV4.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatchCasesV4.java
@@ -22,7 +22,7 @@ public class DataUseMatchCasesV4 {
       "The HMB Research Purpose does not match the Disease-Specific data use limitations.";
   private static final String HMB_F3 =
       "The HMB Research Purpose does not match the POA data use limitations.";
-  private static final String DS_F2 =
+  static final String DS_F2 =
       "The Disease-Specific: %s Research Purpose is not a valid subclass of the Disease-Specific data use limitations.";
   private static final String MDS_F1 =
       "The Methods development Research Purpose does not match the Disease-Specific data use limitations.";
@@ -32,9 +32,9 @@ public class DataUseMatchCasesV4 {
       "The For-Profit Research Purpose does not match the Non-Profit Use (NPU) only data use limitation.";
 
   // rationale for approvals - based on dataset terms
-  private static final String DS_APPROVE_GRU =
+  static final String DS_APPROVE_GRU =
       "The proposed disease-specific research is within the bounds of the general research use permissions of the dataset(s)";
-  private static final String DS_APPROVE_HMB =
+  static final String DS_APPROVE_HMB =
       "The proposed disease-specific research is within the bounds of the health, medical, biomedical use permissions of the dataset(s)";
   private static final String HMB_APPROVE_HMB =
       "The proposed health, medical, biomedical research is within the bounds of the health, medical, biomedical use permissions of the dataset(s)";
@@ -84,11 +84,15 @@ public class DataUseMatchCasesV4 {
           DataUseMatchResultType.APPROVE, Collections.singletonList(DS_APPROVE_HMB));
     }
 
-    // We want all-purpose disease IDs to be a subclass of any dataset disease ID
+    // We want all-purpose disease IDs to be a subclass of any dataset disease ID. The dataset's
+    // disease restrictions may be null (e.g. a POA- or NPU-only dataset), so guard against it.
+    List<String> datasetDiseaseRestrictions =
+        isNullOrEmpty(dataset.getDiseaseRestrictions())
+            ? Collections.emptyList()
+            : dataset.getDiseaseRestrictions();
     List<String> failures = new ArrayList<>();
     for (Map.Entry<String, List<String>> entry : purposeDiseaseIdMap.entrySet()) {
-      boolean match =
-          entry.getValue().stream().anyMatch(dataset.getDiseaseRestrictions()::contains);
+      boolean match = entry.getValue().stream().anyMatch(datasetDiseaseRestrictions::contains);
       if (!match) {
         failures.add(String.format(DS_F2, entry.getKey()));
       }

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
@@ -30,6 +30,7 @@ class DataUseMatcherV4Test {
 
   private static final String CANCER_NODE = "http://purl.obolibrary.org/obo/DOID_162";
   private static final String INTESTINAL_CANCER_NODE = "http://purl.obolibrary.org/obo/DOID_10155";
+  private static final String BRAIN_CANCER_NODE = "http://purl.obolibrary.org/obo/DOID_1319";
   private final Gson gson = GsonUtil.getInstance();
 
   @Mock private OntologyService ontologyService;
@@ -96,6 +97,69 @@ class DataUseMatcherV4Test {
               // Streaming output that writes terms
               output.write(gson.toJson(termResources).getBytes(StandardCharsets.UTF_8));
             });
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Deny(match.getMatchResultType()));
+    assertTrue(match.getMessage().contains(String.format(DataUseMatchCasesV4.DS_F2, CANCER_NODE)));
+  }
+
+  @Test
+  void testDiseaseMatching_datasetGRU() {
+    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
+    DataUse purpose = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    mockOntologyTerm(CANCER_NODE, "http://purl.obolibrary.org/obo/DOID_14566");
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Approve(match.getMatchResultType()));
+    assertTrue(match.getMessage().contains(DataUseMatchCasesV4.DS_APPROVE_GRU));
+  }
+
+  @Test
+  void testDiseaseMatching_datasetHMB() {
+    DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
+    DataUse purpose = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    mockOntologyTerm(CANCER_NODE, "http://purl.obolibrary.org/obo/DOID_14566");
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Approve(match.getMatchResultType()));
+    assertTrue(match.getMessage().contains(DataUseMatchCasesV4.DS_APPROVE_HMB));
+  }
+
+  // An exact disease match (purpose term == dataset term, with no ontology parents) should approve.
+  @Test
+  void testDiseaseMatching_exactMatch() {
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    DataUse purpose = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    mockOntologyTerm(CANCER_NODE);
+    assertApprove(purpose, dataset);
+  }
+
+  // When the purpose lists multiple diseases, every one must be a subclass of a dataset disease.
+  // Here one term matches and one does not, so the result is a denial naming the unmatched term.
+  @Test
+  void testDiseaseMatching_multipleDiseases_partialMatch() {
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    DataUse purpose =
+        new DataUseBuilder()
+            .setDiseaseRestrictions(List.of(INTESTINAL_CANCER_NODE, BRAIN_CANCER_NODE))
+            .build();
+    // Intestinal cancer is a subclass of cancer; brain cancer is not.
+    mockOntologyTerm(INTESTINAL_CANCER_NODE, CANCER_NODE);
+    mockOntologyTerm(BRAIN_CANCER_NODE, "http://purl.obolibrary.org/obo/DOID_14566");
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Deny(match.getMatchResultType()));
+    assertTrue(
+        match.getMessage().contains(String.format(DataUseMatchCasesV4.DS_F2, BRAIN_CANCER_NODE)));
+    assertFalse(
+        match
+            .getMessage()
+            .contains(String.format(DataUseMatchCasesV4.DS_F2, INTESTINAL_CANCER_NODE)));
+  }
+
+  // A disease-specific purpose against a dataset that has no disease restrictions and is neither
+  // GRU nor HMB cannot match, and must not throw on the dataset's null restriction list.
+  @Test
+  void testDiseaseMatching_datasetHasNoDiseaseRestrictions() {
+    DataUse dataset = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
+    DataUse purpose = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    mockOntologyTerm(CANCER_NODE, "http://purl.obolibrary.org/obo/DOID_14566");
     assertDeny(purpose, dataset);
   }
 
@@ -349,5 +413,22 @@ class DataUseMatcherV4Test {
   private MatchResult matchPurposeAndDataset(DataUse purpose, DataUse dataset) {
     DataUseMatcherV4 matcher = new DataUseMatcherV4(new DataUseUtil(ontologyService));
     return matcher.matchPurposeAndDatasetV4(purpose, dataset);
+  }
+
+  /**
+   * Stub the ontology service so that a lookup of {@code termId} returns a term whose parents are
+   * {@code parentIds}. Pass no parent ids to model a leaf term (e.g. for exact-match scenarios).
+   */
+  private void mockOntologyTerm(String termId, String... parentIds) {
+    OntologyTerm resource = new OntologyTerm(termId, "v1", OntologyType.DOID.name());
+    for (String parentId : parentIds) {
+      ParentTerm parent = new ParentTerm();
+      parent.setId(parentId);
+      resource.addParent(parent);
+    }
+    List<OntologyTerm> termResources = List.of(resource);
+    when(ontologyService.findByTermIds(new String[] {termId}))
+        .thenReturn(
+            output -> output.write(gson.toJson(termResources).getBytes(StandardCharsets.UTF_8)));
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2951

## Summary
- Handle latent NPE in `matchDiseases` 
- New tests:
  - `testDiseaseMatching_datasetHasNoDiseaseRestrictions` — the NPE regression test (now asserts DENY).
  - `testDiseaseMatching_datasetGRU` — covers the DS_APPROVE_GRU branch.
  - `testDiseaseMatching_datasetHMB` — covers the DS_APPROVE_HMB branch.
  - `testDiseaseMatching_exactMatch` — purpose term == dataset term with no ontology parents.
  - `testDiseaseMatching_multipleDiseases_partialMatch` — multiple purpose diseases where one matches and one doesn't; asserts the failure names only the unmatched term.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
