### PR TITLE
[DT-2879] Add ontology index reconciliation report

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/OntologyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/OntologyResource.java
@@ -64,6 +64,18 @@ public class OntologyResource extends Resource {
   }
 
   @GET
+  @Path("reconcile")
+  @Produces({MediaType.APPLICATION_JSON})
+  @RolesAllowed({ADMIN})
+  public Response reconcileIndexedTerms(@Auth DuosUser duosUser) {
+    try {
+      return Response.ok(ontologyService.reconcileIndexedTerms()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  @GET
   @Path("search")
   @Produces({MediaType.APPLICATION_JSON})
   public Response searchByTermIds(@QueryParam("ids") String ids) {

--- a/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/OntologyService.java
@@ -8,6 +8,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
@@ -17,6 +18,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
+import org.broadinstitute.consent.http.service.ontology.OntologyReconciliationResult;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
@@ -82,6 +84,18 @@ public class OntologyService implements ConsentLogger {
 
   public StreamingOutput findByTermIds(String[] termIds) {
     return ontologyDAO.findByTermIds(termIds);
+  }
+
+  /**
+   * Reconciles the ontology terms referenced by Datasets and DARs against the indexed terms in the
+   * ontology_index table. Returns referenced term ids that are either missing from the index or
+   * present but flagged unusable, so administrators can identify drift after re-indexing an
+   * ontology.
+   *
+   * @return The list of referenced terms that are missing or unusable in the ontology index.
+   */
+  public List<OntologyReconciliationResult> reconcileIndexedTerms() {
+    return ontologyDAO.findReferencedTermsMissingFromIndex();
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyDAO.java
@@ -5,12 +5,14 @@ import jakarta.ws.rs.core.StreamingOutput;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.StreamingOutputIterator;
 import org.broadinstitute.consent.http.db.mapper.JsonMapper;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
 import org.jdbi.v3.core.result.ResultIterable;
 import org.jdbi.v3.json.Json;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.BatchChunkSize;
@@ -36,6 +38,53 @@ public interface OntologyDAO extends Transactional<OntologyDAO> {
 
   @SqlUpdate("DELETE FROM ontology_index where ontology = :ontology")
   void deleteByOntology(@Bind("ontology") String ontology);
+
+  /**
+   * Reconciles the ontology terms referenced by Datasets and DARs against the terms in the
+   * ontology_index table. Returns one row per referenced term id that is either missing from the
+   * index or present but flagged unusable. Dataset disease restrictions are read from the
+   * dataset.data_use (text) column and DAR ontology entries from the data_access_request.data
+   * (jsonb) column. Comparison is case-insensitive and whitespace-trimmed to mirror the lookup
+   * behavior of {@link #findByTermIds(String[])}.
+   */
+  @RegisterConstructorMapper(OntologyReconciliationResult.class)
+  @SqlQuery(
+      """
+          WITH referenced_terms AS (
+              SELECT 'DATASET' AS source,
+                     d.dataset_id::text AS source_id,
+                     jsonb_array_elements_text(d.data_use::jsonb -> 'diseaseRestrictions') AS term_id
+              FROM dataset d
+              WHERE d.data_use IS NOT NULL
+                AND jsonb_typeof(d.data_use::jsonb -> 'diseaseRestrictions') = 'array'
+              UNION ALL
+              SELECT 'DAR' AS source,
+                     dar.reference_id AS source_id,
+                     jsonb_array_elements(dar.data -> 'ontologies') ->> 'id' AS term_id
+              FROM data_access_request dar
+              WHERE jsonb_typeof(dar.data -> 'ontologies') = 'array'
+          ),
+          clean AS (
+              SELECT source, source_id, term_id, LOWER(TRIM(term_id)) AS norm_id
+              FROM referenced_terms
+              WHERE term_id IS NOT NULL AND TRIM(term_id) <> ''
+          )
+          SELECT
+              c.term_id AS term_id,
+              CASE WHEN oi.id IS NULL THEN 'MISSING_FROM_INDEX'
+                   WHEN oi.usable IS NOT TRUE THEN 'PRESENT_BUT_UNUSABLE' END AS issue,
+              oi.ontology AS ontology,
+              COUNT(*) AS reference_count,
+              COUNT(*) FILTER (WHERE c.source = 'DATASET') AS dataset_refs,
+              COUNT(*) FILTER (WHERE c.source = 'DAR') AS dar_refs,
+              STRING_AGG(DISTINCT c.source || ':' || c.source_id, ', ') AS referenced_by
+          FROM clean c
+          LEFT JOIN ontology_index oi ON LOWER(TRIM(oi.id)) = c.norm_id
+          WHERE oi.id IS NULL OR oi.usable IS NOT TRUE
+          GROUP BY c.term_id, oi.id, oi.usable, oi.ontology
+          ORDER BY issue, reference_count DESC
+          """)
+  List<OntologyReconciliationResult> findReferencedTermsMissingFromIndex();
 
   @Json
   default StreamingOutput findByTermIds(@Bind("ids") String[] ids) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyReconciliationResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ontology/OntologyReconciliationResult.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.consent.http.service.ontology;
+
+/**
+ * Result of reconciling ontology terms referenced by Datasets and DARs against the terms indexed in
+ * the ontology_index table. Each result represents a single referenced term id that is either
+ * missing from the index entirely or present but flagged unusable (obsolete/deprecated).
+ *
+ * @param termId The referenced ontology term id (full IRI).
+ * @param issue MISSING_FROM_INDEX when no ontology_index row exists, or PRESENT_BUT_UNUSABLE when a
+ *     row exists but is not usable.
+ * @param ontology The ontology of the indexed term, or null when the term is missing.
+ * @param referenceCount Total number of Dataset/DAR references to this term.
+ * @param datasetRefs Number of Dataset references to this term.
+ * @param darRefs Number of DAR references to this term.
+ * @param referencedBy Comma-separated list of sources referencing the term (e.g. "DATASET:12,
+ *     DAR:abc-123").
+ */
+public record OntologyReconciliationResult(
+    String termId,
+    String issue,
+    String ontology,
+    Long referenceCount,
+    Long datasetRefs,
+    Long darRefs,
+    String referencedBy) {}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -948,6 +948,8 @@ paths:
     $ref: './paths/votesRationale.yaml'
   /api/ontology:
     $ref: './paths/ontology.yaml'
+  /api/ontology/reconcile:
+    $ref: './paths/ontologyReconcile.yaml'
   /liveness:
     $ref: './paths/liveness.yaml'
   /ontology/search:

--- a/src/main/resources/assets/paths/ontologyReconcile.yaml
+++ b/src/main/resources/assets/paths/ontologyReconcile.yaml
@@ -1,0 +1,20 @@
+get:
+  summary: Reconcile indexed ontology terms
+  description: |
+    Reconcile the ontology terms referenced by Datasets and DARs against the indexed terms in the
+    ontology index. Returns referenced term ids that are either missing from the index or present
+    but flagged unusable, so administrators can identify drift after re-indexing an ontology.
+  operationId: apiOntologyReconcileGet
+  tags:
+    - Admin
+  responses:
+    200:
+      description: Ontology Reconciliation Results
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../schemas/OntologyReconciliationResult.yaml'
+    500:
+      description: Internal Server Error

--- a/src/main/resources/assets/schemas/OntologyReconciliationResult.yaml
+++ b/src/main/resources/assets/schemas/OntologyReconciliationResult.yaml
@@ -1,0 +1,35 @@
+type: object
+description: |
+  The result of reconciling ontology terms referenced by Datasets and DARs against the terms
+  indexed in the ontology index. Each result represents a single referenced term id that is either
+  missing from the index entirely or present but flagged unusable (obsolete/deprecated).
+properties:
+  termId:
+    type: string
+    description: The referenced ontology term id. This is typically the full purl Term URI.
+  issue:
+    type: string
+    description: |
+      The reason the term was flagged. MISSING_FROM_INDEX when no indexed term exists, or
+      PRESENT_BUT_UNUSABLE when an indexed term exists but is flagged unusable.
+    enum: [ MISSING_FROM_INDEX, PRESENT_BUT_UNUSABLE ]
+  ontology:
+    type: string
+    description: The ontology that the indexed term belongs to (e.g. DOID, DUO), or null when the term is missing.
+  referenceCount:
+    type: integer
+    format: int64
+    description: The total number of Dataset and DAR references to this term.
+  datasetRefs:
+    type: integer
+    format: int64
+    description: The number of Dataset references to this term.
+  darRefs:
+    type: integer
+    format: int64
+    description: The number of DAR references to this term.
+  referencedBy:
+    type: string
+    description: |
+      A comma-separated list of the sources that reference this term, prefixed by source type
+      (e.g. "DATASET:12, DAR:abc-123").

--- a/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/OntologyDAOTest.java
@@ -11,14 +11,24 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.FileInputStream;
+import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
 import org.broadinstitute.consent.http.configurations.StoreConfiguration;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.OntologyEntry;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
+import org.broadinstitute.consent.http.service.ontology.OntologyReconciliationResult;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
@@ -159,5 +169,163 @@ class OntologyDAOTest extends DAOTestHelper {
     StreamingOutput output = ontologyDAO.findByQuery(partial, null, null);
     JsonArray jsonArray = getJsonArrayFromStreamingOutput(output);
     assertTrue(jsonArray.isEmpty());
+  }
+
+  private static final String DOID_CANCER = "http://purl.obolibrary.org/obo/DOID_162";
+  private static final String DOID_MISSING = "http://purl.obolibrary.org/obo/DOID_9999999";
+
+  private void insertIndexedTerm(String id, String ontology, boolean usable, Integer userId) {
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate(
+                    """
+                        INSERT INTO ontology_index (id, version, ontology, label, usable, create_user_id)
+                        VALUES (:id, 'v1', :ontology, 'label', :usable, :userId)
+                        """)
+                .bind("id", id)
+                .bind("ontology", ontology)
+                .bind("usable", usable)
+                .bind("userId", userId)
+                .execute());
+  }
+
+  private Dataset insertDatasetWithDiseaseRestrictions(List<String> restrictions) {
+    User user = createUser();
+    Timestamp now = new Timestamp(new Date().getTime());
+    DataUse dataUse =
+        new DataUseBuilder().setGeneralUse(true).setDiseaseRestrictions(restrictions).build();
+    Integer id =
+        datasetDAO.insertDataset(
+            "Name_" + randomAlphabetic(20),
+            now,
+            user.getUserId(),
+            "Object ID_" + randomAlphabetic(20),
+            dataUse.toString(),
+            null);
+    return datasetDAO.findDatasetById(id);
+  }
+
+  private DataAccessRequest insertDarWithOntologies(List<String> termIds) {
+    User user = createUser();
+    String darCode = "DAR-" + randomInt(1, 999999999);
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setOntologies(
+        termIds.stream()
+            .map(
+                termId -> {
+                  OntologyEntry entry = new OntologyEntry();
+                  entry.setId(termId);
+                  entry.setLabel("label");
+                  return entry;
+                })
+            .toList());
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collectionId, referenceId, user.getUserId(), now, now, now, data, randomAlphabetic(10));
+    return dataAccessRequestDAO.findByReferenceId(referenceId);
+  }
+
+  private OntologyReconciliationResult findResult(
+      List<OntologyReconciliationResult> results, String termId) {
+    return results.stream().filter(r -> r.termId().equals(termId)).findFirst().orElse(null);
+  }
+
+  @Test
+  void testReconcileMissingDatasetTerm() {
+    User user = createUser();
+    insertIndexedTerm(DOID_CANCER, OntologyType.DOID.name(), true, user.getUserId());
+    Dataset dataset = insertDatasetWithDiseaseRestrictions(List.of(DOID_CANCER, DOID_MISSING));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    // Only the un-indexed term is flagged; the indexed/usable term is not.
+    assertEquals(1, results.size());
+    OntologyReconciliationResult result = results.getFirst();
+    assertEquals(DOID_MISSING, result.termId());
+    assertEquals("MISSING_FROM_INDEX", result.issue());
+    assertEquals(1L, result.referenceCount());
+    assertEquals(1L, result.datasetRefs());
+    assertEquals(0L, result.darRefs());
+    assertTrue(result.referencedBy().contains("DATASET:" + dataset.getDatasetId()));
+  }
+
+  @Test
+  void testReconcileMissingDarTerm() {
+    DataAccessRequest dar = insertDarWithOntologies(List.of(DOID_MISSING));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    assertEquals(1, results.size());
+    OntologyReconciliationResult result = results.getFirst();
+    assertEquals(DOID_MISSING, result.termId());
+    assertEquals("MISSING_FROM_INDEX", result.issue());
+    assertEquals(0L, result.datasetRefs());
+    assertEquals(1L, result.darRefs());
+    assertTrue(result.referencedBy().contains("DAR:" + dar.getReferenceId()));
+  }
+
+  @Test
+  void testReconcilePresentButUnusableTerm() {
+    User user = createUser();
+    insertIndexedTerm(DOID_CANCER, OntologyType.DOID.name(), false, user.getUserId());
+    insertDatasetWithDiseaseRestrictions(List.of(DOID_CANCER));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    assertEquals(1, results.size());
+    OntologyReconciliationResult result = results.getFirst();
+    assertEquals(DOID_CANCER, result.termId());
+    assertEquals("PRESENT_BUT_UNUSABLE", result.issue());
+    assertEquals(OntologyType.DOID.name(), result.ontology());
+  }
+
+  @Test
+  void testReconcileIndexedUsableTermNotFlagged() {
+    User user = createUser();
+    insertIndexedTerm(DOID_CANCER, OntologyType.DOID.name(), true, user.getUserId());
+    insertDatasetWithDiseaseRestrictions(List.of(DOID_CANCER));
+    insertDarWithOntologies(List.of(DOID_CANCER));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void testReconcileMatchingIsCaseInsensitive() {
+    User user = createUser();
+    // Indexed term is upper-cased; the referenced term is lower-cased. They should still match,
+    // mirroring the normalization in findByTermIds, so the term is not flagged.
+    insertIndexedTerm(DOID_CANCER.toUpperCase(), OntologyType.DOID.name(), true, user.getUserId());
+    insertDatasetWithDiseaseRestrictions(List.of(DOID_CANCER.toLowerCase()));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    assertTrue(results.isEmpty());
+  }
+
+  @Test
+  void testReconcileAggregatesReferencesAcrossSources() {
+    Dataset dataset = insertDatasetWithDiseaseRestrictions(List.of(DOID_MISSING));
+    DataAccessRequest dar = insertDarWithOntologies(List.of(DOID_MISSING));
+
+    List<OntologyReconciliationResult> results = ontologyDAO.findReferencedTermsMissingFromIndex();
+
+    assertEquals(1, results.size());
+    OntologyReconciliationResult result = findResult(results, DOID_MISSING);
+    assertEquals(2L, result.referenceCount());
+    assertEquals(1L, result.datasetRefs());
+    assertEquals(1L, result.darRefs());
+    assertTrue(result.referencedBy().contains("DATASET:" + dataset.getDatasetId()));
+    assertTrue(result.referencedBy().contains("DAR:" + dar.getReferenceId()));
+  }
+
+  @Test
+  void testReconcileNoReferences() {
+    assertTrue(ontologyDAO.findReferencedTermsMissingFromIndex().isEmpty());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/OntologyResourceTest.java
@@ -8,12 +8,14 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
+import java.util.List;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.enumeration.OntologyType;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ontology.OntologyReconciliationResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -109,6 +111,43 @@ class OntologyResourceTest extends AbstractTestHelper {
 
     resource = new OntologyResource(ontologyService);
     try (Response response = resource.deleteOntologyTerms(duosUser, OntologyType.DOID.name())) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+    }
+  }
+
+  @Test
+  void testReconcileIndexedTermsSuccess() {
+    User admin = new User();
+    admin.setAdminRole();
+    DuosUser duosUser = new DuosUser(authUser, admin);
+
+    OntologyReconciliationResult result =
+        new OntologyReconciliationResult(
+            "http://purl.obolibrary.org/obo/DOID_162",
+            "MISSING_FROM_INDEX",
+            null,
+            1L,
+            1L,
+            0L,
+            "DATASET:1");
+    when(ontologyService.reconcileIndexedTerms()).thenReturn(List.of(result));
+
+    resource = new OntologyResource(ontologyService);
+    try (Response response = resource.reconcileIndexedTerms(duosUser)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testReconcileIndexedTermsException() {
+    User admin = new User();
+    admin.setAdminRole();
+    DuosUser duosUser = new DuosUser(authUser, admin);
+
+    when(ontologyService.reconcileIndexedTerms()).thenThrow(new RuntimeException());
+
+    resource = new OntologyResource(ontologyService);
+    try (Response response = resource.reconcileIndexedTerms(duosUser)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/OntologyServiceTest.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.service.ontology.OntologyDAO;
 import org.broadinstitute.consent.http.service.ontology.OntologyIndexService;
+import org.broadinstitute.consent.http.service.ontology.OntologyReconciliationResult;
 import org.broadinstitute.consent.http.service.ontology.OntologyTerm;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -185,6 +186,30 @@ class OntologyServiceTest extends AbstractTestHelper {
     assertNotNull(results);
     JsonArray jsonArray = getJsonArrayFromStreamingOutput(results);
     assertEquals(2, jsonArray.size());
+  }
+
+  @Test
+  void testReconcileIndexedTerms() {
+    OntologyReconciliationResult result =
+        new OntologyReconciliationResult(
+            "http://purl.obolibrary.org/obo/DOID_162",
+            "MISSING_FROM_INDEX",
+            null,
+            2L,
+            1L,
+            1L,
+            "DATASET:1, DAR:abc");
+    when(ontologyDAO.findReferencedTermsMissingFromIndex()).thenReturn(List.of(result));
+
+    List<OntologyReconciliationResult> results = service.reconcileIndexedTerms();
+    assertEquals(1, results.size());
+    assertEquals(result, results.getFirst());
+  }
+
+  @Test
+  void testReconcileIndexedTermsEmpty() {
+    when(ontologyDAO.findReferencedTermsMissingFromIndex()).thenReturn(List.of());
+    assertTrue(service.reconcileIndexedTerms().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2879

## Summary
Adds an admin-only endpoint to reconcile ontology terms referenced by Datasets and DARs against the terms indexed in the `ontology_index` table, surfacing referenced terms that have drifted out of the index (e.g. after re-indexing an ontology from a new OWL file).

A referenced term is flagged when it is either:
- **`MISSING_FROM_INDEX`** — no matching `ontology_index` row exists, or
- **`PRESENT_BUT_UNUSABLE`** — a row exists but is flagged `usable = false` (obsolete/deprecated).

Comparison is case-insensitive and whitespace-trimmed, mirroring the lookup behavior of `findByTermIds`.

## Changes

- `OntologyDAO.findReferencedTermsMissingFromIndex()` — reconciliation query over `dataset.data_use` (text → jsonb) and `data_access_request.data` (jsonb), guarded with `jsonb_typeof(...) = 'array'` so non-array values are skipped.
- `OntologyReconciliationResult` — result record (term id, issue, ontology, reference counts by source, and the referencing sources).
- `OntologyService.reconcileIndexedTerms()` — exposes the DAO method to the resource layer.
- `GET /api/ontology/reconcile` (ADMIN) — returns the results as JSON.
- OpenAPI path and schema files for the new endpoint and entity.

## Tests

- **DAO** (Testcontainers): missing dataset/DAR terms, present-but-unusable, indexed/usable not flagged, case-insensitive matching, cross-source aggregation, no-references.
- **Service / Resource** (mock-based): delegation + success/exception paths.

## Example Responses
```
[
  {
    "termId": "http://purl.obolibrary.org/obo/DOID_00080600",
    "issue": "MISSING_FROM_INDEX",
    "referenceCount": 3,
    "datasetRefs": 3,
    "darRefs": 0,
    "referencedBy": "DATASET:{id_1}, DATASET:{id_2}, DATASET:{id_3}"
  },
  {
    "termId": "http://purl.obolibrary.org/obo/DOID_0060101",
    "issue": "MISSING_FROM_INDEX",
    "referenceCount": 1,
    "datasetRefs": 0,
    "darRefs": 1,
    "referencedBy": "DAR:{reference_id_1}"
  }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)