### PR TITLE
DT-2952: Cover matchMDS branches with direct unit tests

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatchCasesV4.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatchCasesV4.java
@@ -24,7 +24,7 @@ public class DataUseMatchCasesV4 {
       "The HMB Research Purpose does not match the POA data use limitations.";
   static final String DS_F2 =
       "The Disease-Specific: %s Research Purpose is not a valid subclass of the Disease-Specific data use limitations.";
-  private static final String MDS_F1 =
+  static final String MDS_F1 =
       "The Methods development Research Purpose does not match the Disease-Specific data use limitations.";
   private static final String POA_F1 =
       "The Populations, Origins, Ancestry Research Purpose does not match the HMB or Disease-Specific data use limitation.";
@@ -44,7 +44,7 @@ public class DataUseMatchCasesV4 {
       "The proposed population, origins, and/or ancestry research is within the bounds of the general research use permissions of the dataset(s)";
   private static final String POA_APPROVE_POA =
       "The proposed population, origins, and/or ancestry research is within the bounds of the population, origins, and/or ancestry use permissions of the dataset(s)";
-  private static final String MDS_APPROVE =
+  static final String MDS_APPROVE =
       "Methods research is permitted on controlled-access data so long as it is not expressly prohibited";
 
   // rationale for abstain cases

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
@@ -234,6 +234,11 @@ class DataUseMatcherV4Test {
     assertDeny(purpose, dataset);
   }
 
+  // The following testMDS_positive_case_* tests drive the full matcher. Because neither the purpose
+  // nor the dataset has disease restrictions, matchMDS short-circuits to APPROVE on its first
+  // branch and never reaches the GRU/HMB/POA approval logic. They are retained as integration
+  // coverage of that short-circuit; the testMatchMDS_* tests below exercise matchMDS directly so
+  // that each of its branches is covered in isolation.
   @Test
   void testMDS_positive_case_1() {
     DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
@@ -260,6 +265,122 @@ class DataUseMatcherV4Test {
     DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
     DataUse purpose = new DataUseBuilder().setMethodsResearch(true).build();
     assertApprove(purpose, dataset);
+  }
+
+  // Direct unit tests of matchMDS, covering each branch in isolation. A disease restriction is
+  // present on the purpose and/or dataset so the "no disease focused research" short-circuit does
+  // not pre-empt the branch under test. The diseaseMatch argument is set explicitly per case.
+
+  // Branch A: neither purpose nor dataset has disease restrictions -> APPROVE with no rationale.
+  @Test
+  void testMatchMDS_noDiseaseRestrictions_approve() {
+    DataUse purpose = new DataUseBuilder().setMethodsResearch(true).build();
+    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().isEmpty());
+  }
+
+  // Branch B: methodsResearch is false -> APPROVE with no rationale.
+  @Test
+  void testMatchMDS_methodsResearchFalse_approve() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(false)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().isEmpty());
+  }
+
+  // Branch B: methodsResearch is null -> APPROVE with no rationale.
+  @Test
+  void testMatchMDS_methodsResearchNull_approve() {
+    DataUse purpose = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().isEmpty());
+  }
+
+  // Branch C: dataset GRU -> APPROVE with MDS rationale (purpose disease restriction bypasses A).
+  @Test
+  void testMatchMDS_datasetGRU_approve() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(true)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().contains(DataUseMatchCasesV4.MDS_APPROVE));
+  }
+
+  // Branch D: dataset HMB -> APPROVE with MDS rationale.
+  @Test
+  void testMatchMDS_datasetHMB_approve() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(true)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().contains(DataUseMatchCasesV4.MDS_APPROVE));
+  }
+
+  // Branch E: dataset POA -> APPROVE with MDS rationale.
+  @Test
+  void testMatchMDS_datasetPOA_approve() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(true)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().contains(DataUseMatchCasesV4.MDS_APPROVE));
+  }
+
+  // Branch F approve: no GRU/HMB/POA match, but the disease match approved -> APPROVE.
+  @Test
+  void testMatchMDS_diseaseMatchApprove_approve() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(true)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.APPROVE);
+    assertTrue(Approve(result.getMatchResultType()));
+    assertTrue(result.getMessage().contains(DataUseMatchCasesV4.MDS_APPROVE));
+  }
+
+  // Branch F deny: no GRU/HMB/POA match and the disease match did not approve -> DENY with MDS_F1.
+  @Test
+  void testMatchMDS_diseaseMatchDeny_deny() {
+    DataUse purpose =
+        new DataUseBuilder()
+            .setMethodsResearch(true)
+            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .build();
+    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    MatchResult result =
+        DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
+    assertTrue(Deny(result.getMatchResultType()));
+    assertTrue(result.getMessage().contains(DataUseMatchCasesV4.MDS_F1));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV4Test.java
@@ -267,9 +267,11 @@ class DataUseMatcherV4Test {
     assertApprove(purpose, dataset);
   }
 
-  // Direct unit tests of matchMDS, covering each branch in isolation. A disease restriction is
-  // present on the purpose and/or dataset so the "no disease focused research" short-circuit does
-  // not pre-empt the branch under test. The diseaseMatch argument is set explicitly per case.
+  // Direct unit tests of matchMDS, covering each branch in isolation. The diseaseMatch argument is
+  // set explicitly per case. Except for Branch A below, which deliberately exercises the "no
+  // disease
+  // focused research" short-circuit, a disease restriction is present on the purpose and/or dataset
+  // so that short-circuit does not pre-empt the branch under test.
 
   // Branch A: neither purpose nor dataset has disease restrictions -> APPROVE with no rationale.
   @Test
@@ -369,14 +371,18 @@ class DataUseMatcherV4Test {
   }
 
   // Branch F deny: no GRU/HMB/POA match and the disease match did not approve -> DENY with MDS_F1.
+  // The disease restrictions intentionally differ (brain cancer is not a subclass of intestinal
+  // cancer) so the data reflects a non-approving disease match, though the injected diseaseMatch
+  // argument is what actually drives matchMDS here.
   @Test
   void testMatchMDS_diseaseMatchDeny_deny() {
     DataUse purpose =
         new DataUseBuilder()
             .setMethodsResearch(true)
-            .setDiseaseRestrictions(List.of(CANCER_NODE))
+            .setDiseaseRestrictions(List.of(BRAIN_CANCER_NODE))
             .build();
-    DataUse dataset = new DataUseBuilder().setDiseaseRestrictions(List.of(CANCER_NODE)).build();
+    DataUse dataset =
+        new DataUseBuilder().setDiseaseRestrictions(List.of(INTESTINAL_CANCER_NODE)).build();
     MatchResult result =
         DataUseMatchCasesV4.matchMDS(purpose, dataset, DataUseMatchResultType.DENY);
     assertTrue(Deny(result.getMatchResultType()));


### PR DESCRIPTION
### Addresses

[DT-2952](https://broadworkbench.atlassian.net/browse/DT-2952)

Security risk: no

### Summary

Fills coverage gaps in `DataUseMatchCasesV4.matchMDS`. The existing `testMDS_positive_case_*` tests run through the full matcher and short-circuit on the "no disease focused research" branch, so most of `matchMDS` was never exercised — most notably the DENY path.

- Add direct unit tests of `matchMDS` covering each branch in isolation (short-circuits, GRU/HMB/POA approvals, disease-match approve, and the previously-untested DENY path with `MDS_F1`).
- Make `MDS_F1` and `MDS_APPROVE` package-private so tests can assert the rationale strings, consistent with the other match-case constants.
- Annotate the existing integration-style tests to clarify what they actually exercise.

No production logic changes.

[DT-2952]: https://broadworkbench.atlassian.net/browse/DT-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ