### PR TITLE
[DT-3592] Add backend DTOs for dataset/study registration payloads with verification tests.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/ConsentGroupRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/ConsentGroupRequest.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
@@ -62,7 +60,7 @@ public class ConsentGroupRequest {
   private Boolean hmb;
 
   @JsonProperty("diseaseSpecificUse")
-  private List<String> diseaseSpecificUse = new ArrayList<>();
+  private List<String> diseaseSpecificUse;
 
   @JsonProperty("poa")
   private Boolean poa;
@@ -113,257 +111,207 @@ public class ConsentGroupRequest {
   private Integer numberOfParticipants;
 
   @JsonProperty("fileTypes")
-  private List<FileTypeObject> fileTypes = new ArrayList<>();
+  private List<FileTypeObject> fileTypes;
 
   @JsonProperty("data")
-  private Map<String, Object> data = new HashMap<>();
+  private Map<String, Object> data;
 
-  @JsonProperty("datasetId")
   public Integer getDatasetId() {
     return datasetId;
   }
 
-  @JsonProperty("datasetId")
   public void setDatasetId(Integer datasetId) {
     this.datasetId = datasetId;
   }
 
-  @JsonProperty("consentGroupName")
   public String getConsentGroupName() {
     return consentGroupName;
   }
 
-  @JsonProperty("consentGroupName")
   public void setConsentGroupName(String consentGroupName) {
     this.consentGroupName = consentGroupName;
   }
 
-  @JsonProperty("dataAccessCommitteeId")
   public Integer getDataAccessCommitteeId() {
     return dataAccessCommitteeId;
   }
 
-  @JsonProperty("dataAccessCommitteeId")
   public void setDataAccessCommitteeId(Integer dataAccessCommitteeId) {
     this.dataAccessCommitteeId = dataAccessCommitteeId;
   }
 
-  @JsonProperty("accessManagement")
   public ConsentGroup.AccessManagement getAccessManagement() {
     return accessManagement;
   }
 
-  @JsonProperty("accessManagement")
   public void setAccessManagement(ConsentGroup.AccessManagement accessManagement) {
     this.accessManagement = accessManagement;
   }
 
-  @JsonProperty("generalResearchUse")
   public Boolean getGeneralResearchUse() {
     return generalResearchUse;
   }
 
-  @JsonProperty("generalResearchUse")
   public void setGeneralResearchUse(Boolean generalResearchUse) {
     this.generalResearchUse = generalResearchUse;
   }
 
-  @JsonProperty("hmb")
   public Boolean getHmb() {
     return hmb;
   }
 
-  @JsonProperty("hmb")
   public void setHmb(Boolean hmb) {
     this.hmb = hmb;
   }
 
-  @JsonProperty("diseaseSpecificUse")
   public List<String> getDiseaseSpecificUse() {
     return diseaseSpecificUse;
   }
 
-  @JsonProperty("diseaseSpecificUse")
   public void setDiseaseSpecificUse(List<String> diseaseSpecificUse) {
     this.diseaseSpecificUse = diseaseSpecificUse;
   }
 
-  @JsonProperty("poa")
   public Boolean getPoa() {
     return poa;
   }
 
-  @JsonProperty("poa")
   public void setPoa(Boolean poa) {
     this.poa = poa;
   }
 
-  @JsonProperty("otherPrimary")
   public String getOtherPrimary() {
     return otherPrimary;
   }
 
-  @JsonProperty("otherPrimary")
   public void setOtherPrimary(String otherPrimary) {
     this.otherPrimary = otherPrimary;
   }
 
-  @JsonProperty("nmds")
   public Boolean getNmds() {
     return nmds;
   }
 
-  @JsonProperty("nmds")
   public void setNmds(Boolean nmds) {
     this.nmds = nmds;
   }
 
-  @JsonProperty("gso")
   public Boolean getGso() {
     return gso;
   }
 
-  @JsonProperty("gso")
   public void setGso(Boolean gso) {
     this.gso = gso;
   }
 
-  @JsonProperty("pub")
   public Boolean getPub() {
     return pub;
   }
 
-  @JsonProperty("pub")
   public void setPub(Boolean pub) {
     this.pub = pub;
   }
 
-  @JsonProperty("col")
   public Boolean getCol() {
     return col;
   }
 
-  @JsonProperty("col")
   public void setCol(Boolean col) {
     this.col = col;
   }
 
-  @JsonProperty("irb")
   public Boolean getIrb() {
     return irb;
   }
 
-  @JsonProperty("irb")
   public void setIrb(Boolean irb) {
     this.irb = irb;
   }
 
-  @JsonProperty("gs")
   public String getGs() {
     return gs;
   }
 
-  @JsonProperty("gs")
   public void setGs(String gs) {
     this.gs = gs;
   }
 
-  @JsonProperty("mor")
   public Boolean getMor() {
     return mor;
   }
 
-  @JsonProperty("mor")
   public void setMor(Boolean mor) {
     this.mor = mor;
   }
 
-  @JsonProperty("morDate")
   public String getMorDate() {
     return morDate;
   }
 
-  @JsonProperty("morDate")
   public void setMorDate(String morDate) {
     this.morDate = morDate;
   }
 
-  @JsonProperty("npu")
   public Boolean getNpu() {
     return npu;
   }
 
-  @JsonProperty("npu")
   public void setNpu(Boolean npu) {
     this.npu = npu;
   }
 
-  @JsonProperty("otherSecondary")
   public String getOtherSecondary() {
     return otherSecondary;
   }
 
-  @JsonProperty("otherSecondary")
   public void setOtherSecondary(String otherSecondary) {
     this.otherSecondary = otherSecondary;
   }
 
-  @JsonProperty("dataLocation")
   public ConsentGroup.DataLocation getDataLocation() {
     return dataLocation;
   }
 
-  @JsonProperty("dataLocation")
   public void setDataLocation(ConsentGroup.DataLocation dataLocation) {
     this.dataLocation = dataLocation;
   }
 
-  @JsonProperty("url")
   public URI getUrl() {
     return url;
   }
 
-  @JsonProperty("url")
   public void setUrl(URI url) {
     this.url = url;
   }
 
-  @JsonProperty("requestLocation")
   public URI getRequestLocation() {
     return requestLocation;
   }
 
-  @JsonProperty("requestLocation")
   public void setRequestLocation(URI requestLocation) {
     this.requestLocation = requestLocation;
   }
 
-  @JsonProperty("numberOfParticipants")
   public Integer getNumberOfParticipants() {
     return numberOfParticipants;
   }
 
-  @JsonProperty("numberOfParticipants")
   public void setNumberOfParticipants(Integer numberOfParticipants) {
     this.numberOfParticipants = numberOfParticipants;
   }
 
-  @JsonProperty("fileTypes")
   public List<FileTypeObject> getFileTypes() {
     return fileTypes;
   }
 
-  @JsonProperty("fileTypes")
   public void setFileTypes(List<FileTypeObject> fileTypes) {
     this.fileTypes = fileTypes;
   }
 
-  @JsonProperty("data")
   public Map<String, Object> getData() {
     return data;
   }
 
-  @JsonProperty("data")
   public void setData(Map<String, Object> data) {
     this.data = data;
   }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/ConsentGroupRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/ConsentGroupRequest.java
@@ -1,0 +1,370 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "datasetId",
+  "consentGroupName",
+  "accessManagement",
+  "generalResearchUse",
+  "hmb",
+  "diseaseSpecificUse",
+  "poa",
+  "otherPrimary",
+  "nmds",
+  "gso",
+  "pub",
+  "col",
+  "irb",
+  "gs",
+  "mor",
+  "morDate",
+  "npu",
+  "otherSecondary",
+  "dataAccessCommitteeId",
+  "dataLocation",
+  "url",
+  "requestLocation",
+  "numberOfParticipants",
+  "fileTypes",
+  "data"
+})
+public class ConsentGroupRequest {
+
+  @JsonProperty("datasetId")
+  private Integer datasetId;
+
+  @JsonProperty("consentGroupName")
+  private String consentGroupName;
+
+  @JsonProperty("dataAccessCommitteeId")
+  private Integer dataAccessCommitteeId;
+
+  @JsonProperty("accessManagement")
+  private ConsentGroup.AccessManagement accessManagement;
+
+  @JsonProperty("generalResearchUse")
+  private Boolean generalResearchUse;
+
+  @JsonProperty("hmb")
+  private Boolean hmb;
+
+  @JsonProperty("diseaseSpecificUse")
+  private List<String> diseaseSpecificUse = new ArrayList<>();
+
+  @JsonProperty("poa")
+  private Boolean poa;
+
+  @JsonProperty("otherPrimary")
+  private String otherPrimary;
+
+  @JsonProperty("nmds")
+  private Boolean nmds;
+
+  @JsonProperty("gso")
+  private Boolean gso;
+
+  @JsonProperty("pub")
+  private Boolean pub;
+
+  @JsonProperty("col")
+  private Boolean col;
+
+  @JsonProperty("irb")
+  private Boolean irb;
+
+  @JsonProperty("gs")
+  private String gs;
+
+  @JsonProperty("mor")
+  private Boolean mor;
+
+  @JsonProperty("morDate")
+  private String morDate;
+
+  @JsonProperty("npu")
+  private Boolean npu;
+
+  @JsonProperty("otherSecondary")
+  private String otherSecondary;
+
+  @JsonProperty("dataLocation")
+  private ConsentGroup.DataLocation dataLocation;
+
+  @JsonProperty("url")
+  private URI url;
+
+  @JsonProperty("requestLocation")
+  private URI requestLocation;
+
+  @JsonProperty("numberOfParticipants")
+  private Integer numberOfParticipants;
+
+  @JsonProperty("fileTypes")
+  private List<FileTypeObject> fileTypes = new ArrayList<>();
+
+  @JsonProperty("data")
+  private Map<String, Object> data = new HashMap<>();
+
+  @JsonProperty("datasetId")
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  @JsonProperty("datasetId")
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
+  }
+
+  @JsonProperty("consentGroupName")
+  public String getConsentGroupName() {
+    return consentGroupName;
+  }
+
+  @JsonProperty("consentGroupName")
+  public void setConsentGroupName(String consentGroupName) {
+    this.consentGroupName = consentGroupName;
+  }
+
+  @JsonProperty("dataAccessCommitteeId")
+  public Integer getDataAccessCommitteeId() {
+    return dataAccessCommitteeId;
+  }
+
+  @JsonProperty("dataAccessCommitteeId")
+  public void setDataAccessCommitteeId(Integer dataAccessCommitteeId) {
+    this.dataAccessCommitteeId = dataAccessCommitteeId;
+  }
+
+  @JsonProperty("accessManagement")
+  public ConsentGroup.AccessManagement getAccessManagement() {
+    return accessManagement;
+  }
+
+  @JsonProperty("accessManagement")
+  public void setAccessManagement(ConsentGroup.AccessManagement accessManagement) {
+    this.accessManagement = accessManagement;
+  }
+
+  @JsonProperty("generalResearchUse")
+  public Boolean getGeneralResearchUse() {
+    return generalResearchUse;
+  }
+
+  @JsonProperty("generalResearchUse")
+  public void setGeneralResearchUse(Boolean generalResearchUse) {
+    this.generalResearchUse = generalResearchUse;
+  }
+
+  @JsonProperty("hmb")
+  public Boolean getHmb() {
+    return hmb;
+  }
+
+  @JsonProperty("hmb")
+  public void setHmb(Boolean hmb) {
+    this.hmb = hmb;
+  }
+
+  @JsonProperty("diseaseSpecificUse")
+  public List<String> getDiseaseSpecificUse() {
+    return diseaseSpecificUse;
+  }
+
+  @JsonProperty("diseaseSpecificUse")
+  public void setDiseaseSpecificUse(List<String> diseaseSpecificUse) {
+    this.diseaseSpecificUse = diseaseSpecificUse;
+  }
+
+  @JsonProperty("poa")
+  public Boolean getPoa() {
+    return poa;
+  }
+
+  @JsonProperty("poa")
+  public void setPoa(Boolean poa) {
+    this.poa = poa;
+  }
+
+  @JsonProperty("otherPrimary")
+  public String getOtherPrimary() {
+    return otherPrimary;
+  }
+
+  @JsonProperty("otherPrimary")
+  public void setOtherPrimary(String otherPrimary) {
+    this.otherPrimary = otherPrimary;
+  }
+
+  @JsonProperty("nmds")
+  public Boolean getNmds() {
+    return nmds;
+  }
+
+  @JsonProperty("nmds")
+  public void setNmds(Boolean nmds) {
+    this.nmds = nmds;
+  }
+
+  @JsonProperty("gso")
+  public Boolean getGso() {
+    return gso;
+  }
+
+  @JsonProperty("gso")
+  public void setGso(Boolean gso) {
+    this.gso = gso;
+  }
+
+  @JsonProperty("pub")
+  public Boolean getPub() {
+    return pub;
+  }
+
+  @JsonProperty("pub")
+  public void setPub(Boolean pub) {
+    this.pub = pub;
+  }
+
+  @JsonProperty("col")
+  public Boolean getCol() {
+    return col;
+  }
+
+  @JsonProperty("col")
+  public void setCol(Boolean col) {
+    this.col = col;
+  }
+
+  @JsonProperty("irb")
+  public Boolean getIrb() {
+    return irb;
+  }
+
+  @JsonProperty("irb")
+  public void setIrb(Boolean irb) {
+    this.irb = irb;
+  }
+
+  @JsonProperty("gs")
+  public String getGs() {
+    return gs;
+  }
+
+  @JsonProperty("gs")
+  public void setGs(String gs) {
+    this.gs = gs;
+  }
+
+  @JsonProperty("mor")
+  public Boolean getMor() {
+    return mor;
+  }
+
+  @JsonProperty("mor")
+  public void setMor(Boolean mor) {
+    this.mor = mor;
+  }
+
+  @JsonProperty("morDate")
+  public String getMorDate() {
+    return morDate;
+  }
+
+  @JsonProperty("morDate")
+  public void setMorDate(String morDate) {
+    this.morDate = morDate;
+  }
+
+  @JsonProperty("npu")
+  public Boolean getNpu() {
+    return npu;
+  }
+
+  @JsonProperty("npu")
+  public void setNpu(Boolean npu) {
+    this.npu = npu;
+  }
+
+  @JsonProperty("otherSecondary")
+  public String getOtherSecondary() {
+    return otherSecondary;
+  }
+
+  @JsonProperty("otherSecondary")
+  public void setOtherSecondary(String otherSecondary) {
+    this.otherSecondary = otherSecondary;
+  }
+
+  @JsonProperty("dataLocation")
+  public ConsentGroup.DataLocation getDataLocation() {
+    return dataLocation;
+  }
+
+  @JsonProperty("dataLocation")
+  public void setDataLocation(ConsentGroup.DataLocation dataLocation) {
+    this.dataLocation = dataLocation;
+  }
+
+  @JsonProperty("url")
+  public URI getUrl() {
+    return url;
+  }
+
+  @JsonProperty("url")
+  public void setUrl(URI url) {
+    this.url = url;
+  }
+
+  @JsonProperty("requestLocation")
+  public URI getRequestLocation() {
+    return requestLocation;
+  }
+
+  @JsonProperty("requestLocation")
+  public void setRequestLocation(URI requestLocation) {
+    this.requestLocation = requestLocation;
+  }
+
+  @JsonProperty("numberOfParticipants")
+  public Integer getNumberOfParticipants() {
+    return numberOfParticipants;
+  }
+
+  @JsonProperty("numberOfParticipants")
+  public void setNumberOfParticipants(Integer numberOfParticipants) {
+    this.numberOfParticipants = numberOfParticipants;
+  }
+
+  @JsonProperty("fileTypes")
+  public List<FileTypeObject> getFileTypes() {
+    return fileTypes;
+  }
+
+  @JsonProperty("fileTypes")
+  public void setFileTypes(List<FileTypeObject> fileTypes) {
+    this.fileTypes = fileTypes;
+  }
+
+  @JsonProperty("data")
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  @JsonProperty("data")
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequest.java
@@ -1,0 +1,616 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.NihICsSupportingStudy;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+  "studyName",
+  "studyType",
+  "studyDescription",
+  "dataTypes",
+  "phenotypeIndication",
+  "species",
+  "piName",
+  "piEmail",
+  "dataCustodianEmail",
+  "publicVisibility",
+  "throughBioId",
+  "nihAnvilUse",
+  "submittingToAnvil",
+  "dbGaPPhsID",
+  "dbGaPStudyRegistrationName",
+  "embargoReleaseDate",
+  "sequencingCenter",
+  "piInstitution",
+  "nihGrantContractNumber",
+  "nihICsSupportingStudy",
+  "nihProgramOfficerName",
+  "nihInstitutionCenterSubmission",
+  "nihGenomicProgramAdministratorName",
+  "multiCenterStudy",
+  "collaboratingSites",
+  "controlledAccessRequiredForGenomicSummaryResultsGSR",
+  "controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation",
+  "alternativeDataSharingPlan",
+  "alternativeDataSharingPlanReasons",
+  "alternativeDataSharingPlanExplanation",
+  "alternativeDataSharingPlanFileName",
+  "alternativeDataSharingPlanDataSubmitted",
+  "alternativeDataSharingPlanDataReleased",
+  "alternativeDataSharingPlanTargetDeliveryDate",
+  "alternativeDataSharingPlanTargetPublicReleaseDate",
+  "alternativeDataSharingPlanAccessManagement",
+  "externalIdentifier",
+  "externalIdentifierType",
+  "consentGroups",
+  "assets",
+  "data"
+})
+public class StudyRegistrationRequest {
+
+  @JsonProperty("studyName")
+  private String studyName;
+
+  @JsonProperty("studyType")
+  private DatasetRegistrationSchemaV1.StudyType studyType;
+
+  @JsonProperty("studyDescription")
+  private String studyDescription;
+
+  @JsonProperty("dataTypes")
+  private List<String> dataTypes = new ArrayList<>();
+
+  @JsonProperty("phenotypeIndication")
+  private String phenotypeIndication;
+
+  @JsonProperty("species")
+  private String species;
+
+  @JsonProperty("piName")
+  private String piName;
+
+  @JsonProperty("piEmail")
+  private String piEmail;
+
+  @JsonProperty("dataCustodianEmail")
+  private List<String> dataCustodianEmail = new ArrayList<>();
+
+  @JsonProperty("publicVisibility")
+  private Boolean publicVisibility;
+
+  @JsonProperty("throughBioId")
+  private String throughBioId;
+
+  @JsonProperty("nihAnvilUse")
+  private DatasetRegistrationSchemaV1.NihAnvilUse nihAnvilUse;
+
+  @JsonProperty("submittingToAnvil")
+  private Boolean submittingToAnvil;
+
+  @JsonProperty("dbGaPPhsID")
+  private String dbGaPPhsID;
+
+  @JsonProperty("dbGaPStudyRegistrationName")
+  private String dbGaPStudyRegistrationName;
+
+  @JsonProperty("embargoReleaseDate")
+  private String embargoReleaseDate;
+
+  @JsonProperty("sequencingCenter")
+  private String sequencingCenter;
+
+  @JsonProperty("piInstitution")
+  private Integer piInstitution;
+
+  @JsonProperty("nihGrantContractNumber")
+  private String nihGrantContractNumber;
+
+  @JsonProperty("nihICsSupportingStudy")
+  private List<NihICsSupportingStudy> nihICsSupportingStudy = new ArrayList<>();
+
+  @JsonProperty("nihProgramOfficerName")
+  private String nihProgramOfficerName;
+
+  @JsonProperty("nihInstitutionCenterSubmission")
+  private DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission nihInstitutionCenterSubmission;
+
+  @JsonProperty("nihGenomicProgramAdministratorName")
+  private String nihGenomicProgramAdministratorName;
+
+  @JsonProperty("multiCenterStudy")
+  private Boolean multiCenterStudy;
+
+  @JsonProperty("collaboratingSites")
+  private List<String> collaboratingSites = new ArrayList<>();
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
+  private Boolean controlledAccessRequiredForGenomicSummaryResultsGSR;
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation")
+  private String controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
+
+  @JsonProperty("alternativeDataSharingPlan")
+  private Boolean alternativeDataSharingPlan;
+
+  @JsonProperty("alternativeDataSharingPlanReasons")
+  private List<AlternativeDataSharingPlanReason> alternativeDataSharingPlanReasons =
+      new ArrayList<>();
+
+  @JsonProperty("alternativeDataSharingPlanExplanation")
+  private String alternativeDataSharingPlanExplanation;
+
+  @JsonProperty("alternativeDataSharingPlanFileName")
+  private String alternativeDataSharingPlanFileName;
+
+  @JsonProperty("alternativeDataSharingPlanDataSubmitted")
+  private DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
+      alternativeDataSharingPlanDataSubmitted;
+
+  @JsonProperty("alternativeDataSharingPlanDataReleased")
+  private Boolean alternativeDataSharingPlanDataReleased;
+
+  @JsonProperty("alternativeDataSharingPlanTargetDeliveryDate")
+  private String alternativeDataSharingPlanTargetDeliveryDate;
+
+  @JsonProperty("alternativeDataSharingPlanTargetPublicReleaseDate")
+  private String alternativeDataSharingPlanTargetPublicReleaseDate;
+
+  @JsonProperty("alternativeDataSharingPlanAccessManagement")
+  private DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
+      alternativeDataSharingPlanAccessManagement;
+
+  @JsonProperty("externalIdentifier")
+  private String externalIdentifier;
+
+  @JsonProperty("externalIdentifierType")
+  private String externalIdentifierType;
+
+  @JsonProperty("consentGroups")
+  private List<ConsentGroupRequest> consentGroups = new ArrayList<>();
+
+  @JsonProperty("assets")
+  private Map<String, Object> assets = new HashMap<>();
+
+  @JsonProperty("data")
+  private Map<String, Object> data = new HashMap<>();
+
+  @JsonProperty("studyName")
+  public String getStudyName() {
+    return studyName;
+  }
+
+  @JsonProperty("studyName")
+  public void setStudyName(String studyName) {
+    this.studyName = studyName;
+  }
+
+  @JsonProperty("studyType")
+  public DatasetRegistrationSchemaV1.StudyType getStudyType() {
+    return studyType;
+  }
+
+  @JsonProperty("studyType")
+  public void setStudyType(DatasetRegistrationSchemaV1.StudyType studyType) {
+    this.studyType = studyType;
+  }
+
+  @JsonProperty("studyDescription")
+  public String getStudyDescription() {
+    return studyDescription;
+  }
+
+  @JsonProperty("studyDescription")
+  public void setStudyDescription(String studyDescription) {
+    this.studyDescription = studyDescription;
+  }
+
+  @JsonProperty("dataTypes")
+  public List<String> getDataTypes() {
+    return dataTypes;
+  }
+
+  @JsonProperty("dataTypes")
+  public void setDataTypes(List<String> dataTypes) {
+    this.dataTypes = dataTypes;
+  }
+
+  @JsonProperty("phenotypeIndication")
+  public String getPhenotypeIndication() {
+    return phenotypeIndication;
+  }
+
+  @JsonProperty("phenotypeIndication")
+  public void setPhenotypeIndication(String phenotypeIndication) {
+    this.phenotypeIndication = phenotypeIndication;
+  }
+
+  @JsonProperty("species")
+  public String getSpecies() {
+    return species;
+  }
+
+  @JsonProperty("species")
+  public void setSpecies(String species) {
+    this.species = species;
+  }
+
+  @JsonProperty("piName")
+  public String getPiName() {
+    return piName;
+  }
+
+  @JsonProperty("piName")
+  public void setPiName(String piName) {
+    this.piName = piName;
+  }
+
+  @JsonProperty("piEmail")
+  public String getPiEmail() {
+    return piEmail;
+  }
+
+  @JsonProperty("piEmail")
+  public void setPiEmail(String piEmail) {
+    this.piEmail = piEmail;
+  }
+
+  @JsonProperty("dataCustodianEmail")
+  public List<String> getDataCustodianEmail() {
+    return dataCustodianEmail;
+  }
+
+  @JsonProperty("dataCustodianEmail")
+  public void setDataCustodianEmail(List<String> dataCustodianEmail) {
+    this.dataCustodianEmail = dataCustodianEmail;
+  }
+
+  @JsonProperty("publicVisibility")
+  public Boolean getPublicVisibility() {
+    return publicVisibility;
+  }
+
+  @JsonProperty("publicVisibility")
+  public void setPublicVisibility(Boolean publicVisibility) {
+    this.publicVisibility = publicVisibility;
+  }
+
+  @JsonProperty("throughBioId")
+  public String getThroughBioId() {
+    return throughBioId;
+  }
+
+  @JsonProperty("throughBioId")
+  public void setThroughBioId(String throughBioId) {
+    this.throughBioId = throughBioId;
+  }
+
+  @JsonProperty("nihAnvilUse")
+  public DatasetRegistrationSchemaV1.NihAnvilUse getNihAnvilUse() {
+    return nihAnvilUse;
+  }
+
+  @JsonProperty("nihAnvilUse")
+  public void setNihAnvilUse(DatasetRegistrationSchemaV1.NihAnvilUse nihAnvilUse) {
+    this.nihAnvilUse = nihAnvilUse;
+  }
+
+  @JsonProperty("submittingToAnvil")
+  public Boolean getSubmittingToAnvil() {
+    return submittingToAnvil;
+  }
+
+  @JsonProperty("submittingToAnvil")
+  public void setSubmittingToAnvil(Boolean submittingToAnvil) {
+    this.submittingToAnvil = submittingToAnvil;
+  }
+
+  @JsonProperty("dbGaPPhsID")
+  public String getDbGaPPhsID() {
+    return dbGaPPhsID;
+  }
+
+  @JsonProperty("dbGaPPhsID")
+  public void setDbGaPPhsID(String dbGaPPhsID) {
+    this.dbGaPPhsID = dbGaPPhsID;
+  }
+
+  @JsonProperty("dbGaPStudyRegistrationName")
+  public String getDbGaPStudyRegistrationName() {
+    return dbGaPStudyRegistrationName;
+  }
+
+  @JsonProperty("dbGaPStudyRegistrationName")
+  public void setDbGaPStudyRegistrationName(String dbGaPStudyRegistrationName) {
+    this.dbGaPStudyRegistrationName = dbGaPStudyRegistrationName;
+  }
+
+  @JsonProperty("embargoReleaseDate")
+  public String getEmbargoReleaseDate() {
+    return embargoReleaseDate;
+  }
+
+  @JsonProperty("embargoReleaseDate")
+  public void setEmbargoReleaseDate(String embargoReleaseDate) {
+    this.embargoReleaseDate = embargoReleaseDate;
+  }
+
+  @JsonProperty("sequencingCenter")
+  public String getSequencingCenter() {
+    return sequencingCenter;
+  }
+
+  @JsonProperty("sequencingCenter")
+  public void setSequencingCenter(String sequencingCenter) {
+    this.sequencingCenter = sequencingCenter;
+  }
+
+  @JsonProperty("piInstitution")
+  public Integer getPiInstitution() {
+    return piInstitution;
+  }
+
+  @JsonProperty("piInstitution")
+  public void setPiInstitution(Integer piInstitution) {
+    this.piInstitution = piInstitution;
+  }
+
+  @JsonProperty("nihGrantContractNumber")
+  public String getNihGrantContractNumber() {
+    return nihGrantContractNumber;
+  }
+
+  @JsonProperty("nihGrantContractNumber")
+  public void setNihGrantContractNumber(String nihGrantContractNumber) {
+    this.nihGrantContractNumber = nihGrantContractNumber;
+  }
+
+  @JsonProperty("nihICsSupportingStudy")
+  public List<NihICsSupportingStudy> getNihICsSupportingStudy() {
+    return nihICsSupportingStudy;
+  }
+
+  @JsonProperty("nihICsSupportingStudy")
+  public void setNihICsSupportingStudy(List<NihICsSupportingStudy> nihICsSupportingStudy) {
+    this.nihICsSupportingStudy = nihICsSupportingStudy;
+  }
+
+  @JsonProperty("nihProgramOfficerName")
+  public String getNihProgramOfficerName() {
+    return nihProgramOfficerName;
+  }
+
+  @JsonProperty("nihProgramOfficerName")
+  public void setNihProgramOfficerName(String nihProgramOfficerName) {
+    this.nihProgramOfficerName = nihProgramOfficerName;
+  }
+
+  @JsonProperty("nihInstitutionCenterSubmission")
+  public DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission
+      getNihInstitutionCenterSubmission() {
+    return nihInstitutionCenterSubmission;
+  }
+
+  @JsonProperty("nihInstitutionCenterSubmission")
+  public void setNihInstitutionCenterSubmission(
+      DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission nihInstitutionCenterSubmission) {
+    this.nihInstitutionCenterSubmission = nihInstitutionCenterSubmission;
+  }
+
+  @JsonProperty("nihGenomicProgramAdministratorName")
+  public String getNihGenomicProgramAdministratorName() {
+    return nihGenomicProgramAdministratorName;
+  }
+
+  @JsonProperty("nihGenomicProgramAdministratorName")
+  public void setNihGenomicProgramAdministratorName(String nihGenomicProgramAdministratorName) {
+    this.nihGenomicProgramAdministratorName = nihGenomicProgramAdministratorName;
+  }
+
+  @JsonProperty("multiCenterStudy")
+  public Boolean getMultiCenterStudy() {
+    return multiCenterStudy;
+  }
+
+  @JsonProperty("multiCenterStudy")
+  public void setMultiCenterStudy(Boolean multiCenterStudy) {
+    this.multiCenterStudy = multiCenterStudy;
+  }
+
+  @JsonProperty("collaboratingSites")
+  public List<String> getCollaboratingSites() {
+    return collaboratingSites;
+  }
+
+  @JsonProperty("collaboratingSites")
+  public void setCollaboratingSites(List<String> collaboratingSites) {
+    this.collaboratingSites = collaboratingSites;
+  }
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
+  public Boolean getControlledAccessRequiredForGenomicSummaryResultsGSR() {
+    return controlledAccessRequiredForGenomicSummaryResultsGSR;
+  }
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
+  public void setControlledAccessRequiredForGenomicSummaryResultsGSR(
+      Boolean controlledAccessRequiredForGenomicSummaryResultsGSR) {
+    this.controlledAccessRequiredForGenomicSummaryResultsGSR =
+        controlledAccessRequiredForGenomicSummaryResultsGSR;
+  }
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation")
+  public String getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation() {
+    return controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
+  }
+
+  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation")
+  public void setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(
+      String controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation) {
+    this.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation =
+        controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
+  }
+
+  @JsonProperty("alternativeDataSharingPlan")
+  public Boolean getAlternativeDataSharingPlan() {
+    return alternativeDataSharingPlan;
+  }
+
+  @JsonProperty("alternativeDataSharingPlan")
+  public void setAlternativeDataSharingPlan(Boolean alternativeDataSharingPlan) {
+    this.alternativeDataSharingPlan = alternativeDataSharingPlan;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanReasons")
+  public List<AlternativeDataSharingPlanReason> getAlternativeDataSharingPlanReasons() {
+    return alternativeDataSharingPlanReasons;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanReasons")
+  public void setAlternativeDataSharingPlanReasons(
+      List<AlternativeDataSharingPlanReason> alternativeDataSharingPlanReasons) {
+    this.alternativeDataSharingPlanReasons = alternativeDataSharingPlanReasons;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanExplanation")
+  public String getAlternativeDataSharingPlanExplanation() {
+    return alternativeDataSharingPlanExplanation;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanExplanation")
+  public void setAlternativeDataSharingPlanExplanation(
+      String alternativeDataSharingPlanExplanation) {
+    this.alternativeDataSharingPlanExplanation = alternativeDataSharingPlanExplanation;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanFileName")
+  public String getAlternativeDataSharingPlanFileName() {
+    return alternativeDataSharingPlanFileName;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanFileName")
+  public void setAlternativeDataSharingPlanFileName(String alternativeDataSharingPlanFileName) {
+    this.alternativeDataSharingPlanFileName = alternativeDataSharingPlanFileName;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanDataSubmitted")
+  public DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
+      getAlternativeDataSharingPlanDataSubmitted() {
+    return alternativeDataSharingPlanDataSubmitted;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanDataSubmitted")
+  public void setAlternativeDataSharingPlanDataSubmitted(
+      DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
+          alternativeDataSharingPlanDataSubmitted) {
+    this.alternativeDataSharingPlanDataSubmitted = alternativeDataSharingPlanDataSubmitted;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanDataReleased")
+  public Boolean getAlternativeDataSharingPlanDataReleased() {
+    return alternativeDataSharingPlanDataReleased;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanDataReleased")
+  public void setAlternativeDataSharingPlanDataReleased(
+      Boolean alternativeDataSharingPlanDataReleased) {
+    this.alternativeDataSharingPlanDataReleased = alternativeDataSharingPlanDataReleased;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanTargetDeliveryDate")
+  public String getAlternativeDataSharingPlanTargetDeliveryDate() {
+    return alternativeDataSharingPlanTargetDeliveryDate;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanTargetDeliveryDate")
+  public void setAlternativeDataSharingPlanTargetDeliveryDate(
+      String alternativeDataSharingPlanTargetDeliveryDate) {
+    this.alternativeDataSharingPlanTargetDeliveryDate =
+        alternativeDataSharingPlanTargetDeliveryDate;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanTargetPublicReleaseDate")
+  public String getAlternativeDataSharingPlanTargetPublicReleaseDate() {
+    return alternativeDataSharingPlanTargetPublicReleaseDate;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanTargetPublicReleaseDate")
+  public void setAlternativeDataSharingPlanTargetPublicReleaseDate(
+      String alternativeDataSharingPlanTargetPublicReleaseDate) {
+    this.alternativeDataSharingPlanTargetPublicReleaseDate =
+        alternativeDataSharingPlanTargetPublicReleaseDate;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanAccessManagement")
+  public DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
+      getAlternativeDataSharingPlanAccessManagement() {
+    return alternativeDataSharingPlanAccessManagement;
+  }
+
+  @JsonProperty("alternativeDataSharingPlanAccessManagement")
+  public void setAlternativeDataSharingPlanAccessManagement(
+      DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
+          alternativeDataSharingPlanAccessManagement) {
+    this.alternativeDataSharingPlanAccessManagement = alternativeDataSharingPlanAccessManagement;
+  }
+
+  @JsonProperty("externalIdentifier")
+  public String getExternalIdentifier() {
+    return externalIdentifier;
+  }
+
+  @JsonProperty("externalIdentifier")
+  public void setExternalIdentifier(String externalIdentifier) {
+    this.externalIdentifier = externalIdentifier;
+  }
+
+  @JsonProperty("externalIdentifierType")
+  public String getExternalIdentifierType() {
+    return externalIdentifierType;
+  }
+
+  @JsonProperty("externalIdentifierType")
+  public void setExternalIdentifierType(String externalIdentifierType) {
+    this.externalIdentifierType = externalIdentifierType;
+  }
+
+  @JsonProperty("consentGroups")
+  public List<ConsentGroupRequest> getConsentGroups() {
+    return consentGroups;
+  }
+
+  @JsonProperty("consentGroups")
+  public void setConsentGroups(List<ConsentGroupRequest> consentGroups) {
+    this.consentGroups = consentGroups;
+  }
+
+  @JsonProperty("assets")
+  public Map<String, Object> getAssets() {
+    return assets;
+  }
+
+  @JsonProperty("assets")
+  public void setAssets(Map<String, Object> assets) {
+    this.assets = assets;
+  }
+
+  @JsonProperty("data")
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  @JsonProperty("data")
+  public void setData(Map<String, Object> data) {
+    this.data = data;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequest.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
@@ -51,11 +49,11 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.NihICsSupp
   "alternativeDataSharingPlanTargetDeliveryDate",
   "alternativeDataSharingPlanTargetPublicReleaseDate",
   "alternativeDataSharingPlanAccessManagement",
-  "externalIdentifier",
-  "externalIdentifierType",
   "consentGroups",
   "assets",
-  "data"
+  "data",
+  "externalIdentifier",
+  "externalIdentifierType"
 })
 public class StudyRegistrationRequest {
 
@@ -69,7 +67,7 @@ public class StudyRegistrationRequest {
   private String studyDescription;
 
   @JsonProperty("dataTypes")
-  private List<String> dataTypes = new ArrayList<>();
+  private List<String> dataTypes;
 
   @JsonProperty("phenotypeIndication")
   private String phenotypeIndication;
@@ -84,7 +82,7 @@ public class StudyRegistrationRequest {
   private String piEmail;
 
   @JsonProperty("dataCustodianEmail")
-  private List<String> dataCustodianEmail = new ArrayList<>();
+  private List<String> dataCustodianEmail;
 
   @JsonProperty("publicVisibility")
   private Boolean publicVisibility;
@@ -117,7 +115,7 @@ public class StudyRegistrationRequest {
   private String nihGrantContractNumber;
 
   @JsonProperty("nihICsSupportingStudy")
-  private List<NihICsSupportingStudy> nihICsSupportingStudy = new ArrayList<>();
+  private List<NihICsSupportingStudy> nihICsSupportingStudy;
 
   @JsonProperty("nihProgramOfficerName")
   private String nihProgramOfficerName;
@@ -132,7 +130,7 @@ public class StudyRegistrationRequest {
   private Boolean multiCenterStudy;
 
   @JsonProperty("collaboratingSites")
-  private List<String> collaboratingSites = new ArrayList<>();
+  private List<String> collaboratingSites;
 
   @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
   private Boolean controlledAccessRequiredForGenomicSummaryResultsGSR;
@@ -144,8 +142,7 @@ public class StudyRegistrationRequest {
   private Boolean alternativeDataSharingPlan;
 
   @JsonProperty("alternativeDataSharingPlanReasons")
-  private List<AlternativeDataSharingPlanReason> alternativeDataSharingPlanReasons =
-      new ArrayList<>();
+  private List<AlternativeDataSharingPlanReason> alternativeDataSharingPlanReasons;
 
   @JsonProperty("alternativeDataSharingPlanExplanation")
   private String alternativeDataSharingPlanExplanation;
@@ -170,447 +167,365 @@ public class StudyRegistrationRequest {
   private DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
       alternativeDataSharingPlanAccessManagement;
 
+  @JsonProperty("consentGroups")
+  private List<ConsentGroupRequest> consentGroups;
+
+  @JsonProperty("assets")
+  private Map<String, Object> assets;
+
+  @JsonProperty("data")
+  private Map<String, Object> data;
+
   @JsonProperty("externalIdentifier")
   private String externalIdentifier;
 
   @JsonProperty("externalIdentifierType")
   private String externalIdentifierType;
 
-  @JsonProperty("consentGroups")
-  private List<ConsentGroupRequest> consentGroups = new ArrayList<>();
-
-  @JsonProperty("assets")
-  private Map<String, Object> assets = new HashMap<>();
-
-  @JsonProperty("data")
-  private Map<String, Object> data = new HashMap<>();
-
-  @JsonProperty("studyName")
   public String getStudyName() {
     return studyName;
   }
 
-  @JsonProperty("studyName")
   public void setStudyName(String studyName) {
     this.studyName = studyName;
   }
 
-  @JsonProperty("studyType")
   public DatasetRegistrationSchemaV1.StudyType getStudyType() {
     return studyType;
   }
 
-  @JsonProperty("studyType")
   public void setStudyType(DatasetRegistrationSchemaV1.StudyType studyType) {
     this.studyType = studyType;
   }
 
-  @JsonProperty("studyDescription")
   public String getStudyDescription() {
     return studyDescription;
   }
 
-  @JsonProperty("studyDescription")
   public void setStudyDescription(String studyDescription) {
     this.studyDescription = studyDescription;
   }
 
-  @JsonProperty("dataTypes")
   public List<String> getDataTypes() {
     return dataTypes;
   }
 
-  @JsonProperty("dataTypes")
   public void setDataTypes(List<String> dataTypes) {
     this.dataTypes = dataTypes;
   }
 
-  @JsonProperty("phenotypeIndication")
   public String getPhenotypeIndication() {
     return phenotypeIndication;
   }
 
-  @JsonProperty("phenotypeIndication")
   public void setPhenotypeIndication(String phenotypeIndication) {
     this.phenotypeIndication = phenotypeIndication;
   }
 
-  @JsonProperty("species")
   public String getSpecies() {
     return species;
   }
 
-  @JsonProperty("species")
   public void setSpecies(String species) {
     this.species = species;
   }
 
-  @JsonProperty("piName")
   public String getPiName() {
     return piName;
   }
 
-  @JsonProperty("piName")
   public void setPiName(String piName) {
     this.piName = piName;
   }
 
-  @JsonProperty("piEmail")
   public String getPiEmail() {
     return piEmail;
   }
 
-  @JsonProperty("piEmail")
   public void setPiEmail(String piEmail) {
     this.piEmail = piEmail;
   }
 
-  @JsonProperty("dataCustodianEmail")
   public List<String> getDataCustodianEmail() {
     return dataCustodianEmail;
   }
 
-  @JsonProperty("dataCustodianEmail")
   public void setDataCustodianEmail(List<String> dataCustodianEmail) {
     this.dataCustodianEmail = dataCustodianEmail;
   }
 
-  @JsonProperty("publicVisibility")
   public Boolean getPublicVisibility() {
     return publicVisibility;
   }
 
-  @JsonProperty("publicVisibility")
   public void setPublicVisibility(Boolean publicVisibility) {
     this.publicVisibility = publicVisibility;
   }
 
-  @JsonProperty("throughBioId")
   public String getThroughBioId() {
     return throughBioId;
   }
 
-  @JsonProperty("throughBioId")
   public void setThroughBioId(String throughBioId) {
     this.throughBioId = throughBioId;
   }
 
-  @JsonProperty("nihAnvilUse")
   public DatasetRegistrationSchemaV1.NihAnvilUse getNihAnvilUse() {
     return nihAnvilUse;
   }
 
-  @JsonProperty("nihAnvilUse")
   public void setNihAnvilUse(DatasetRegistrationSchemaV1.NihAnvilUse nihAnvilUse) {
     this.nihAnvilUse = nihAnvilUse;
   }
 
-  @JsonProperty("submittingToAnvil")
   public Boolean getSubmittingToAnvil() {
     return submittingToAnvil;
   }
 
-  @JsonProperty("submittingToAnvil")
   public void setSubmittingToAnvil(Boolean submittingToAnvil) {
     this.submittingToAnvil = submittingToAnvil;
   }
 
-  @JsonProperty("dbGaPPhsID")
   public String getDbGaPPhsID() {
     return dbGaPPhsID;
   }
 
-  @JsonProperty("dbGaPPhsID")
   public void setDbGaPPhsID(String dbGaPPhsID) {
     this.dbGaPPhsID = dbGaPPhsID;
   }
 
-  @JsonProperty("dbGaPStudyRegistrationName")
   public String getDbGaPStudyRegistrationName() {
     return dbGaPStudyRegistrationName;
   }
 
-  @JsonProperty("dbGaPStudyRegistrationName")
   public void setDbGaPStudyRegistrationName(String dbGaPStudyRegistrationName) {
     this.dbGaPStudyRegistrationName = dbGaPStudyRegistrationName;
   }
 
-  @JsonProperty("embargoReleaseDate")
   public String getEmbargoReleaseDate() {
     return embargoReleaseDate;
   }
 
-  @JsonProperty("embargoReleaseDate")
   public void setEmbargoReleaseDate(String embargoReleaseDate) {
     this.embargoReleaseDate = embargoReleaseDate;
   }
 
-  @JsonProperty("sequencingCenter")
   public String getSequencingCenter() {
     return sequencingCenter;
   }
 
-  @JsonProperty("sequencingCenter")
   public void setSequencingCenter(String sequencingCenter) {
     this.sequencingCenter = sequencingCenter;
   }
 
-  @JsonProperty("piInstitution")
   public Integer getPiInstitution() {
     return piInstitution;
   }
 
-  @JsonProperty("piInstitution")
   public void setPiInstitution(Integer piInstitution) {
     this.piInstitution = piInstitution;
   }
 
-  @JsonProperty("nihGrantContractNumber")
   public String getNihGrantContractNumber() {
     return nihGrantContractNumber;
   }
 
-  @JsonProperty("nihGrantContractNumber")
   public void setNihGrantContractNumber(String nihGrantContractNumber) {
     this.nihGrantContractNumber = nihGrantContractNumber;
   }
 
-  @JsonProperty("nihICsSupportingStudy")
   public List<NihICsSupportingStudy> getNihICsSupportingStudy() {
     return nihICsSupportingStudy;
   }
 
-  @JsonProperty("nihICsSupportingStudy")
   public void setNihICsSupportingStudy(List<NihICsSupportingStudy> nihICsSupportingStudy) {
     this.nihICsSupportingStudy = nihICsSupportingStudy;
   }
 
-  @JsonProperty("nihProgramOfficerName")
   public String getNihProgramOfficerName() {
     return nihProgramOfficerName;
   }
 
-  @JsonProperty("nihProgramOfficerName")
   public void setNihProgramOfficerName(String nihProgramOfficerName) {
     this.nihProgramOfficerName = nihProgramOfficerName;
   }
 
-  @JsonProperty("nihInstitutionCenterSubmission")
   public DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission
       getNihInstitutionCenterSubmission() {
     return nihInstitutionCenterSubmission;
   }
 
-  @JsonProperty("nihInstitutionCenterSubmission")
   public void setNihInstitutionCenterSubmission(
       DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission nihInstitutionCenterSubmission) {
     this.nihInstitutionCenterSubmission = nihInstitutionCenterSubmission;
   }
 
-  @JsonProperty("nihGenomicProgramAdministratorName")
   public String getNihGenomicProgramAdministratorName() {
     return nihGenomicProgramAdministratorName;
   }
 
-  @JsonProperty("nihGenomicProgramAdministratorName")
   public void setNihGenomicProgramAdministratorName(String nihGenomicProgramAdministratorName) {
     this.nihGenomicProgramAdministratorName = nihGenomicProgramAdministratorName;
   }
 
-  @JsonProperty("multiCenterStudy")
   public Boolean getMultiCenterStudy() {
     return multiCenterStudy;
   }
 
-  @JsonProperty("multiCenterStudy")
   public void setMultiCenterStudy(Boolean multiCenterStudy) {
     this.multiCenterStudy = multiCenterStudy;
   }
 
-  @JsonProperty("collaboratingSites")
   public List<String> getCollaboratingSites() {
     return collaboratingSites;
   }
 
-  @JsonProperty("collaboratingSites")
   public void setCollaboratingSites(List<String> collaboratingSites) {
     this.collaboratingSites = collaboratingSites;
   }
 
-  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
   public Boolean getControlledAccessRequiredForGenomicSummaryResultsGSR() {
     return controlledAccessRequiredForGenomicSummaryResultsGSR;
   }
 
-  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSR")
   public void setControlledAccessRequiredForGenomicSummaryResultsGSR(
       Boolean controlledAccessRequiredForGenomicSummaryResultsGSR) {
     this.controlledAccessRequiredForGenomicSummaryResultsGSR =
         controlledAccessRequiredForGenomicSummaryResultsGSR;
   }
 
-  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation")
   public String getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation() {
     return controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
   }
 
-  @JsonProperty("controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation")
   public void setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(
       String controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation) {
     this.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation =
         controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation;
   }
 
-  @JsonProperty("alternativeDataSharingPlan")
   public Boolean getAlternativeDataSharingPlan() {
     return alternativeDataSharingPlan;
   }
 
-  @JsonProperty("alternativeDataSharingPlan")
   public void setAlternativeDataSharingPlan(Boolean alternativeDataSharingPlan) {
     this.alternativeDataSharingPlan = alternativeDataSharingPlan;
   }
 
-  @JsonProperty("alternativeDataSharingPlanReasons")
   public List<AlternativeDataSharingPlanReason> getAlternativeDataSharingPlanReasons() {
     return alternativeDataSharingPlanReasons;
   }
 
-  @JsonProperty("alternativeDataSharingPlanReasons")
   public void setAlternativeDataSharingPlanReasons(
       List<AlternativeDataSharingPlanReason> alternativeDataSharingPlanReasons) {
     this.alternativeDataSharingPlanReasons = alternativeDataSharingPlanReasons;
   }
 
-  @JsonProperty("alternativeDataSharingPlanExplanation")
   public String getAlternativeDataSharingPlanExplanation() {
     return alternativeDataSharingPlanExplanation;
   }
 
-  @JsonProperty("alternativeDataSharingPlanExplanation")
   public void setAlternativeDataSharingPlanExplanation(
       String alternativeDataSharingPlanExplanation) {
     this.alternativeDataSharingPlanExplanation = alternativeDataSharingPlanExplanation;
   }
 
-  @JsonProperty("alternativeDataSharingPlanFileName")
   public String getAlternativeDataSharingPlanFileName() {
     return alternativeDataSharingPlanFileName;
   }
 
-  @JsonProperty("alternativeDataSharingPlanFileName")
   public void setAlternativeDataSharingPlanFileName(String alternativeDataSharingPlanFileName) {
     this.alternativeDataSharingPlanFileName = alternativeDataSharingPlanFileName;
   }
 
-  @JsonProperty("alternativeDataSharingPlanDataSubmitted")
   public DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
       getAlternativeDataSharingPlanDataSubmitted() {
     return alternativeDataSharingPlanDataSubmitted;
   }
 
-  @JsonProperty("alternativeDataSharingPlanDataSubmitted")
   public void setAlternativeDataSharingPlanDataSubmitted(
       DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
           alternativeDataSharingPlanDataSubmitted) {
     this.alternativeDataSharingPlanDataSubmitted = alternativeDataSharingPlanDataSubmitted;
   }
 
-  @JsonProperty("alternativeDataSharingPlanDataReleased")
   public Boolean getAlternativeDataSharingPlanDataReleased() {
     return alternativeDataSharingPlanDataReleased;
   }
 
-  @JsonProperty("alternativeDataSharingPlanDataReleased")
   public void setAlternativeDataSharingPlanDataReleased(
       Boolean alternativeDataSharingPlanDataReleased) {
     this.alternativeDataSharingPlanDataReleased = alternativeDataSharingPlanDataReleased;
   }
 
-  @JsonProperty("alternativeDataSharingPlanTargetDeliveryDate")
   public String getAlternativeDataSharingPlanTargetDeliveryDate() {
     return alternativeDataSharingPlanTargetDeliveryDate;
   }
 
-  @JsonProperty("alternativeDataSharingPlanTargetDeliveryDate")
   public void setAlternativeDataSharingPlanTargetDeliveryDate(
       String alternativeDataSharingPlanTargetDeliveryDate) {
     this.alternativeDataSharingPlanTargetDeliveryDate =
         alternativeDataSharingPlanTargetDeliveryDate;
   }
 
-  @JsonProperty("alternativeDataSharingPlanTargetPublicReleaseDate")
   public String getAlternativeDataSharingPlanTargetPublicReleaseDate() {
     return alternativeDataSharingPlanTargetPublicReleaseDate;
   }
 
-  @JsonProperty("alternativeDataSharingPlanTargetPublicReleaseDate")
   public void setAlternativeDataSharingPlanTargetPublicReleaseDate(
       String alternativeDataSharingPlanTargetPublicReleaseDate) {
     this.alternativeDataSharingPlanTargetPublicReleaseDate =
         alternativeDataSharingPlanTargetPublicReleaseDate;
   }
 
-  @JsonProperty("alternativeDataSharingPlanAccessManagement")
   public DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
       getAlternativeDataSharingPlanAccessManagement() {
     return alternativeDataSharingPlanAccessManagement;
   }
 
-  @JsonProperty("alternativeDataSharingPlanAccessManagement")
   public void setAlternativeDataSharingPlanAccessManagement(
       DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement
           alternativeDataSharingPlanAccessManagement) {
     this.alternativeDataSharingPlanAccessManagement = alternativeDataSharingPlanAccessManagement;
   }
 
-  @JsonProperty("externalIdentifier")
-  public String getExternalIdentifier() {
-    return externalIdentifier;
-  }
-
-  @JsonProperty("externalIdentifier")
-  public void setExternalIdentifier(String externalIdentifier) {
-    this.externalIdentifier = externalIdentifier;
-  }
-
-  @JsonProperty("externalIdentifierType")
-  public String getExternalIdentifierType() {
-    return externalIdentifierType;
-  }
-
-  @JsonProperty("externalIdentifierType")
-  public void setExternalIdentifierType(String externalIdentifierType) {
-    this.externalIdentifierType = externalIdentifierType;
-  }
-
-  @JsonProperty("consentGroups")
   public List<ConsentGroupRequest> getConsentGroups() {
     return consentGroups;
   }
 
-  @JsonProperty("consentGroups")
   public void setConsentGroups(List<ConsentGroupRequest> consentGroups) {
     this.consentGroups = consentGroups;
   }
 
-  @JsonProperty("assets")
   public Map<String, Object> getAssets() {
     return assets;
   }
 
-  @JsonProperty("assets")
   public void setAssets(Map<String, Object> assets) {
     this.assets = assets;
   }
 
-  @JsonProperty("data")
   public Map<String, Object> getData() {
     return data;
   }
 
-  @JsonProperty("data")
   public void setData(Map<String, Object> data) {
     this.data = data;
+  }
+
+  public String getExternalIdentifier() {
+    return externalIdentifier;
+  }
+
+  public void setExternalIdentifier(String externalIdentifier) {
+    this.externalIdentifier = externalIdentifier;
+  }
+
+  public String getExternalIdentifierType() {
+    return externalIdentifierType;
+  }
+
+  public void setExternalIdentifierType(String externalIdentifierType) {
+    this.externalIdentifierType = externalIdentifierType;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.models.dto.registration;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StudyUpdateRequest extends StudyRegistrationRequest {}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequest.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequest.java
@@ -1,0 +1,6 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StudyUpdateRequest extends StudyRegistrationRequest {}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
@@ -33,83 +33,20 @@ class RegistrationDtoPayloadShapeTest {
 
     ConsentGroupRequest result = mapper.readValue(json, ConsentGroupRequest.class);
 
-    assertEquals(source.getDatasetId(), result.getDatasetId());
-    assertEquals(source.getConsentGroupName(), result.getConsentGroupName());
-    assertEquals(source.getDataAccessCommitteeId(), result.getDataAccessCommitteeId());
-    assertEquals(source.getAccessManagement(), result.getAccessManagement());
-    assertEquals(source.getGeneralResearchUse(), result.getGeneralResearchUse());
-    assertEquals(source.getHmb(), result.getHmb());
-    assertEquals(source.getDiseaseSpecificUse(), result.getDiseaseSpecificUse());
-    assertEquals(source.getPoa(), result.getPoa());
-    assertEquals(source.getOtherPrimary(), result.getOtherPrimary());
-    assertEquals(source.getNmds(), result.getNmds());
-    assertEquals(source.getGso(), result.getGso());
-    assertEquals(source.getPub(), result.getPub());
-    assertEquals(source.getCol(), result.getCol());
-    assertEquals(source.getIrb(), result.getIrb());
-    assertEquals(source.getGs(), result.getGs());
-    assertEquals(source.getMor(), result.getMor());
-    assertEquals(source.getMorDate(), result.getMorDate());
-    assertEquals(source.getNpu(), result.getNpu());
-    assertEquals(source.getOtherSecondary(), result.getOtherSecondary());
-    assertEquals(source.getDataLocation(), result.getDataLocation());
-    assertEquals(source.getUrl(), result.getUrl());
-    assertEquals(source.getRequestLocation(), result.getRequestLocation());
-    assertEquals(source.getNumberOfParticipants(), result.getNumberOfParticipants());
-    assertNotNull(result.getFileTypes());
-    assertEquals(1, result.getFileTypes().size());
-    assertEquals(
-        source.getFileTypes().get(0).getFileType(), result.getFileTypes().get(0).getFileType());
-    assertEquals(
-        source.getFileTypes().get(0).getFunctionalEquivalence(),
-        result.getFileTypes().get(0).getFunctionalEquivalence());
-    assertEquals(source.getData(), result.getData());
-    // datasetIdentifier is server-assigned and intentionally absent from ConsentGroupRequest
+    assertConsentGroupRequestFieldsMatch(source, result);
   }
 
   @Test
   void consentGroupRequest_serializesBackToConsentGroupJson() throws Exception {
     ConsentGroup source = buildConsentGroup();
 
-    // ConsentGroup → JSON → ConsentGroupRequest → JSON → ConsentGroup
+    // ConsentGroup → JSON → ConsentGroupRequest → JSON → ConsentGroupRequest
     String dtoJson =
         mapper.writeValueAsString(
             mapper.readValue(mapper.writeValueAsString(source), ConsentGroupRequest.class));
-    ConsentGroup roundTripped = mapper.readValue(dtoJson, ConsentGroup.class);
+    ConsentGroupRequest roundTripped = mapper.readValue(dtoJson, ConsentGroupRequest.class);
 
-    assertEquals(source.getDatasetId(), roundTripped.getDatasetId());
-    assertEquals(source.getConsentGroupName(), roundTripped.getConsentGroupName());
-    assertEquals(source.getDataAccessCommitteeId(), roundTripped.getDataAccessCommitteeId());
-    assertEquals(source.getAccessManagement(), roundTripped.getAccessManagement());
-    assertEquals(source.getGeneralResearchUse(), roundTripped.getGeneralResearchUse());
-    assertEquals(source.getHmb(), roundTripped.getHmb());
-    assertEquals(source.getDiseaseSpecificUse(), roundTripped.getDiseaseSpecificUse());
-    assertEquals(source.getPoa(), roundTripped.getPoa());
-    assertEquals(source.getOtherPrimary(), roundTripped.getOtherPrimary());
-    assertEquals(source.getNmds(), roundTripped.getNmds());
-    assertEquals(source.getGso(), roundTripped.getGso());
-    assertEquals(source.getPub(), roundTripped.getPub());
-    assertEquals(source.getCol(), roundTripped.getCol());
-    assertEquals(source.getIrb(), roundTripped.getIrb());
-    assertEquals(source.getGs(), roundTripped.getGs());
-    assertEquals(source.getMor(), roundTripped.getMor());
-    assertEquals(source.getMorDate(), roundTripped.getMorDate());
-    assertEquals(source.getNpu(), roundTripped.getNpu());
-    assertEquals(source.getOtherSecondary(), roundTripped.getOtherSecondary());
-    assertEquals(source.getDataLocation(), roundTripped.getDataLocation());
-    assertEquals(source.getUrl(), roundTripped.getUrl());
-    assertEquals(source.getRequestLocation(), roundTripped.getRequestLocation());
-    assertEquals(source.getNumberOfParticipants(), roundTripped.getNumberOfParticipants());
-    assertNotNull(roundTripped.getFileTypes());
-    assertEquals(1, roundTripped.getFileTypes().size());
-    assertEquals(
-        source.getFileTypes().get(0).getFileType(),
-        roundTripped.getFileTypes().get(0).getFileType());
-    assertEquals(
-        source.getFileTypes().get(0).getFunctionalEquivalence(),
-        roundTripped.getFileTypes().get(0).getFunctionalEquivalence());
-    assertEquals(source.getData(), roundTripped.getData());
-    // datasetIdentifier is server-assigned and intentionally absent from ConsentGroupRequest
+    assertConsentGroupRequestFieldsMatch(source, roundTripped);
   }
 
   // ── StudyRegistrationRequest ───────────────────────────────────────────────
@@ -271,6 +208,42 @@ class RegistrationDtoPayloadShapeTest {
     schema.setConsentGroups(List.of(cg));
 
     return schema;
+  }
+
+  private void assertConsentGroupRequestFieldsMatch(
+      ConsentGroup source, ConsentGroupRequest result) {
+    // datasetIdentifier is server-assigned and intentionally absent from ConsentGroupRequest
+    assertEquals(source.getDatasetId(), result.getDatasetId());
+    assertEquals(source.getConsentGroupName(), result.getConsentGroupName());
+    assertEquals(source.getDataAccessCommitteeId(), result.getDataAccessCommitteeId());
+    assertEquals(source.getAccessManagement(), result.getAccessManagement());
+    assertEquals(source.getGeneralResearchUse(), result.getGeneralResearchUse());
+    assertEquals(source.getHmb(), result.getHmb());
+    assertEquals(source.getDiseaseSpecificUse(), result.getDiseaseSpecificUse());
+    assertEquals(source.getPoa(), result.getPoa());
+    assertEquals(source.getOtherPrimary(), result.getOtherPrimary());
+    assertEquals(source.getNmds(), result.getNmds());
+    assertEquals(source.getGso(), result.getGso());
+    assertEquals(source.getPub(), result.getPub());
+    assertEquals(source.getCol(), result.getCol());
+    assertEquals(source.getIrb(), result.getIrb());
+    assertEquals(source.getGs(), result.getGs());
+    assertEquals(source.getMor(), result.getMor());
+    assertEquals(source.getMorDate(), result.getMorDate());
+    assertEquals(source.getNpu(), result.getNpu());
+    assertEquals(source.getOtherSecondary(), result.getOtherSecondary());
+    assertEquals(source.getDataLocation(), result.getDataLocation());
+    assertEquals(source.getUrl(), result.getUrl());
+    assertEquals(source.getRequestLocation(), result.getRequestLocation());
+    assertEquals(source.getNumberOfParticipants(), result.getNumberOfParticipants());
+    assertNotNull(result.getFileTypes());
+    assertEquals(1, result.getFileTypes().size());
+    assertEquals(
+        source.getFileTypes().get(0).getFileType(), result.getFileTypes().get(0).getFileType());
+    assertEquals(
+        source.getFileTypes().get(0).getFunctionalEquivalence(),
+        result.getFileTypes().get(0).getFunctionalEquivalence());
+    assertEquals(source.getData(), result.getData());
   }
 
   private void assertStudyFieldsMatch(

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
@@ -66,33 +66,18 @@ class RegistrationDtoPayloadShapeTest {
   void studyRegistrationRequest_serializesBackToDatasetRegistrationSchemaV1() throws Exception {
     DatasetRegistrationSchemaV1 source = buildFullyPopulatedSchema();
 
-    // Schema → DTO → JSON → Schema
+    // Schema → JSON → DTO → JSON → Schema
     String dtoJson =
         mapper.writeValueAsString(
             mapper.readValue(mapper.writeValueAsString(source), StudyRegistrationRequest.class));
     DatasetRegistrationSchemaV1 roundTripped =
         mapper.readValue(dtoJson, DatasetRegistrationSchemaV1.class);
 
-    assertEquals(source.getStudyName(), roundTripped.getStudyName());
-    assertEquals(source.getStudyType(), roundTripped.getStudyType());
-    assertEquals(source.getStudyDescription(), roundTripped.getStudyDescription());
-    assertEquals(source.getDataTypes(), roundTripped.getDataTypes());
-    assertEquals(source.getPiName(), roundTripped.getPiName());
-    assertEquals(source.getNihAnvilUse(), roundTripped.getNihAnvilUse());
-    assertEquals(source.getNihICsSupportingStudy(), roundTripped.getNihICsSupportingStudy());
-    assertEquals(
-        source.getAlternativeDataSharingPlanReasons(),
-        roundTripped.getAlternativeDataSharingPlanReasons());
-    assertEquals(source.getExternalIdentifier(), roundTripped.getExternalIdentifier());
-    assertEquals(source.getExternalIdentifierType(), roundTripped.getExternalIdentifierType());
-    assertNotNull(roundTripped.getConsentGroups());
-    assertEquals(1, roundTripped.getConsentGroups().size());
-    assertEquals(
-        source.getConsentGroups().get(0).getConsentGroupName(),
-        roundTripped.getConsentGroups().get(0).getConsentGroupName());
-    assertEquals(
-        source.getConsentGroups().get(0).getAccessManagement(),
-        roundTripped.getConsentGroups().get(0).getAccessManagement());
+    // Full-tree comparison catches any field that fails to survive the round-trip.
+    // buildFullyPopulatedSchema() omits studyId, dataSubmitterUserId, and consentGroup
+    // datasetIdentifier — the only fields intentionally absent from the DTO — so the
+    // source and round-tripped trees are structurally identical.
+    assertEquals(mapper.valueToTree(source), mapper.valueToTree(roundTripped));
   }
 
   // ── StudyUpdateRequest ─────────────────────────────────────────────────────

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
@@ -1,0 +1,329 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.NihICsSupportingStudy;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that StudyRegistrationRequest, StudyUpdateRequest, and ConsentGroupRequest share the
+ * same external JSON payload shape as DatasetRegistrationSchemaV1 and ConsentGroup. Each test
+ * serializes the existing model class and deserializes the resulting JSON into the new DTO,
+ * asserting every mapped field round-trips correctly.
+ */
+class RegistrationDtoPayloadShapeTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  // ── ConsentGroupRequest ────────────────────────────────────────────────────
+
+  @Test
+  void consentGroupRequest_roundTripsAllFieldsFromConsentGroupJson() throws Exception {
+    ConsentGroup source = buildConsentGroup();
+    String json = mapper.writeValueAsString(source);
+
+    ConsentGroupRequest result = mapper.readValue(json, ConsentGroupRequest.class);
+
+    assertEquals(source.getDatasetId(), result.getDatasetId());
+    assertEquals(source.getConsentGroupName(), result.getConsentGroupName());
+    assertEquals(source.getDataAccessCommitteeId(), result.getDataAccessCommitteeId());
+    assertEquals(source.getAccessManagement(), result.getAccessManagement());
+    assertEquals(source.getGeneralResearchUse(), result.getGeneralResearchUse());
+    assertEquals(source.getHmb(), result.getHmb());
+    assertEquals(source.getDiseaseSpecificUse(), result.getDiseaseSpecificUse());
+    assertEquals(source.getPoa(), result.getPoa());
+    assertEquals(source.getOtherPrimary(), result.getOtherPrimary());
+    assertEquals(source.getNmds(), result.getNmds());
+    assertEquals(source.getGso(), result.getGso());
+    assertEquals(source.getPub(), result.getPub());
+    assertEquals(source.getCol(), result.getCol());
+    assertEquals(source.getIrb(), result.getIrb());
+    assertEquals(source.getGs(), result.getGs());
+    assertEquals(source.getMor(), result.getMor());
+    assertEquals(source.getMorDate(), result.getMorDate());
+    assertEquals(source.getNpu(), result.getNpu());
+    assertEquals(source.getOtherSecondary(), result.getOtherSecondary());
+    assertEquals(source.getDataLocation(), result.getDataLocation());
+    assertEquals(source.getUrl(), result.getUrl());
+    assertEquals(source.getRequestLocation(), result.getRequestLocation());
+    assertEquals(source.getNumberOfParticipants(), result.getNumberOfParticipants());
+    assertNotNull(result.getFileTypes());
+    assertEquals(1, result.getFileTypes().size());
+    assertEquals(
+        source.getFileTypes().get(0).getFileType(), result.getFileTypes().get(0).getFileType());
+    assertEquals(
+        source.getFileTypes().get(0).getFunctionalEquivalence(),
+        result.getFileTypes().get(0).getFunctionalEquivalence());
+    assertEquals(source.getData(), result.getData());
+    // datasetIdentifier is server-assigned and intentionally absent from ConsentGroupRequest
+  }
+
+  @Test
+  void consentGroupRequest_serializesBackToConsentGroupJson() throws Exception {
+    ConsentGroup source = buildConsentGroup();
+
+    // ConsentGroup → JSON → ConsentGroupRequest → JSON → ConsentGroup
+    String dtoJson =
+        mapper.writeValueAsString(
+            mapper.readValue(mapper.writeValueAsString(source), ConsentGroupRequest.class));
+    ConsentGroup roundTripped = mapper.readValue(dtoJson, ConsentGroup.class);
+
+    assertEquals(source.getDatasetId(), roundTripped.getDatasetId());
+    assertEquals(source.getConsentGroupName(), roundTripped.getConsentGroupName());
+    assertEquals(source.getAccessManagement(), roundTripped.getAccessManagement());
+    assertEquals(source.getNumberOfParticipants(), roundTripped.getNumberOfParticipants());
+    assertEquals(source.getDataLocation(), roundTripped.getDataLocation());
+    assertEquals(source.getUrl(), roundTripped.getUrl());
+    assertEquals(source.getHmb(), roundTripped.getHmb());
+    assertEquals(source.getDiseaseSpecificUse(), roundTripped.getDiseaseSpecificUse());
+  }
+
+  // ── StudyRegistrationRequest ───────────────────────────────────────────────
+
+  @Test
+  void studyRegistrationRequest_roundTripsAllFieldsFromDatasetRegistrationSchemaV1Json()
+      throws Exception {
+    DatasetRegistrationSchemaV1 source = buildFullyPopulatedSchema();
+    String json = mapper.writeValueAsString(source);
+
+    StudyRegistrationRequest result = mapper.readValue(json, StudyRegistrationRequest.class);
+
+    assertStudyFieldsMatch(source, result);
+  }
+
+  @Test
+  void studyRegistrationRequest_serializesBackToDatasetRegistrationSchemaV1() throws Exception {
+    DatasetRegistrationSchemaV1 source = buildFullyPopulatedSchema();
+
+    // Schema → DTO → JSON → Schema
+    String dtoJson =
+        mapper.writeValueAsString(
+            mapper.readValue(mapper.writeValueAsString(source), StudyRegistrationRequest.class));
+    DatasetRegistrationSchemaV1 roundTripped =
+        mapper.readValue(dtoJson, DatasetRegistrationSchemaV1.class);
+
+    assertEquals(source.getStudyName(), roundTripped.getStudyName());
+    assertEquals(source.getStudyType(), roundTripped.getStudyType());
+    assertEquals(source.getStudyDescription(), roundTripped.getStudyDescription());
+    assertEquals(source.getDataTypes(), roundTripped.getDataTypes());
+    assertEquals(source.getPiName(), roundTripped.getPiName());
+    assertEquals(source.getNihAnvilUse(), roundTripped.getNihAnvilUse());
+    assertEquals(source.getNihICsSupportingStudy(), roundTripped.getNihICsSupportingStudy());
+    assertEquals(
+        source.getAlternativeDataSharingPlanReasons(),
+        roundTripped.getAlternativeDataSharingPlanReasons());
+    assertNotNull(roundTripped.getConsentGroups());
+    assertEquals(1, roundTripped.getConsentGroups().size());
+    assertEquals(
+        source.getConsentGroups().get(0).getConsentGroupName(),
+        roundTripped.getConsentGroups().get(0).getConsentGroupName());
+    assertEquals(
+        source.getConsentGroups().get(0).getAccessManagement(),
+        roundTripped.getConsentGroups().get(0).getAccessManagement());
+  }
+
+  // ── StudyUpdateRequest ─────────────────────────────────────────────────────
+
+  @Test
+  void studyUpdateRequest_roundTripsAllFieldsFromDatasetRegistrationSchemaV1Json()
+      throws Exception {
+    DatasetRegistrationSchemaV1 source = buildFullyPopulatedSchema();
+    String json = mapper.writeValueAsString(source);
+
+    StudyUpdateRequest result = mapper.readValue(json, StudyUpdateRequest.class);
+
+    // StudyUpdateRequest extends StudyRegistrationRequest — same payload shape
+    assertStudyFieldsMatch(source, result);
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private ConsentGroup buildConsentGroup() {
+    FileTypeObject ft = new FileTypeObject();
+    ft.setFileType(FileTypeObject.FileType.GENOME);
+    ft.setFunctionalEquivalence("WGS equivalent");
+
+    ConsentGroup cg = new ConsentGroup();
+    cg.setDatasetId(99);
+    cg.setDatasetIdentifier("DUOS-000099"); // read-only; excluded from DTO
+    cg.setConsentGroupName("Test Consent Group");
+    cg.setDataAccessCommitteeId(7);
+    cg.setAccessManagement(ConsentGroup.AccessManagement.CONTROLLED);
+    cg.setGeneralResearchUse(false);
+    cg.setHmb(true);
+    cg.setDiseaseSpecificUse(List.of("MONDO:0004975", "MONDO:0005148"));
+    cg.setPoa(false);
+    cg.setOtherPrimary("primary restriction text");
+    cg.setNmds(true);
+    cg.setGso(false);
+    cg.setPub(true);
+    cg.setCol(false);
+    cg.setIrb(true);
+    cg.setGs("USA");
+    cg.setMor(true);
+    cg.setMorDate("2025-12-31");
+    cg.setNpu(false);
+    cg.setOtherSecondary("secondary restriction text");
+    cg.setDataLocation(ConsentGroup.DataLocation.TERRA_WORKSPACE);
+    cg.setUrl(URI.create("https://example.com/data"));
+    cg.setRequestLocation(URI.create("https://example.com/request"));
+    cg.setNumberOfParticipants(500);
+    cg.setFileTypes(List.of(ft));
+    cg.setData(Map.of("key", "value"));
+    return cg;
+  }
+
+  private DatasetRegistrationSchemaV1 buildFullyPopulatedSchema() {
+    DatasetRegistrationSchemaV1 schema = new DatasetRegistrationSchemaV1();
+    schema.setStudyName("Shape Parity Test Study");
+    schema.setStudyType(DatasetRegistrationSchemaV1.StudyType.OBSERVATIONAL);
+    schema.setStudyDescription("Study to verify DTO shape parity");
+    schema.setDataTypes(List.of("WGS", "Phenotype"));
+    schema.setPiName("Jane Researcher");
+    schema.setPiEmail("jane@example.com");
+    schema.setPhenotypeIndication("Cardiovascular");
+    schema.setSpecies("Human");
+    schema.setDataCustodianEmail(List.of("custodian@example.com"));
+    schema.setPublicVisibility(true);
+    schema.setThroughBioId("bio-12345");
+    schema.setNihAnvilUse(
+        DatasetRegistrationSchemaV1.NihAnvilUse
+            .I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    schema.setSubmittingToAnvil(true);
+    schema.setDbGaPPhsID("phs000001");
+    schema.setDbGaPStudyRegistrationName("GWAS Study");
+    schema.setEmbargoReleaseDate("2026-01-01");
+    schema.setSequencingCenter("Broad Institute");
+    schema.setPiInstitution(42);
+    schema.setNihGrantContractNumber("R01HG012345");
+    schema.setNihICsSupportingStudy(
+        List.of(NihICsSupportingStudy.NHGRI, NihICsSupportingStudy.NCI));
+    schema.setNihProgramOfficerName("Officer Smith");
+    schema.setNihInstitutionCenterSubmission(
+        DatasetRegistrationSchemaV1.NihInstitutionCenterSubmission.NHGRI);
+    schema.setNihGenomicProgramAdministratorName("Admin Jones");
+    schema.setMultiCenterStudy(true);
+    schema.setCollaboratingSites(List.of("Site A", "Site B"));
+    schema.setControlledAccessRequiredForGenomicSummaryResultsGSR(false);
+    schema.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation("N/A");
+    schema.setAlternativeDataSharingPlan(true);
+    schema.setAlternativeDataSharingPlanReasons(
+        List.of(AlternativeDataSharingPlanReason.LEGAL_RESTRICTIONS));
+    schema.setAlternativeDataSharingPlanExplanation("Legal hold");
+    schema.setAlternativeDataSharingPlanFileName("plan.pdf");
+    schema.setAlternativeDataSharingPlanDataSubmitted(
+        DatasetRegistrationSchemaV1.AlternativeDataSharingPlanDataSubmitted
+            .WITHIN_3_MONTHS_OF_THE_LAST_DATA_GENERATED_OR_LAST_CLINICAL_VISIT);
+    schema.setAlternativeDataSharingPlanDataReleased(true);
+    schema.setAlternativeDataSharingPlanTargetDeliveryDate("2026-03-01");
+    schema.setAlternativeDataSharingPlanTargetPublicReleaseDate("2026-06-01");
+    schema.setAlternativeDataSharingPlanAccessManagement(
+        DatasetRegistrationSchemaV1.AlternativeDataSharingPlanAccessManagement.CONTROLLED_ACCESS);
+    schema.setExternalIdentifier("ext-001");
+    schema.setExternalIdentifierType("dbGaP");
+    schema.setAssets(Map.of("workspaceId", "ws-001"));
+    schema.setData(Map.of("note", "extra metadata"));
+
+    ConsentGroup cg = new ConsentGroup();
+    cg.setConsentGroupName("Consent Group 1");
+    cg.setDatasetId(10);
+    cg.setAccessManagement(ConsentGroup.AccessManagement.OPEN);
+    cg.setGeneralResearchUse(true);
+    cg.setNumberOfParticipants(100);
+    cg.setDataLocation(ConsentGroup.DataLocation.AN_VIL_WORKSPACE);
+    cg.setUrl(URI.create("https://anvil.example.com/workspace"));
+    schema.setConsentGroups(List.of(cg));
+
+    return schema;
+  }
+
+  private void assertStudyFieldsMatch(
+      DatasetRegistrationSchemaV1 source, StudyRegistrationRequest result) {
+    // studyId and dataSubmitterUserId are intentionally excluded from the DTO (system-set fields)
+    assertEquals(source.getStudyName(), result.getStudyName());
+    assertEquals(source.getStudyType(), result.getStudyType());
+    assertEquals(source.getStudyDescription(), result.getStudyDescription());
+    assertEquals(source.getDataTypes(), result.getDataTypes());
+    assertEquals(source.getPiName(), result.getPiName());
+    assertEquals(source.getPiEmail(), result.getPiEmail());
+    assertEquals(source.getPhenotypeIndication(), result.getPhenotypeIndication());
+    assertEquals(source.getSpecies(), result.getSpecies());
+    assertEquals(source.getDataCustodianEmail(), result.getDataCustodianEmail());
+    assertEquals(source.getPublicVisibility(), result.getPublicVisibility());
+    assertEquals(source.getThroughBioId(), result.getThroughBioId());
+    assertEquals(source.getNihAnvilUse(), result.getNihAnvilUse());
+    assertEquals(source.getSubmittingToAnvil(), result.getSubmittingToAnvil());
+    assertEquals(source.getDbGaPPhsID(), result.getDbGaPPhsID());
+    assertEquals(source.getDbGaPStudyRegistrationName(), result.getDbGaPStudyRegistrationName());
+    assertEquals(source.getEmbargoReleaseDate(), result.getEmbargoReleaseDate());
+    assertEquals(source.getSequencingCenter(), result.getSequencingCenter());
+    assertEquals(source.getPiInstitution(), result.getPiInstitution());
+    assertEquals(source.getNihGrantContractNumber(), result.getNihGrantContractNumber());
+    assertEquals(source.getNihICsSupportingStudy(), result.getNihICsSupportingStudy());
+    assertEquals(source.getNihProgramOfficerName(), result.getNihProgramOfficerName());
+    assertEquals(
+        source.getNihInstitutionCenterSubmission(), result.getNihInstitutionCenterSubmission());
+    assertEquals(
+        source.getNihGenomicProgramAdministratorName(),
+        result.getNihGenomicProgramAdministratorName());
+    assertEquals(source.getMultiCenterStudy(), result.getMultiCenterStudy());
+    assertEquals(source.getCollaboratingSites(), result.getCollaboratingSites());
+    assertEquals(
+        source.getControlledAccessRequiredForGenomicSummaryResultsGSR(),
+        result.getControlledAccessRequiredForGenomicSummaryResultsGSR());
+    assertEquals(
+        source.getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(),
+        result.getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation());
+    assertEquals(source.getAlternativeDataSharingPlan(), result.getAlternativeDataSharingPlan());
+    assertEquals(
+        source.getAlternativeDataSharingPlanReasons(),
+        result.getAlternativeDataSharingPlanReasons());
+    assertEquals(
+        source.getAlternativeDataSharingPlanExplanation(),
+        result.getAlternativeDataSharingPlanExplanation());
+    assertEquals(
+        source.getAlternativeDataSharingPlanFileName(),
+        result.getAlternativeDataSharingPlanFileName());
+    assertEquals(
+        source.getAlternativeDataSharingPlanDataSubmitted(),
+        result.getAlternativeDataSharingPlanDataSubmitted());
+    assertEquals(
+        source.getAlternativeDataSharingPlanDataReleased(),
+        result.getAlternativeDataSharingPlanDataReleased());
+    assertEquals(
+        source.getAlternativeDataSharingPlanTargetDeliveryDate(),
+        result.getAlternativeDataSharingPlanTargetDeliveryDate());
+    assertEquals(
+        source.getAlternativeDataSharingPlanTargetPublicReleaseDate(),
+        result.getAlternativeDataSharingPlanTargetPublicReleaseDate());
+    assertEquals(
+        source.getAlternativeDataSharingPlanAccessManagement(),
+        result.getAlternativeDataSharingPlanAccessManagement());
+    assertEquals(source.getExternalIdentifier(), result.getExternalIdentifier());
+    assertEquals(source.getExternalIdentifierType(), result.getExternalIdentifierType());
+    assertNotNull(result.getAssets());
+    assertNotNull(result.getData());
+
+    // consent groups
+    assertNotNull(result.getConsentGroups());
+    assertEquals(source.getConsentGroups().size(), result.getConsentGroups().size());
+    ConsentGroup sourceCg = source.getConsentGroups().get(0);
+    ConsentGroupRequest resultCg = result.getConsentGroups().get(0);
+    assertEquals(sourceCg.getDatasetId(), resultCg.getDatasetId());
+    assertEquals(sourceCg.getConsentGroupName(), resultCg.getConsentGroupName());
+    assertEquals(sourceCg.getAccessManagement(), resultCg.getAccessManagement());
+    assertEquals(sourceCg.getGeneralResearchUse(), resultCg.getGeneralResearchUse());
+    assertEquals(sourceCg.getNumberOfParticipants(), resultCg.getNumberOfParticipants());
+    assertEquals(sourceCg.getDataLocation(), resultCg.getDataLocation());
+    assertEquals(sourceCg.getUrl(), resultCg.getUrl());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/RegistrationDtoPayloadShapeTest.java
@@ -79,12 +79,37 @@ class RegistrationDtoPayloadShapeTest {
 
     assertEquals(source.getDatasetId(), roundTripped.getDatasetId());
     assertEquals(source.getConsentGroupName(), roundTripped.getConsentGroupName());
+    assertEquals(source.getDataAccessCommitteeId(), roundTripped.getDataAccessCommitteeId());
     assertEquals(source.getAccessManagement(), roundTripped.getAccessManagement());
-    assertEquals(source.getNumberOfParticipants(), roundTripped.getNumberOfParticipants());
-    assertEquals(source.getDataLocation(), roundTripped.getDataLocation());
-    assertEquals(source.getUrl(), roundTripped.getUrl());
+    assertEquals(source.getGeneralResearchUse(), roundTripped.getGeneralResearchUse());
     assertEquals(source.getHmb(), roundTripped.getHmb());
     assertEquals(source.getDiseaseSpecificUse(), roundTripped.getDiseaseSpecificUse());
+    assertEquals(source.getPoa(), roundTripped.getPoa());
+    assertEquals(source.getOtherPrimary(), roundTripped.getOtherPrimary());
+    assertEquals(source.getNmds(), roundTripped.getNmds());
+    assertEquals(source.getGso(), roundTripped.getGso());
+    assertEquals(source.getPub(), roundTripped.getPub());
+    assertEquals(source.getCol(), roundTripped.getCol());
+    assertEquals(source.getIrb(), roundTripped.getIrb());
+    assertEquals(source.getGs(), roundTripped.getGs());
+    assertEquals(source.getMor(), roundTripped.getMor());
+    assertEquals(source.getMorDate(), roundTripped.getMorDate());
+    assertEquals(source.getNpu(), roundTripped.getNpu());
+    assertEquals(source.getOtherSecondary(), roundTripped.getOtherSecondary());
+    assertEquals(source.getDataLocation(), roundTripped.getDataLocation());
+    assertEquals(source.getUrl(), roundTripped.getUrl());
+    assertEquals(source.getRequestLocation(), roundTripped.getRequestLocation());
+    assertEquals(source.getNumberOfParticipants(), roundTripped.getNumberOfParticipants());
+    assertNotNull(roundTripped.getFileTypes());
+    assertEquals(1, roundTripped.getFileTypes().size());
+    assertEquals(
+        source.getFileTypes().get(0).getFileType(),
+        roundTripped.getFileTypes().get(0).getFileType());
+    assertEquals(
+        source.getFileTypes().get(0).getFunctionalEquivalence(),
+        roundTripped.getFileTypes().get(0).getFunctionalEquivalence());
+    assertEquals(source.getData(), roundTripped.getData());
+    // datasetIdentifier is server-assigned and intentionally absent from ConsentGroupRequest
   }
 
   // ── StudyRegistrationRequest ───────────────────────────────────────────────
@@ -121,6 +146,8 @@ class RegistrationDtoPayloadShapeTest {
     assertEquals(
         source.getAlternativeDataSharingPlanReasons(),
         roundTripped.getAlternativeDataSharingPlanReasons());
+    assertEquals(source.getExternalIdentifier(), roundTripped.getExternalIdentifier());
+    assertEquals(source.getExternalIdentifierType(), roundTripped.getExternalIdentifierType());
     assertNotNull(roundTripped.getConsentGroups());
     assertEquals(1, roundTripped.getConsentGroups().size());
     assertEquals(
@@ -310,8 +337,8 @@ class RegistrationDtoPayloadShapeTest {
         result.getAlternativeDataSharingPlanAccessManagement());
     assertEquals(source.getExternalIdentifier(), result.getExternalIdentifier());
     assertEquals(source.getExternalIdentifierType(), result.getExternalIdentifierType());
-    assertNotNull(result.getAssets());
-    assertNotNull(result.getData());
+    assertEquals(source.getAssets(), result.getAssets());
+    assertEquals(source.getData(), result.getData());
 
     // consent groups
     assertNotNull(result.getConsentGroups());


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3592](https://broadworkbench.atlassian.net/browse/DT-3592)

### Summary

Introduces typed DTO classes for the study registration API surface, replacing direct use of the auto-generated DatasetRegistrationSchemaV1 and ConsentGroup schema models in request handling.

Changes

New classes (src/main/java/.../dto/registration/):

- StudyRegistrationRequest — DTO for study creation payloads. Mirrors the full field set of DatasetRegistrationSchemaV1 with explicit `@JsonProperty` annotations and `@JsonPropertyOrder` to enforce stable serialization order. Includes all study-level fields (NIH metadata, alternative data sharing plan, collaborating sites, etc.) and a list of ConsentGroupRequest objects.
- ConsentGroupRequest — DTO for consent group payloads within a registration request. Mirrors ConsentGroup with all primary/secondary use restriction fields, data location, file types, and a passthrough data map. Intentionally omits the server-assigned datasetIdentifier field.
- StudyUpdateRequest — Thin subclass of StudyRegistrationRequest to distinguish update vs. create semantics at the type level, with no additional fields.

New tests (src/test/java/.../dto/registration/RegistrationDtoPayloadShapeTest.java):

- Round-trip tests verify that serializio JSON and deserializing into the new DTO
preserves every mapped field.
- Inverse round-trip tests verify that DTO-serialized JSON can be deserialized back into the original schema
model with no data loss.
- Covers ConsentGroupRequest, StudyRegistrationRequest, and StudyUpdateRequest.

Notes                                                                                                         
- All three DTOs use `@JsonIgnoreProperties(ignoreUnknown = true)` and `@JsonInclude(NON_NULL)` to be tolerant of schema evolution.
- ConsentGroupRequest intentionally excludes datasetIdentifier, which is server-assigned and should not be   accepted as client input.
- StudyUpdateRequest is currently a marker subclass; additional update-only fields can be added here without touching the base class.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
