### PR TITLE
[DT-3593] Study Registration validator and tests.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
@@ -1,0 +1,171 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import jakarta.ws.rs.BadRequestException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.validator.routines.EmailValidator;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+
+public class StudyRegistrationRequestValidator {
+
+  public boolean validate(StudyRegistrationRequest registration) {
+    validateRequiredStudyFields(registration);
+    validateConditionalStudyFields(registration);
+    validateEmailFields(registration);
+    validateDateFields(registration);
+    validateConsentGroups(registration.getConsentGroups());
+    return true;
+  }
+
+  private void validateRequiredStudyFields(StudyRegistrationRequest registration) {
+    if (Objects.isNull(registration.getStudyName()) || registration.getStudyName().isBlank()) {
+      throw new BadRequestException("Study Name is required");
+    }
+    if (Objects.isNull(registration.getStudyDescription())) {
+      throw new BadRequestException("Study Description is required");
+    }
+    if (Objects.isNull(registration.getDataTypes()) || registration.getDataTypes().isEmpty()) {
+      throw new BadRequestException("Data Types is required");
+    }
+    if (Objects.isNull(registration.getPublicVisibility())) {
+      throw new BadRequestException("Public Visibility is required");
+    }
+    if (Objects.isNull(registration.getNihAnvilUse())) {
+      throw new BadRequestException("NIH Anvil Use is required");
+    }
+    if (Objects.isNull(registration.getPiName())) {
+      throw new BadRequestException("Principal Investigator is required");
+    }
+  }
+
+  private void validateConditionalStudyFields(StudyRegistrationRequest registration) {
+    NihAnvilUse anvilUse = registration.getNihAnvilUse();
+    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
+      if (Objects.isNull(registration.getDbGaPPhsID())) {
+        throw new BadRequestException("DbGap phs ID is required");
+      }
+      if (Objects.isNull(registration.getPiInstitution())) {
+        throw new BadRequestException("PI Institution is required");
+      }
+      if (Objects.isNull(registration.getNihGrantContractNumber())) {
+        throw new BadRequestException("NIH Grant of Contract Number is required");
+      }
+    }
+    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID)
+        || anvilUse.equals(
+            NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL)) {
+      if (Objects.isNull(registration.getPiInstitution())) {
+        throw new BadRequestException("PI Institution is required");
+      }
+      if (Objects.isNull(registration.getNihGrantContractNumber())) {
+        throw new BadRequestException("NIH Grant of Contract Number is required");
+      }
+    }
+    if (Boolean.TRUE.equals(
+        registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())) {
+      if (Objects.isNull(
+          registration
+              .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
+        throw new BadRequestException(
+            "Controlled access GSR explanation is required when GSR access is required");
+      }
+    }
+    if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
+      if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
+        throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
+      }
+      if (Objects.isNull(registration.getAlternativeDataSharingPlanReasons())
+          || registration.getAlternativeDataSharingPlanReasons().isEmpty()) {
+        throw new BadRequestException("Alternative Data Sharing Plan Reasons is required");
+      }
+    }
+  }
+
+  private void validateEmailFields(StudyRegistrationRequest registration) {
+    EmailValidator emailValidator = EmailValidator.getInstance();
+    if (registration.getPiEmail() != null && !registration.getPiEmail().isBlank()) {
+      if (!emailValidator.isValid(registration.getPiEmail())) {
+        throw new BadRequestException("PI Email is not a valid email address");
+      }
+    }
+    if (registration.getDataCustodianEmail() != null) {
+      registration.getDataCustodianEmail().stream()
+          .filter(Objects::nonNull)
+          .filter(e -> !e.isBlank())
+          .forEach(
+              email -> {
+                if (!emailValidator.isValid(email)) {
+                  throw new BadRequestException(
+                      "Data Custodian Email is not a valid email address: " + email);
+                }
+              });
+    }
+  }
+
+  private void validateDateFields(StudyRegistrationRequest registration) {
+    validateDateString(registration.getEmbargoReleaseDate(), "Embargo Release Date");
+    validateDateString(
+        registration.getAlternativeDataSharingPlanTargetDeliveryDate(),
+        "Alternative Data Sharing Plan Target Delivery Date");
+    validateDateString(
+        registration.getAlternativeDataSharingPlanTargetPublicReleaseDate(),
+        "Alternative Data Sharing Plan Target Public Release Date");
+  }
+
+  private void validateConsentGroups(List<ConsentGroupRequest> consentGroups) {
+    if (Objects.isNull(consentGroups) || consentGroups.isEmpty()) {
+      throw new BadRequestException("At least one Consent Group is required");
+    }
+    consentGroups.forEach(this::validateConsentGroup);
+  }
+
+  private void validateConsentGroup(ConsentGroupRequest cg) {
+    if (Objects.isNull(cg.getConsentGroupName()) || cg.getConsentGroupName().isBlank()) {
+      throw new BadRequestException("Consent Group Name is required");
+    }
+    if (Objects.isNull(cg.getNumberOfParticipants())) {
+      throw new BadRequestException("Number of Participants is required");
+    }
+    validateDataUseConsistency(cg);
+    validateDacRequirement(cg);
+    validateDateString(cg.getMorDate(), "Moratorium Date");
+  }
+
+  private void validateDataUseConsistency(ConsentGroupRequest cg) {
+    int count = 0;
+    if (AccessManagement.OPEN.equals(cg.getAccessManagement())) count++;
+    if (Boolean.TRUE.equals(cg.getGeneralResearchUse())) count++;
+    if (Boolean.TRUE.equals(cg.getHmb())) count++;
+    if (Boolean.TRUE.equals(cg.getPoa())) count++;
+    if (cg.getDiseaseSpecificUse() != null && !cg.getDiseaseSpecificUse().isEmpty()) count++;
+    if (cg.getOtherPrimary() != null && !cg.getOtherPrimary().isBlank()) count++;
+    if (count != 1) {
+      throw new BadRequestException(
+          "Consent Group must have exactly one primary data use (open access, or one of:"
+              + " general research use, health/medical/biomedical, populations/origins/ancestry,"
+              + " disease-specific, other)");
+    }
+  }
+
+  private void validateDacRequirement(ConsentGroupRequest cg) {
+    if (AccessManagement.CONTROLLED.equals(cg.getAccessManagement())
+        && Objects.isNull(cg.getDataAccessCommitteeId())) {
+      throw new BadRequestException(
+          "Data Access Committee is required for controlled access datasets");
+    }
+  }
+
+  private void validateDateString(String dateStr, String fieldName) {
+    if (dateStr == null || dateStr.isBlank()) {
+      return;
+    }
+    try {
+      LocalDate.parse(dateStr);
+    } catch (DateTimeParseException e) {
+      throw new BadRequestException(fieldName + " is not a valid date");
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
@@ -42,37 +42,46 @@ public class StudyRegistrationRequestValidator {
   }
 
   private void validateConditionalStudyFields(StudyRegistrationRequest registration) {
-    NihAnvilUse anvilUse = registration.getNihAnvilUse();
+    validateNihAnvilUseConditionals(registration.getNihAnvilUse(), registration);
+    validateGsrConditionals(registration);
+    validateAlternativeDataSharingConditionals(registration);
+  }
+
+  private void validateNihAnvilUseConditionals(
+      NihAnvilUse anvilUse, StudyRegistrationRequest registration) {
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
       if (Objects.isNull(registration.getDbGaPPhsID())) {
         throw new BadRequestException("DbGap phs ID is required");
       }
-      if (Objects.isNull(registration.getPiInstitution())) {
-        throw new BadRequestException("PI Institution is required");
-      }
-      if (Objects.isNull(registration.getNihGrantContractNumber())) {
-        throw new BadRequestException("NIH Grant of Contract Number is required");
-      }
+      validatePiInstitutionAndGrantNumber(registration);
     }
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID)
         || anvilUse.equals(
             NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL)) {
-      if (Objects.isNull(registration.getPiInstitution())) {
-        throw new BadRequestException("PI Institution is required");
-      }
-      if (Objects.isNull(registration.getNihGrantContractNumber())) {
-        throw new BadRequestException("NIH Grant of Contract Number is required");
-      }
+      validatePiInstitutionAndGrantNumber(registration);
     }
-    if (Boolean.TRUE.equals(
-        registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())) {
-      if (Objects.isNull(
-          registration
-              .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
-        throw new BadRequestException(
-            "Controlled access GSR explanation is required when GSR access is required");
-      }
+  }
+
+  private void validatePiInstitutionAndGrantNumber(StudyRegistrationRequest registration) {
+    if (Objects.isNull(registration.getPiInstitution())) {
+      throw new BadRequestException("PI Institution is required");
     }
+    if (Objects.isNull(registration.getNihGrantContractNumber())) {
+      throw new BadRequestException("NIH Grant of Contract Number is required");
+    }
+  }
+
+  private void validateGsrConditionals(StudyRegistrationRequest registration) {
+    if (Boolean.TRUE.equals(registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())
+        && Objects.isNull(
+            registration
+                .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
+      throw new BadRequestException(
+          "Controlled access GSR explanation is required when GSR access is required");
+    }
+  }
+
+  private void validateAlternativeDataSharingConditionals(StudyRegistrationRequest registration) {
     if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
       if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
         throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
@@ -86,10 +95,10 @@ public class StudyRegistrationRequestValidator {
 
   private void validateEmailFields(StudyRegistrationRequest registration) {
     EmailValidator emailValidator = EmailValidator.getInstance();
-    if (registration.getPiEmail() != null && !registration.getPiEmail().isBlank()) {
-      if (!emailValidator.isValid(registration.getPiEmail())) {
-        throw new BadRequestException("PI Email is not a valid email address");
-      }
+    if (registration.getPiEmail() != null
+        && !registration.getPiEmail().isBlank()
+        && !emailValidator.isValid(registration.getPiEmail())) {
+      throw new BadRequestException("PI Email is not a valid email address");
     }
     if (registration.getDataCustodianEmail() != null) {
       registration.getDataCustodianEmail().stream()
@@ -165,7 +174,7 @@ public class StudyRegistrationRequestValidator {
     try {
       LocalDate.parse(dateStr);
     } catch (DateTimeParseException e) {
-      throw new BadRequestException(fieldName + " is not a valid date");
+      throw new BadRequestException(fieldName + " is not a valid date", e);
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
@@ -13,7 +13,7 @@ public class StudyRegistrationRequestValidator {
 
   public boolean validate(StudyRegistrationRequest registration) {
     validateRequiredStudyFields(registration);
-    validateConditionalStudyFields(registration);
+    validateConditionalFields(registration);
     validateEmailFields(registration);
     validateDateFields(registration);
     validateConsentGroups(registration.getConsentGroups());
@@ -41,13 +41,13 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateConditionalStudyFields(StudyRegistrationRequest registration) {
+  protected void validateConditionalFields(StudyRegistrationRequest registration) {
     validateNihAnvilUseConditionals(registration.getNihAnvilUse(), registration);
     validateGsrConditionals(registration);
     validateAlternativeDataSharingConditionals(registration);
   }
 
-  private void validateNihAnvilUseConditionals(
+  protected void validateNihAnvilUseConditionals(
       NihAnvilUse anvilUse, StudyRegistrationRequest registration) {
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
       if (Objects.isNull(registration.getDbGaPPhsID())) {
@@ -62,7 +62,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validatePiInstitutionAndGrantNumber(StudyRegistrationRequest registration) {
+  protected void validatePiInstitutionAndGrantNumber(StudyRegistrationRequest registration) {
     if (Objects.isNull(registration.getPiInstitution())) {
       throw new BadRequestException("PI Institution is required");
     }
@@ -71,7 +71,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateGsrConditionals(StudyRegistrationRequest registration) {
+  protected void validateGsrConditionals(StudyRegistrationRequest registration) {
     if (Boolean.TRUE.equals(registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())
         && Objects.isNull(
             registration
@@ -81,7 +81,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateAlternativeDataSharingConditionals(StudyRegistrationRequest registration) {
+  protected void validateAlternativeDataSharingConditionals(StudyRegistrationRequest registration) {
     if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
       if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
         throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
@@ -93,7 +93,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateEmailFields(StudyRegistrationRequest registration) {
+  protected void validateEmailFields(StudyRegistrationRequest registration) {
     EmailValidator emailValidator = EmailValidator.getInstance();
     if (registration.getPiEmail() != null
         && !registration.getPiEmail().isBlank()
@@ -114,7 +114,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateDateFields(StudyRegistrationRequest registration) {
+  protected void validateDateFields(StudyRegistrationRequest registration) {
     validateDateString(registration.getEmbargoReleaseDate(), "Embargo Release Date");
     validateDateString(
         registration.getAlternativeDataSharingPlanTargetDeliveryDate(),
@@ -128,10 +128,10 @@ public class StudyRegistrationRequestValidator {
     if (Objects.isNull(consentGroups) || consentGroups.isEmpty()) {
       throw new BadRequestException("At least one Consent Group is required");
     }
-    consentGroups.forEach(this::validateConsentGroup);
+    consentGroups.forEach(this::validateNewConsentGroup);
   }
 
-  private void validateConsentGroup(ConsentGroupRequest cg) {
+  protected void validateNewConsentGroup(ConsentGroupRequest cg) {
     if (Objects.isNull(cg.getConsentGroupName()) || cg.getConsentGroupName().isBlank()) {
       throw new BadRequestException("Consent Group Name is required");
     }
@@ -143,7 +143,7 @@ public class StudyRegistrationRequestValidator {
     validateDateString(cg.getMorDate(), "Moratorium Date");
   }
 
-  private void validateDataUseConsistency(ConsentGroupRequest cg) {
+  protected void validateDataUseConsistency(ConsentGroupRequest cg) {
     int count = 0;
     if (AccessManagement.OPEN.equals(cg.getAccessManagement())) count++;
     if (Boolean.TRUE.equals(cg.getGeneralResearchUse())) count++;
@@ -159,7 +159,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateDacRequirement(ConsentGroupRequest cg) {
+  protected void validateDacRequirement(ConsentGroupRequest cg) {
     if (AccessManagement.CONTROLLED.equals(cg.getAccessManagement())
         && Objects.isNull(cg.getDataAccessCommitteeId())) {
       throw new BadRequestException(
@@ -167,7 +167,7 @@ public class StudyRegistrationRequestValidator {
     }
   }
 
-  private void validateDateString(String dateStr, String fieldName) {
+  protected void validateDateString(String dateStr, String fieldName) {
     if (dateStr == null || dateStr.isBlank()) {
       return;
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
@@ -51,7 +51,7 @@ public class StudyRegistrationRequestValidator {
       NihAnvilUse anvilUse, StudyRegistrationRequest registration) {
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
       if (Objects.isNull(registration.getDbGaPPhsID())) {
-        throw new BadRequestException("DbGap phs ID is required");
+        throw new BadRequestException("dbGaPPhsID is required");
       }
       validatePiInstitutionAndGrantNumber(registration);
     }
@@ -67,7 +67,7 @@ public class StudyRegistrationRequestValidator {
       throw new BadRequestException("PI Institution is required");
     }
     if (Objects.isNull(registration.getNihGrantContractNumber())) {
-      throw new BadRequestException("NIH Grant of Contract Number is required");
+      throw new BadRequestException("NIH Grant or Contract Number is required");
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
@@ -75,37 +75,46 @@ public class StudyUpdateRequestValidator {
   }
 
   private void validateConditionalFields(StudyUpdateRequest registration) {
-    NihAnvilUse anvilUse = registration.getNihAnvilUse();
+    validateNihAnvilUseConditionals(registration.getNihAnvilUse(), registration);
+    validateGsrConditionals(registration);
+    validateAlternativeDataSharingConditionals(registration);
+  }
+
+  private void validateNihAnvilUseConditionals(
+      NihAnvilUse anvilUse, StudyUpdateRequest registration) {
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
       if (Objects.isNull(registration.getDbGaPPhsID())) {
         throw new BadRequestException("DbGap phs ID is required");
       }
-      if (Objects.isNull(registration.getPiInstitution())) {
-        throw new BadRequestException("PI Institution is required");
-      }
-      if (Objects.isNull(registration.getNihGrantContractNumber())) {
-        throw new BadRequestException("NIH Grant of Contract Number is required");
-      }
+      validatePiInstitutionAndGrantNumber(registration);
     }
     if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID)
         || anvilUse.equals(
             NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL)) {
-      if (Objects.isNull(registration.getPiInstitution())) {
-        throw new BadRequestException("PI Institution is required");
-      }
-      if (Objects.isNull(registration.getNihGrantContractNumber())) {
-        throw new BadRequestException("NIH Grant of Contract Number is required");
-      }
+      validatePiInstitutionAndGrantNumber(registration);
     }
-    if (Boolean.TRUE.equals(
-        registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())) {
-      if (Objects.isNull(
-          registration
-              .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
-        throw new BadRequestException(
-            "Controlled access GSR explanation is required when GSR access is required");
-      }
+  }
+
+  private void validatePiInstitutionAndGrantNumber(StudyUpdateRequest registration) {
+    if (Objects.isNull(registration.getPiInstitution())) {
+      throw new BadRequestException("PI Institution is required");
     }
+    if (Objects.isNull(registration.getNihGrantContractNumber())) {
+      throw new BadRequestException("NIH Grant of Contract Number is required");
+    }
+  }
+
+  private void validateGsrConditionals(StudyUpdateRequest registration) {
+    if (Boolean.TRUE.equals(registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())
+        && Objects.isNull(
+            registration
+                .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
+      throw new BadRequestException(
+          "Controlled access GSR explanation is required when GSR access is required");
+    }
+  }
+
+  private void validateAlternativeDataSharingConditionals(StudyUpdateRequest registration) {
     if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
       if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
         throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
@@ -119,10 +128,10 @@ public class StudyUpdateRequestValidator {
 
   private void validateEmailFields(StudyUpdateRequest registration) {
     EmailValidator emailValidator = EmailValidator.getInstance();
-    if (registration.getPiEmail() != null && !registration.getPiEmail().isBlank()) {
-      if (!emailValidator.isValid(registration.getPiEmail())) {
-        throw new BadRequestException("PI Email is not a valid email address");
-      }
+    if (registration.getPiEmail() != null
+        && !registration.getPiEmail().isBlank()
+        && !emailValidator.isValid(registration.getPiEmail())) {
+      throw new BadRequestException("PI Email is not a valid email address");
     }
     if (registration.getDataCustodianEmail() != null) {
       registration.getDataCustodianEmail().stream()
@@ -200,8 +209,8 @@ public class StudyUpdateRequestValidator {
     if (registration.getConsentGroups() == null || registration.getConsentGroups().isEmpty()) {
       return;
     }
-    HashSet<Integer> existingDatasetIds = new HashSet<>(existingStudy.getDatasetIds());
-    HashSet<Integer> submittedDatasetIds =
+    Set<Integer> existingDatasetIds = new HashSet<>(existingStudy.getDatasetIds());
+    Set<Integer> submittedDatasetIds =
         new HashSet<>(
             registration.getConsentGroups().stream()
                 .map(ConsentGroupRequest::getDatasetId)
@@ -264,7 +273,7 @@ public class StudyUpdateRequestValidator {
     try {
       LocalDate.parse(dateStr);
     } catch (DateTimeParseException e) {
-      throw new BadRequestException(fieldName + " is not a valid date");
+      throw new BadRequestException(fieldName + " is not a valid date", e);
     }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
@@ -42,6 +42,9 @@ public class StudyUpdateRequestValidator extends StudyRegistrationRequestValidat
     if (registration.getStudyName() == null) {
       return;
     }
+    if (registration.getStudyName().isBlank()) {
+      throw new BadRequestException("Study Name is required");
+    }
     if (registration.getStudyName().equals(existingStudy.getName())) {
       return;
     }
@@ -118,6 +121,7 @@ public class StudyUpdateRequestValidator extends StudyRegistrationRequestValidat
   }
 
   private void validateConsentGroupRemoval(Study existingStudy, StudyUpdateRequest registration) {
+    // null or empty list means "no consent group changes" — removal validation is skipped
     if (registration.getConsentGroups() == null || registration.getConsentGroups().isEmpty()) {
       return;
     }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
@@ -1,22 +1,17 @@
 package org.broadinstitute.consent.http.models.dto.registration;
 
 import jakarta.ws.rs.BadRequestException;
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.collections4.SetUtils;
-import org.apache.commons.validator.routines.EmailValidator;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Study;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
 import org.broadinstitute.consent.http.service.DatasetService;
 
-public class StudyUpdateRequestValidator {
+public class StudyUpdateRequestValidator extends StudyRegistrationRequestValidator {
 
   private final DatasetService datasetService;
 
@@ -72,89 +67,6 @@ public class StudyUpdateRequestValidator {
     if (Objects.isNull(registration.getPiName())) {
       throw new BadRequestException("Principal Investigator is required");
     }
-  }
-
-  private void validateConditionalFields(StudyUpdateRequest registration) {
-    validateNihAnvilUseConditionals(registration.getNihAnvilUse(), registration);
-    validateGsrConditionals(registration);
-    validateAlternativeDataSharingConditionals(registration);
-  }
-
-  private void validateNihAnvilUseConditionals(
-      NihAnvilUse anvilUse, StudyUpdateRequest registration) {
-    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
-      if (Objects.isNull(registration.getDbGaPPhsID())) {
-        throw new BadRequestException("DbGap phs ID is required");
-      }
-      validatePiInstitutionAndGrantNumber(registration);
-    }
-    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID)
-        || anvilUse.equals(
-            NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL)) {
-      validatePiInstitutionAndGrantNumber(registration);
-    }
-  }
-
-  private void validatePiInstitutionAndGrantNumber(StudyUpdateRequest registration) {
-    if (Objects.isNull(registration.getPiInstitution())) {
-      throw new BadRequestException("PI Institution is required");
-    }
-    if (Objects.isNull(registration.getNihGrantContractNumber())) {
-      throw new BadRequestException("NIH Grant of Contract Number is required");
-    }
-  }
-
-  private void validateGsrConditionals(StudyUpdateRequest registration) {
-    if (Boolean.TRUE.equals(registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())
-        && Objects.isNull(
-            registration
-                .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
-      throw new BadRequestException(
-          "Controlled access GSR explanation is required when GSR access is required");
-    }
-  }
-
-  private void validateAlternativeDataSharingConditionals(StudyUpdateRequest registration) {
-    if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
-      if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
-        throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
-      }
-      if (Objects.isNull(registration.getAlternativeDataSharingPlanReasons())
-          || registration.getAlternativeDataSharingPlanReasons().isEmpty()) {
-        throw new BadRequestException("Alternative Data Sharing Plan Reasons is required");
-      }
-    }
-  }
-
-  private void validateEmailFields(StudyUpdateRequest registration) {
-    EmailValidator emailValidator = EmailValidator.getInstance();
-    if (registration.getPiEmail() != null
-        && !registration.getPiEmail().isBlank()
-        && !emailValidator.isValid(registration.getPiEmail())) {
-      throw new BadRequestException("PI Email is not a valid email address");
-    }
-    if (registration.getDataCustodianEmail() != null) {
-      registration.getDataCustodianEmail().stream()
-          .filter(Objects::nonNull)
-          .filter(e -> !e.isBlank())
-          .forEach(
-              email -> {
-                if (!emailValidator.isValid(email)) {
-                  throw new BadRequestException(
-                      "Data Custodian Email is not a valid email address: " + email);
-                }
-              });
-    }
-  }
-
-  private void validateDateFields(StudyUpdateRequest registration) {
-    validateDateString(registration.getEmbargoReleaseDate(), "Embargo Release Date");
-    validateDateString(
-        registration.getAlternativeDataSharingPlanTargetDeliveryDate(),
-        "Alternative Data Sharing Plan Target Delivery Date");
-    validateDateString(
-        registration.getAlternativeDataSharingPlanTargetPublicReleaseDate(),
-        "Alternative Data Sharing Plan Target Public Release Date");
   }
 
   private void validateConsentGroupMembership(
@@ -228,52 +140,5 @@ public class StudyUpdateRequestValidator {
     consentGroups.stream()
         .filter(cg -> Objects.isNull(cg.getDatasetId()))
         .forEach(this::validateNewConsentGroup);
-  }
-
-  private void validateNewConsentGroup(ConsentGroupRequest cg) {
-    if (Objects.isNull(cg.getConsentGroupName()) || cg.getConsentGroupName().isBlank()) {
-      throw new BadRequestException("Consent Group Name is required");
-    }
-    if (Objects.isNull(cg.getNumberOfParticipants())) {
-      throw new BadRequestException("Number of Participants is required");
-    }
-    validateDataUseConsistency(cg);
-    validateDacRequirement(cg);
-    validateDateString(cg.getMorDate(), "Moratorium Date");
-  }
-
-  private void validateDataUseConsistency(ConsentGroupRequest cg) {
-    int count = 0;
-    if (AccessManagement.OPEN.equals(cg.getAccessManagement())) count++;
-    if (Boolean.TRUE.equals(cg.getGeneralResearchUse())) count++;
-    if (Boolean.TRUE.equals(cg.getHmb())) count++;
-    if (Boolean.TRUE.equals(cg.getPoa())) count++;
-    if (cg.getDiseaseSpecificUse() != null && !cg.getDiseaseSpecificUse().isEmpty()) count++;
-    if (cg.getOtherPrimary() != null && !cg.getOtherPrimary().isBlank()) count++;
-    if (count != 1) {
-      throw new BadRequestException(
-          "Consent Group must have exactly one primary data use (open access, or one of:"
-              + " general research use, health/medical/biomedical, populations/origins/ancestry,"
-              + " disease-specific, other)");
-    }
-  }
-
-  private void validateDacRequirement(ConsentGroupRequest cg) {
-    if (AccessManagement.CONTROLLED.equals(cg.getAccessManagement())
-        && Objects.isNull(cg.getDataAccessCommitteeId())) {
-      throw new BadRequestException(
-          "Data Access Committee is required for controlled access datasets");
-    }
-  }
-
-  private void validateDateString(String dateStr, String fieldName) {
-    if (dateStr == null || dateStr.isBlank()) {
-      return;
-    }
-    try {
-      LocalDate.parse(dateStr);
-    } catch (DateTimeParseException e) {
-      throw new BadRequestException(fieldName + " is not a valid date", e);
-    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidator.java
@@ -1,0 +1,270 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import jakarta.ws.rs.BadRequestException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.collections4.SetUtils;
+import org.apache.commons.validator.routines.EmailValidator;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.service.DatasetService;
+
+public class StudyUpdateRequestValidator {
+
+  private final DatasetService datasetService;
+
+  public StudyUpdateRequestValidator(DatasetService datasetService) {
+    this.datasetService = datasetService;
+  }
+
+  /**
+   * Validates a study update request against the existing study state.
+   *
+   * <p>Note: dataSubmitterUserId is excluded from StudyUpdateRequest by design and cannot be
+   * changed through this endpoint; submitter immutability is enforced structurally.
+   */
+  public boolean validate(Study existingStudy, StudyUpdateRequest registration) {
+    validateStudyNameUniqueness(existingStudy, registration);
+    validateRequiredFields(registration);
+    validateConditionalFields(registration);
+    validateEmailFields(registration);
+    validateDateFields(registration);
+    validateConsentGroupMembership(existingStudy, registration);
+    validateConsentGroupNameChanges(existingStudy, registration);
+    validateConsentGroupRemoval(existingStudy, registration);
+    validateNewConsentGroups(registration.getConsentGroups());
+    return true;
+  }
+
+  private void validateStudyNameUniqueness(Study existingStudy, StudyUpdateRequest registration) {
+    if (registration.getStudyName() == null) {
+      return;
+    }
+    if (registration.getStudyName().equals(existingStudy.getName())) {
+      return;
+    }
+    Set<String> studyNames = datasetService.findAllStudyNames();
+    if (studyNames.contains(registration.getStudyName())) {
+      throw new BadRequestException("Invalid change to Study Name");
+    }
+  }
+
+  private void validateRequiredFields(StudyUpdateRequest registration) {
+    if (Objects.isNull(registration.getStudyDescription())) {
+      throw new BadRequestException("Study Description is required");
+    }
+    if (Objects.isNull(registration.getDataTypes()) || registration.getDataTypes().isEmpty()) {
+      throw new BadRequestException("Data Types is required");
+    }
+    if (Objects.isNull(registration.getPublicVisibility())) {
+      throw new BadRequestException("Public Visibility is required");
+    }
+    if (Objects.isNull(registration.getNihAnvilUse())) {
+      throw new BadRequestException("NIH Anvil Use is required");
+    }
+    if (Objects.isNull(registration.getPiName())) {
+      throw new BadRequestException("Principal Investigator is required");
+    }
+  }
+
+  private void validateConditionalFields(StudyUpdateRequest registration) {
+    NihAnvilUse anvilUse = registration.getNihAnvilUse();
+    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY)) {
+      if (Objects.isNull(registration.getDbGaPPhsID())) {
+        throw new BadRequestException("DbGap phs ID is required");
+      }
+      if (Objects.isNull(registration.getPiInstitution())) {
+        throw new BadRequestException("PI Institution is required");
+      }
+      if (Objects.isNull(registration.getNihGrantContractNumber())) {
+        throw new BadRequestException("NIH Grant of Contract Number is required");
+      }
+    }
+    if (anvilUse.equals(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID)
+        || anvilUse.equals(
+            NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL)) {
+      if (Objects.isNull(registration.getPiInstitution())) {
+        throw new BadRequestException("PI Institution is required");
+      }
+      if (Objects.isNull(registration.getNihGrantContractNumber())) {
+        throw new BadRequestException("NIH Grant of Contract Number is required");
+      }
+    }
+    if (Boolean.TRUE.equals(
+        registration.getControlledAccessRequiredForGenomicSummaryResultsGSR())) {
+      if (Objects.isNull(
+          registration
+              .getControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation())) {
+        throw new BadRequestException(
+            "Controlled access GSR explanation is required when GSR access is required");
+      }
+    }
+    if (Boolean.TRUE.equals(registration.getAlternativeDataSharingPlan())) {
+      if (Objects.isNull(registration.getAlternativeDataSharingPlanExplanation())) {
+        throw new BadRequestException("Alternative Data Sharing Plan Explanation is required");
+      }
+      if (Objects.isNull(registration.getAlternativeDataSharingPlanReasons())
+          || registration.getAlternativeDataSharingPlanReasons().isEmpty()) {
+        throw new BadRequestException("Alternative Data Sharing Plan Reasons is required");
+      }
+    }
+  }
+
+  private void validateEmailFields(StudyUpdateRequest registration) {
+    EmailValidator emailValidator = EmailValidator.getInstance();
+    if (registration.getPiEmail() != null && !registration.getPiEmail().isBlank()) {
+      if (!emailValidator.isValid(registration.getPiEmail())) {
+        throw new BadRequestException("PI Email is not a valid email address");
+      }
+    }
+    if (registration.getDataCustodianEmail() != null) {
+      registration.getDataCustodianEmail().stream()
+          .filter(Objects::nonNull)
+          .filter(e -> !e.isBlank())
+          .forEach(
+              email -> {
+                if (!emailValidator.isValid(email)) {
+                  throw new BadRequestException(
+                      "Data Custodian Email is not a valid email address: " + email);
+                }
+              });
+    }
+  }
+
+  private void validateDateFields(StudyUpdateRequest registration) {
+    validateDateString(registration.getEmbargoReleaseDate(), "Embargo Release Date");
+    validateDateString(
+        registration.getAlternativeDataSharingPlanTargetDeliveryDate(),
+        "Alternative Data Sharing Plan Target Delivery Date");
+    validateDateString(
+        registration.getAlternativeDataSharingPlanTargetPublicReleaseDate(),
+        "Alternative Data Sharing Plan Target Public Release Date");
+  }
+
+  private void validateConsentGroupMembership(
+      Study existingStudy, StudyUpdateRequest registration) {
+    if (registration.getConsentGroups() == null) {
+      return;
+    }
+    List<ConsentGroupRequest> nonStudyGroups =
+        registration.getConsentGroups().stream()
+            .filter(cg -> Objects.nonNull(cg.getDatasetId()))
+            .filter(
+                cg ->
+                    existingStudy.getDatasetIds().stream()
+                        .noneMatch(id -> id.equals(cg.getDatasetId())))
+            .toList();
+    if (!nonStudyGroups.isEmpty()) {
+      throw new BadRequestException("Invalid Consent Group changes to study");
+    }
+  }
+
+  private void validateConsentGroupNameChanges(
+      Study existingStudy, StudyUpdateRequest registration) {
+    if (registration.getConsentGroups() == null) {
+      return;
+    }
+    List<ConsentGroupRequest> invalidNameChanges =
+        registration.getConsentGroups().stream()
+            .filter(cg -> Objects.nonNull(cg.getDatasetId()))
+            .filter(cg -> Objects.nonNull(cg.getConsentGroupName()))
+            .filter(
+                cg -> {
+                  Optional<Dataset> dataset =
+                      SetUtils.emptyIfNull(existingStudy.getDatasets()).stream()
+                          .filter(d -> d.getDatasetId().equals(cg.getDatasetId()))
+                          .findFirst();
+                  if (dataset.isEmpty()) {
+                    return false;
+                  }
+                  String storedName = dataset.get().getName();
+                  // Only block a rename: stored name is set AND the submitted name differs
+                  return storedName != null
+                      && !storedName.isBlank()
+                      && !cg.getConsentGroupName().equals(storedName);
+                })
+            .toList();
+    if (!invalidNameChanges.isEmpty()) {
+      throw new BadRequestException("Invalid Name changes to existing Consent Groups");
+    }
+  }
+
+  private void validateConsentGroupRemoval(Study existingStudy, StudyUpdateRequest registration) {
+    if (registration.getConsentGroups() == null || registration.getConsentGroups().isEmpty()) {
+      return;
+    }
+    HashSet<Integer> existingDatasetIds = new HashSet<>(existingStudy.getDatasetIds());
+    HashSet<Integer> submittedDatasetIds =
+        new HashSet<>(
+            registration.getConsentGroups().stream()
+                .map(ConsentGroupRequest::getDatasetId)
+                .filter(Objects::nonNull)
+                .toList());
+    if (!submittedDatasetIds.containsAll(existingDatasetIds)) {
+      throw new BadRequestException("Invalid removal of Consent Groups");
+    }
+  }
+
+  private void validateNewConsentGroups(List<ConsentGroupRequest> consentGroups) {
+    if (consentGroups == null) {
+      return;
+    }
+    consentGroups.stream()
+        .filter(cg -> Objects.isNull(cg.getDatasetId()))
+        .forEach(this::validateNewConsentGroup);
+  }
+
+  private void validateNewConsentGroup(ConsentGroupRequest cg) {
+    if (Objects.isNull(cg.getConsentGroupName()) || cg.getConsentGroupName().isBlank()) {
+      throw new BadRequestException("Consent Group Name is required");
+    }
+    if (Objects.isNull(cg.getNumberOfParticipants())) {
+      throw new BadRequestException("Number of Participants is required");
+    }
+    validateDataUseConsistency(cg);
+    validateDacRequirement(cg);
+    validateDateString(cg.getMorDate(), "Moratorium Date");
+  }
+
+  private void validateDataUseConsistency(ConsentGroupRequest cg) {
+    int count = 0;
+    if (AccessManagement.OPEN.equals(cg.getAccessManagement())) count++;
+    if (Boolean.TRUE.equals(cg.getGeneralResearchUse())) count++;
+    if (Boolean.TRUE.equals(cg.getHmb())) count++;
+    if (Boolean.TRUE.equals(cg.getPoa())) count++;
+    if (cg.getDiseaseSpecificUse() != null && !cg.getDiseaseSpecificUse().isEmpty()) count++;
+    if (cg.getOtherPrimary() != null && !cg.getOtherPrimary().isBlank()) count++;
+    if (count != 1) {
+      throw new BadRequestException(
+          "Consent Group must have exactly one primary data use (open access, or one of:"
+              + " general research use, health/medical/biomedical, populations/origins/ancestry,"
+              + " disease-specific, other)");
+    }
+  }
+
+  private void validateDacRequirement(ConsentGroupRequest cg) {
+    if (AccessManagement.CONTROLLED.equals(cg.getAccessManagement())
+        && Objects.isNull(cg.getDataAccessCommitteeId())) {
+      throw new BadRequestException(
+          "Data Access Committee is required for controlled access datasets");
+    }
+  }
+
+  private void validateDateString(String dateStr, String fieldName) {
+    if (dateStr == null || dateStr.isBlank()) {
+      return;
+    }
+    try {
+      LocalDate.parse(dateStr);
+    } catch (DateTimeParseException e) {
+      throw new BadRequestException(fieldName + " is not a valid date");
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
@@ -215,7 +215,7 @@ class StudyRegistrationRequestValidatorTest {
     ConsentGroupRequest cg = registration.getConsentGroups().get(0);
     cg.setAccessManagement(AccessManagement.CONTROLLED);
     cg.setGeneralResearchUse(true);
-    cg.setDataAccessCommitteeId(RandomUtils.nextInt(1, 100));
+    cg.setDataAccessCommitteeId(RandomUtils.secureStrong().randomInt(1, 100));
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 
@@ -233,7 +233,7 @@ class StudyRegistrationRequestValidatorTest {
   void testValidate_piInstitution_required_for_dbgap() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
-    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setDbGaPPhsID(RandomStringUtils.secureStrong().nextAlphabetic(8));
     registration.setPiInstitution(null);
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
@@ -242,8 +242,8 @@ class StudyRegistrationRequestValidatorTest {
   void testValidate_nihGrantContractNumber_required_for_dbgap() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
-    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
-    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setDbGaPPhsID(RandomStringUtils.secureStrong().nextAlphabetic(8));
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
     registration.setNihGrantContractNumber(null);
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
@@ -262,7 +262,7 @@ class StudyRegistrationRequestValidatorTest {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setNihAnvilUse(
         NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
-    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
     registration.setNihGrantContractNumber(null);
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
@@ -303,7 +303,8 @@ class StudyRegistrationRequestValidatorTest {
   void testValidate_altSharingPlanReasons_required() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setAlternativeDataSharingPlan(true);
-    registration.setAlternativeDataSharingPlanExplanation(RandomStringUtils.randomAlphabetic(10));
+    registration.setAlternativeDataSharingPlanExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
     registration.setAlternativeDataSharingPlanReasons(List.of());
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
@@ -400,21 +401,21 @@ class StudyRegistrationRequestValidatorTest {
 
   private ConsentGroupRequest createValidConsentGroup() {
     ConsentGroupRequest cg = new ConsentGroupRequest();
-    cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    cg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    cg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    cg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     cg.setAccessManagement(AccessManagement.OPEN);
     return cg;
   }
 
   private StudyRegistrationRequest createValidRegistration() {
     StudyRegistrationRequest registration = new StudyRegistrationRequest();
-    registration.setStudyName(RandomStringUtils.randomAlphabetic(10));
-    registration.setStudyDescription(RandomStringUtils.randomAlphabetic(20));
-    registration.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(8)));
+    registration.setStudyName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setStudyDescription(RandomStringUtils.secureStrong().nextAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.secureStrong().nextAlphabetic(8)));
     registration.setPublicVisibility(true);
     registration.setNihAnvilUse(
         NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
-    registration.setPiName(RandomStringUtils.randomAlphabetic(10));
+    registration.setPiName(RandomStringUtils.secureStrong().nextAlphabetic(10));
     registration.setConsentGroups(List.of(createValidConsentGroup()));
     return registration;
   }

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.BadRequestException;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
 import org.junit.jupiter.api.BeforeEach;
@@ -394,6 +396,106 @@ class StudyRegistrationRequestValidatorTest {
   void testValidate_morDate_absent_is_allowed() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.getConsentGroups().get(0).setMorDate(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── NIH happy paths ──────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_nihAnvilUse_dbgapPhsId_allFieldsValid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(RandomStringUtils.secureStrong().nextAlphabetic(8));
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
+    registration.setNihGrantContractNumber(RandomStringUtils.secureStrong().nextAlphabetic(8));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_nihAnvilUse_nhgriFundedNoPhs_allFieldsValid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID);
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
+    registration.setNihGrantContractNumber(RandomStringUtils.secureStrong().nextAlphabetic(8));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── GSR conditional ──────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_gsrExplanation_present_when_gsr_true() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Alt sharing plan ─────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_altSharingPlanReasons_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setAlternativeDataSharingPlanReasons(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlan_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setAlternativeDataSharingPlanReasons(
+        List.of(AlternativeDataSharingPlanReason.OTHER));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Email blank / filtered ───────────────────────────────────────────────
+
+  @Test
+  void testValidate_piEmail_blank_is_allowed() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiEmail("   ");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_blank_is_filtered() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataCustodianEmail(List.of("  ", "valid@example.com"));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Data-use edge cases ───────────────────────────────────────────────────
+
+  @Test
+  void testValidate_diseaseSpecificUse_emptyList_notCounted() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    // OPEN access is already set; empty diseaseSpecificUse adds nothing → count=1, valid
+    cg.setDiseaseSpecificUse(new ArrayList<>());
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_otherPrimary_blank_not_counted() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    // OPEN access is already set; blank otherPrimary adds nothing → count=1, valid
+    cg.setOtherPrimary("   ");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Date blank ───────────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_embargoReleaseDate_blank_is_allowed() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setEmbargoReleaseDate("  ");
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
@@ -1,0 +1,421 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.BadRequestException;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StudyRegistrationRequestValidatorTest {
+
+  private StudyRegistrationRequestValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = new StudyRegistrationRequestValidator();
+  }
+
+  @Test
+  void testValidate_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    assertTrue(validator.validate(registration));
+  }
+
+  // ── Required study fields ────────────────────────────────────────────────
+
+  @Test
+  void testValidate_studyName_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setStudyName(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_studyName_blank() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setStudyName("  ");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_studyDescription_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setStudyDescription(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataTypes_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataTypes(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataTypes_empty() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataTypes(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_publicVisibility_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPublicVisibility(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_nihAnvilUse_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piName_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiName(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  // ── Consent groups ───────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_consentGroups_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setConsentGroups(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_consentGroups_empty() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setConsentGroups(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_consentGroupName_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setConsentGroupName(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_consentGroupName_blank() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setConsentGroupName("   ");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_numberOfParticipants_null() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setNumberOfParticipants(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  // ── Data-use consistency ─────────────────────────────────────────────────
+
+  @Test
+  void testValidate_dataUse_noPrimaryUse() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setGeneralResearchUse(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_multiplePrimaryUses() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    // valid is OPEN; adding a second primary use makes it invalid
+    cg.setGeneralResearchUse(true);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_generalResearchUse() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setGeneralResearchUse(true);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_hmb() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setHmb(true);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_poa() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setPoa(true);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_diseaseSpecificUse() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setDiseaseSpecificUse(List.of("DOID:162"));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataUse_otherPrimary() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(null);
+    cg.setOtherPrimary("Some specific use");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── DAC requirement ──────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_dac_required_for_controlled() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(AccessManagement.CONTROLLED);
+    cg.setGeneralResearchUse(true);
+    cg.setDataAccessCommitteeId(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dac_not_required_for_open() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    // OPEN with no DAC is valid
+    cg.setDataAccessCommitteeId(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dac_provided_for_controlled() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
+    cg.setAccessManagement(AccessManagement.CONTROLLED);
+    cg.setGeneralResearchUse(true);
+    cg.setDataAccessCommitteeId(RandomUtils.nextInt(1, 100));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── NIH conditional fields ───────────────────────────────────────────────
+
+  @Test
+  void testValidate_dbGaPPhsID_required() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piInstitution_required_for_dbgap() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setPiInstitution(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_nihGrantContractNumber_required_for_dbgap() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setNihGrantContractNumber(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piInstitution_required_for_seeking_anvil() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setPiInstitution(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_nihGrantContractNumber_required_for_seeking_anvil() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setNihGrantContractNumber(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piInstitution_required_for_nhgri_no_phs() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_DO_NOT_HAVE_A_DB_GA_P_PHS_ID);
+    registration.setPiInstitution(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_gsrExplanation_required_when_gsr_true() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_gsrExplanation_not_required_when_gsr_false() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(false);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlanExplanation_required() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlanReasons_required() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(RandomStringUtils.randomAlphabetic(10));
+    registration.setAlternativeDataSharingPlanReasons(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  // ── Email validation ─────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_piEmail_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiEmail("not-an-email");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piEmail_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiEmail("pi@example.com");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_piEmail_absent_is_allowed() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiEmail(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataCustodianEmail(List.of("valid@example.com", "not-an-email"));
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataCustodianEmail(List.of("a@example.com", "b@example.org"));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Date validation ──────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_embargoReleaseDate_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setEmbargoReleaseDate("01/15/2025");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_embargoReleaseDate_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setEmbargoReleaseDate("2025-01-15");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingDeliveryDate_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingPublicReleaseDate_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlanTargetPublicReleaseDate("15-01-2025");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_morDate_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setMorDate("January 15, 2025");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_morDate_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setMorDate("2025-06-01");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_morDate_absent_is_allowed() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setMorDate(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private ConsentGroupRequest createValidConsentGroup() {
+    ConsentGroupRequest cg = new ConsentGroupRequest();
+    cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    cg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    cg.setAccessManagement(AccessManagement.OPEN);
+    return cg;
+  }
+
+  private StudyRegistrationRequest createValidRegistration() {
+    StudyRegistrationRequest registration = new StudyRegistrationRequest();
+    registration.setStudyName(RandomStringUtils.randomAlphabetic(10));
+    registration.setStudyDescription(RandomStringUtils.randomAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(8)));
+    registration.setPublicVisibility(true);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
+    registration.setPiName(RandomStringUtils.randomAlphabetic(10));
+    registration.setConsentGroups(List.of(createValidConsentGroup()));
+    return registration;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidatorTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.ws.rs.BadRequestException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.AlternativeDataSharingPlanReason;
@@ -14,6 +16,10 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGro
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StudyRegistrationRequestValidatorTest {
 
@@ -30,99 +36,31 @@ class StudyRegistrationRequestValidatorTest {
     assertTrue(validator.validate(registration));
   }
 
-  // ── Required study fields ────────────────────────────────────────────────
+  // ── Required fields & invalid values ─────────────────────────────────────
 
-  @Test
-  void testValidate_studyName_null() {
+  @ParameterizedTest
+  @MethodSource({"invalidRegistrationMutations", "invalidDateMutations"})
+  void testValidate_invalidField_throws(Consumer<StudyRegistrationRequest> mutate) {
     StudyRegistrationRequest registration = createValidRegistration();
-    registration.setStudyName(null);
+    mutate.accept(registration);
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
 
-  @Test
-  void testValidate_studyName_blank() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setStudyName("  ");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_studyDescription_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setStudyDescription(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataTypes_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setDataTypes(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataTypes_empty() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setDataTypes(List.of());
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_publicVisibility_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPublicVisibility(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_nihAnvilUse_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setNihAnvilUse(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_piName_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPiName(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  // ── Consent groups ───────────────────────────────────────────────────────
-
-  @Test
-  void testValidate_consentGroups_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setConsentGroups(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_consentGroups_empty() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setConsentGroups(List.of());
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_consentGroupName_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setConsentGroupName(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_consentGroupName_blank() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setConsentGroupName("   ");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_numberOfParticipants_null() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setNumberOfParticipants(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  static Stream<Consumer<StudyRegistrationRequest>> invalidRegistrationMutations() {
+    return Stream.<Consumer<StudyRegistrationRequest>>of(
+        r -> r.setStudyName(null),
+        r -> r.setStudyName("  "),
+        r -> r.setStudyDescription(null),
+        r -> r.setDataTypes(null),
+        r -> r.setDataTypes(List.of()),
+        r -> r.setPublicVisibility(null),
+        r -> r.setNihAnvilUse(null),
+        r -> r.setPiName(null),
+        r -> r.setConsentGroups(null),
+        r -> r.setConsentGroups(List.of()),
+        r -> r.getConsentGroups().get(0).setConsentGroupName(null),
+        r -> r.getConsentGroups().get(0).setConsentGroupName("   "),
+        r -> r.getConsentGroups().get(0).setNumberOfParticipants(null));
   }
 
   // ── Data-use consistency ─────────────────────────────────────────────────
@@ -145,49 +83,23 @@ class StudyRegistrationRequestValidatorTest {
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
 
-  @Test
-  void testValidate_dataUse_generalResearchUse() {
+  @ParameterizedTest
+  @MethodSource("validPrimaryDataUseMutations")
+  void testValidate_dataUse_validPrimaryUse(Consumer<ConsentGroupRequest> mutate) {
     StudyRegistrationRequest registration = createValidRegistration();
     ConsentGroupRequest cg = registration.getConsentGroups().get(0);
     cg.setAccessManagement(null);
-    cg.setGeneralResearchUse(true);
+    mutate.accept(cg);
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 
-  @Test
-  void testValidate_dataUse_hmb() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
-    cg.setAccessManagement(null);
-    cg.setHmb(true);
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataUse_poa() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
-    cg.setAccessManagement(null);
-    cg.setPoa(true);
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataUse_diseaseSpecificUse() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
-    cg.setAccessManagement(null);
-    cg.setDiseaseSpecificUse(List.of("DOID:162"));
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataUse_otherPrimary() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    ConsentGroupRequest cg = registration.getConsentGroups().get(0);
-    cg.setAccessManagement(null);
-    cg.setOtherPrimary("Some specific use");
-    assertDoesNotThrow(() -> validator.validate(registration));
+  static Stream<Consumer<ConsentGroupRequest>> validPrimaryDataUseMutations() {
+    return Stream.<Consumer<ConsentGroupRequest>>of(
+        cg -> cg.setGeneralResearchUse(true),
+        cg -> cg.setHmb(true),
+        cg -> cg.setPoa(true),
+        cg -> cg.setDiseaseSpecificUse(List.of("DOID:162")),
+        cg -> cg.setOtherPrimary("Some specific use"));
   }
 
   // ── DAC requirement ──────────────────────────────────────────────────────
@@ -277,128 +189,6 @@ class StudyRegistrationRequestValidatorTest {
     assertThrows(BadRequestException.class, () -> validator.validate(registration));
   }
 
-  @Test
-  void testValidate_gsrExplanation_required_when_gsr_true() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
-    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_gsrExplanation_not_required_when_gsr_false() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(false);
-    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_altSharingPlanExplanation_required() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setAlternativeDataSharingPlan(true);
-    registration.setAlternativeDataSharingPlanExplanation(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_altSharingPlanReasons_required() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setAlternativeDataSharingPlan(true);
-    registration.setAlternativeDataSharingPlanExplanation(
-        RandomStringUtils.secureStrong().nextAlphabetic(10));
-    registration.setAlternativeDataSharingPlanReasons(List.of());
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  // ── Email validation ─────────────────────────────────────────────────────
-
-  @Test
-  void testValidate_piEmail_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPiEmail("not-an-email");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_piEmail_valid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPiEmail("pi@example.com");
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_piEmail_absent_is_allowed() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPiEmail(null);
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataCustodianEmail_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setDataCustodianEmail(List.of("valid@example.com", "not-an-email"));
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_dataCustodianEmail_valid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setDataCustodianEmail(List.of("a@example.com", "b@example.org"));
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  // ── Date validation ──────────────────────────────────────────────────────
-
-  @Test
-  void testValidate_embargoReleaseDate_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setEmbargoReleaseDate("01/15/2025");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_embargoReleaseDate_valid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setEmbargoReleaseDate("2025-01-15");
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_altSharingDeliveryDate_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_altSharingPublicReleaseDate_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setAlternativeDataSharingPlanTargetPublicReleaseDate("15-01-2025");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_morDate_invalid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setMorDate("January 15, 2025");
-    assertThrows(BadRequestException.class, () -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_morDate_valid() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setMorDate("2025-06-01");
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  @Test
-  void testValidate_morDate_absent_is_allowed() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.getConsentGroups().get(0).setMorDate(null);
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
   // ── NIH happy paths ──────────────────────────────────────────────────────
 
   @Test
@@ -423,6 +213,22 @@ class StudyRegistrationRequestValidatorTest {
   // ── GSR conditional ──────────────────────────────────────────────────────
 
   @Test
+  void testValidate_gsrExplanation_required_when_gsr_true() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_gsrExplanation_not_required_when_gsr_false() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(false);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
   void testValidate_gsrExplanation_present_when_gsr_true() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
@@ -432,6 +238,24 @@ class StudyRegistrationRequestValidatorTest {
   }
 
   // ── Alt sharing plan ─────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_altSharingPlanExplanation_required() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlanReasons_required() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setAlternativeDataSharingPlanReasons(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
 
   @Test
   void testValidate_altSharingPlanReasons_null() {
@@ -454,12 +278,35 @@ class StudyRegistrationRequestValidatorTest {
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 
-  // ── Email blank / filtered ───────────────────────────────────────────────
+  // ── Email validation ─────────────────────────────────────────────────────
 
   @Test
-  void testValidate_piEmail_blank_is_allowed() {
+  void testValidate_piEmail_invalid() {
     StudyRegistrationRequest registration = createValidRegistration();
-    registration.setPiEmail("   ");
+    registration.setPiEmail("not-an-email");
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"   ", "pi@example.com"})
+  void testValidate_piEmail_allowed(String email) {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setPiEmail(email);
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_invalid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataCustodianEmail(List.of("valid@example.com", "not-an-email"));
+    assertThrows(BadRequestException.class, () -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setDataCustodianEmail(List.of("a@example.com", "b@example.org"));
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 
@@ -467,6 +314,39 @@ class StudyRegistrationRequestValidatorTest {
   void testValidate_dataCustodianEmail_blank_is_filtered() {
     StudyRegistrationRequest registration = createValidRegistration();
     registration.setDataCustodianEmail(List.of("  ", "valid@example.com"));
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  // ── Date validation ──────────────────────────────────────────────────────
+
+  static Stream<Consumer<StudyRegistrationRequest>> invalidDateMutations() {
+    return Stream.<Consumer<StudyRegistrationRequest>>of(
+        r -> r.setEmbargoReleaseDate("01/15/2025"),
+        r -> r.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date"),
+        r -> r.setAlternativeDataSharingPlanTargetPublicReleaseDate("15-01-2025"),
+        r -> r.getConsentGroups().get(0).setMorDate("January 15, 2025"));
+  }
+
+  @Test
+  void testValidate_embargoReleaseDate_valid() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setEmbargoReleaseDate("2025-01-15");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @Test
+  void testValidate_embargoReleaseDate_blank_is_allowed() {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setEmbargoReleaseDate("  ");
+    assertDoesNotThrow(() -> validator.validate(registration));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"2025-06-01"})
+  void testValidate_morDate_allowed(String date) {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.getConsentGroups().get(0).setMorDate(date);
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 
@@ -487,15 +367,6 @@ class StudyRegistrationRequestValidatorTest {
     ConsentGroupRequest cg = registration.getConsentGroups().get(0);
     // OPEN access is already set; blank otherPrimary adds nothing → count=1, valid
     cg.setOtherPrimary("   ");
-    assertDoesNotThrow(() -> validator.validate(registration));
-  }
-
-  // ── Date blank ───────────────────────────────────────────────────────────
-
-  @Test
-  void testValidate_embargoReleaseDate_blank_is_allowed() {
-    StudyRegistrationRequest registration = createValidRegistration();
-    registration.setEmbargoReleaseDate("  ");
     assertDoesNotThrow(() -> validator.validate(registration));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
@@ -12,6 +12,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.models.Dataset;
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -96,52 +99,23 @@ class StudyUpdateRequestValidatorTest {
 
   // ── Required fields ──────────────────────────────────────────────────────
 
-  @Test
-  void testValidate_studyDescription_null() {
+  @ParameterizedTest
+  @MethodSource({"invalidRegistrationMutations", "invalidDateMutations"})
+  void testValidate_requiredField_invalid(Consumer<StudyUpdateRequest> mutate) {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setStudyDescription(null);
+    mutate.accept(registration);
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
 
-  @Test
-  void testValidate_dataTypes_null() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setDataTypes(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_dataTypes_empty() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setDataTypes(List.of());
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_publicVisibility_null() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setPublicVisibility(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_nihAnvilUse_null() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setNihAnvilUse(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_piName_null() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setPiName(null);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  static Stream<Consumer<StudyUpdateRequest>> invalidRegistrationMutations() {
+    return Stream.<Consumer<StudyUpdateRequest>>of(
+        r -> r.setStudyDescription(null),
+        r -> r.setDataTypes(null),
+        r -> r.setDataTypes(List.of()),
+        r -> r.setPublicVisibility(null),
+        r -> r.setNihAnvilUse(null),
+        r -> r.setPiName(null));
   }
 
   // ── NIH conditional fields ───────────────────────────────────────────────
@@ -261,18 +235,12 @@ class StudyUpdateRequestValidatorTest {
     assertDoesNotThrow(() -> validator.validate(study, registration));
   }
 
-  @Test
-  void testValidate_consentGroupNameChange_allowed_whenStoredNameIsNull() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {""})
+  void testValidate_consentGroupNameChange_allowed_whenStoredNameIsNullOrBlank(String storedName) {
     Study study = createMockStudy();
-    study.getDatasets().forEach(d -> d.setName(null));
-    StudyUpdateRequest registration = createValidRegistration(study);
-    assertDoesNotThrow(() -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_consentGroupNameChange_allowed_whenNameIsBlank() {
-    Study study = createMockStudy();
-    study.getDatasets().forEach(d -> d.setName(""));
+    study.getDatasets().forEach(d -> d.setName(storedName));
     StudyUpdateRequest registration = createValidRegistration(study);
     assertDoesNotThrow(() -> validator.validate(study, registration));
   }
@@ -323,62 +291,32 @@ class StudyUpdateRequestValidatorTest {
     assertDoesNotThrow(() -> validator.validate(study, registration));
   }
 
-  @Test
-  void testValidate_newConsentGroup_missingName() {
+  @ParameterizedTest
+  @MethodSource("invalidNewConsentGroupMutations")
+  void testValidate_newConsentGroup_invalid(Consumer<ConsentGroupRequest> mutate) {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(null);
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
     newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.OPEN);
+    mutate.accept(newCg);
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
     groups.add(newCg);
     registration.setConsentGroups(groups);
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
 
-  @Test
-  void testValidate_newConsentGroup_missingParticipants() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
-    newCg.setNumberOfParticipants(null);
-    newCg.setAccessManagement(AccessManagement.OPEN);
-    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
-    groups.add(newCg);
-    registration.setConsentGroups(groups);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_newConsentGroup_noPrimaryDataUse() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
-    // no accessManagement, no data-use flags
-    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
-    groups.add(newCg);
-    registration.setConsentGroups(groups);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_newConsentGroup_controlled_dacRequired() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
-    newCg.setAccessManagement(AccessManagement.CONTROLLED);
-    newCg.setGeneralResearchUse(true);
-    // dataAccessCommitteeId intentionally absent
-    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
-    groups.add(newCg);
-    registration.setConsentGroups(groups);
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  static Stream<Consumer<ConsentGroupRequest>> invalidNewConsentGroupMutations() {
+    return Stream.<Consumer<ConsentGroupRequest>>of(
+        cg -> cg.setConsentGroupName(null),
+        cg -> cg.setNumberOfParticipants(null),
+        cg -> cg.setAccessManagement(null),
+        cg -> {
+          cg.setAccessManagement(AccessManagement.CONTROLLED);
+          cg.setGeneralResearchUse(true);
+          // dataAccessCommitteeId intentionally absent
+        });
   }
 
   @Test
@@ -462,12 +400,10 @@ class StudyUpdateRequestValidatorTest {
 
   // ── Date validation (update path) ───────────────────────────────────────
 
-  @Test
-  void testValidate_embargoReleaseDate_invalid() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setEmbargoReleaseDate("01/15/2025");
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  static Stream<Consumer<StudyUpdateRequest>> invalidDateMutations() {
+    return Stream.<Consumer<StudyUpdateRequest>>of(
+        r -> r.setEmbargoReleaseDate("01/15/2025"),
+        r -> r.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date"));
   }
 
   @Test
@@ -476,14 +412,6 @@ class StudyUpdateRequestValidatorTest {
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setEmbargoReleaseDate("2025-01-15");
     assertDoesNotThrow(() -> validator.validate(study, registration));
-  }
-
-  @Test
-  void testValidate_altSharingDeliveryDate_invalid() {
-    Study study = createMockStudy();
-    StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date");
-    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
 
   // ── morDate in new consent groups (update path) ──────────────────────────

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
@@ -22,6 +22,9 @@ import org.broadinstitute.consent.http.service.DatasetService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -52,6 +55,15 @@ class StudyUpdateRequestValidatorTest {
     registration.setStudyName(null);
     // null name — uniqueness check is skipped entirely, no service call needed
     assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_studyName_blank_rejected() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setStudyName("   ");
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+    verify(datasetService, never()).findAllStudyNames();
   }
 
   @Test
@@ -286,7 +298,8 @@ class StudyUpdateRequestValidatorTest {
   }
 
   @Test
-  void testValidate_consentGroupRemoval_allowsEmptyList() {
+  void testValidate_consentGroupRemoval_emptyListIsNoOp() {
+    // empty list is treated the same as null — "no consent group changes"
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setConsentGroups(List.of());
@@ -421,11 +434,13 @@ class StudyUpdateRequestValidatorTest {
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
 
-  @Test
-  void testValidate_piEmail_valid() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"   ", "pi@example.com"})
+  void testValidate_piEmail_allowed(String email) {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
-    registration.setPiEmail("pi@example.com");
+    registration.setPiEmail(email);
     assertDoesNotThrow(() -> validator.validate(study, registration));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
@@ -3,6 +3,8 @@ package org.broadinstitute.consent.http.models.dto.registration;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.BadRequestException;
@@ -58,6 +60,7 @@ class StudyUpdateRequestValidatorTest {
     StudyUpdateRequest registration = createValidRegistration(study);
     // name unchanged — service must not be called, so no stub needed
     assertDoesNotThrow(() -> validator.validate(study, registration));
+    verify(datasetService, never()).findAllStudyNames();
   }
 
   @Test
@@ -71,7 +74,7 @@ class StudyUpdateRequestValidatorTest {
 
   @Test
   void testValidate_studyName_changedToExistingName() {
-    String takenName = RandomStringUtils.randomAlphabetic(12);
+    String takenName = RandomStringUtils.secureStrong().nextAlphabetic(12);
     Study study = createMockStudy();
     when(datasetService.findAllStudyNames()).thenReturn(Set.of(study.getName(), takenName));
     StudyUpdateRequest registration = createValidRegistration(study);
@@ -145,7 +148,7 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
-    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setDbGaPPhsID(RandomStringUtils.secureStrong().nextAlphabetic(8));
     registration.setPiInstitution(null);
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
@@ -155,8 +158,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
-    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
-    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setDbGaPPhsID(RandomStringUtils.secureStrong().nextAlphabetic(8));
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
     registration.setNihGrantContractNumber(null);
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
@@ -177,7 +180,7 @@ class StudyUpdateRequestValidatorTest {
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setNihAnvilUse(
         NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
-    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setPiInstitution(RandomUtils.secureStrong().randomInt(1, 100));
     registration.setNihGrantContractNumber(null);
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
@@ -228,8 +231,8 @@ class StudyUpdateRequestValidatorTest {
     // datasetId is in getDatasetIds() (membership passes) but getDatasets() is empty,
     // so dataset lookup returns empty — the return false; branch is exercised
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
-    int datasetId = RandomUtils.nextInt(10, 99);
+    study.setName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    int datasetId = RandomUtils.secureStrong().randomInt(10, 99);
     study.addDatasetIds(Set.of(datasetId));
     // intentionally no datasets added via addDatasets()
 
@@ -239,7 +242,7 @@ class StudyUpdateRequestValidatorTest {
             ? new ConsentGroupRequest()
             : registration.getConsentGroups().get(0);
     cg.setDatasetId(datasetId);
-    cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    cg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
     if (registration.getConsentGroups().isEmpty()) {
       registration.setConsentGroups(new ArrayList<>(List.of(cg)));
     }
@@ -273,9 +276,9 @@ class StudyUpdateRequestValidatorTest {
     Dataset extraDataset = new Dataset();
     extraDataset.setName("");
     extraDataset.setDatasetId(10000);
-    extraDataset.setDacId(RandomUtils.nextInt(1, 100));
+    extraDataset.setDacId(RandomUtils.secureStrong().randomInt(1, 100));
     study.getDatasets().add(extraDataset);
-    ArrayList<Integer> ids = new ArrayList<>(study.getDatasetIds());
+    List<Integer> ids = new ArrayList<>(study.getDatasetIds());
     ids.add(extraDataset.getDatasetId());
     study.addDatasetIds(new HashSet<>(ids));
 
@@ -297,8 +300,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.OPEN);
     // No datasetId — this is a new consent group
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
@@ -313,7 +316,7 @@ class StudyUpdateRequestValidatorTest {
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
     newCg.setConsentGroupName(null);
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.OPEN);
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
     groups.add(newCg);
@@ -326,7 +329,7 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
     newCg.setNumberOfParticipants(null);
     newCg.setAccessManagement(AccessManagement.OPEN);
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
@@ -340,8 +343,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     // no accessManagement, no data-use flags
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
     groups.add(newCg);
@@ -354,8 +357,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.CONTROLLED);
     newCg.setGeneralResearchUse(true);
     // dataAccessCommitteeId intentionally absent
@@ -402,7 +405,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     registration.setAlternativeDataSharingPlan(true);
-    registration.setAlternativeDataSharingPlanExplanation(RandomStringUtils.randomAlphabetic(10));
+    registration.setAlternativeDataSharingPlanExplanation(
+        RandomStringUtils.secureStrong().nextAlphabetic(10));
     registration.setAlternativeDataSharingPlanReasons(List.of());
     assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
   }
@@ -474,8 +478,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.OPEN);
     newCg.setMorDate("January 15, 2025");
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
@@ -489,8 +493,8 @@ class StudyUpdateRequestValidatorTest {
     Study study = createMockStudy();
     StudyUpdateRequest registration = createValidRegistration(study);
     ConsentGroupRequest newCg = new ConsentGroupRequest();
-    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
     newCg.setAccessManagement(AccessManagement.OPEN);
     newCg.setMorDate("2025-06-01");
     List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
@@ -514,11 +518,11 @@ class StudyUpdateRequestValidatorTest {
 
   private Study createMockStudy() {
     Study study = new Study();
-    study.setName(RandomStringUtils.randomAlphabetic(10));
+    study.setName(RandomStringUtils.secureStrong().nextAlphabetic(10));
     Dataset dataset = new Dataset();
     dataset.setName("");
-    dataset.setDatasetId(RandomUtils.nextInt(10, 99));
-    dataset.setDacId(RandomUtils.nextInt(1, 100));
+    dataset.setDatasetId(RandomUtils.secureStrong().randomInt(10, 99));
+    dataset.setDacId(RandomUtils.secureStrong().randomInt(1, 100));
     study.addDatasets(List.of(dataset));
     study.addDatasetIds(Set.of(dataset.getDatasetId()));
     return study;
@@ -527,20 +531,20 @@ class StudyUpdateRequestValidatorTest {
   private StudyUpdateRequest createValidRegistration(Study study) {
     StudyUpdateRequest registration = new StudyUpdateRequest();
     registration.setStudyName(study.getName());
-    registration.setStudyDescription(RandomStringUtils.randomAlphabetic(20));
-    registration.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(8)));
+    registration.setStudyDescription(RandomStringUtils.secureStrong().nextAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.secureStrong().nextAlphabetic(8)));
     registration.setPublicVisibility(true);
     registration.setNihAnvilUse(
         NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
-    registration.setPiName(RandomStringUtils.randomAlphabetic(10));
+    registration.setPiName(RandomStringUtils.secureStrong().nextAlphabetic(10));
 
     List<ConsentGroupRequest> consentGroups =
         study.getDatasets().stream()
             .map(
                 d -> {
                   ConsentGroupRequest cg = new ConsentGroupRequest();
-                  cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
-                  cg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+                  cg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+                  cg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
                   cg.setDatasetId(d.getDatasetId());
                   // existing consent groups omit data-use fields — they were already validated
                   return cg;

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyUpdateRequestValidatorTest.java
@@ -1,0 +1,552 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.BadRequestException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyUpdateRequestValidatorTest {
+
+  @Mock private DatasetService datasetService;
+  private StudyUpdateRequestValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = new StudyUpdateRequestValidator(datasetService);
+  }
+
+  @Test
+  void testValidate_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    assertTrue(validator.validate(study, registration));
+  }
+
+  // ── Study name uniqueness ────────────────────────────────────────────────
+
+  @Test
+  void testValidate_studyName_null_skipsUniquenessCheck() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setStudyName(null);
+    // null name — uniqueness check is skipped entirely, no service call needed
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_studyName_unchanged_doesNotQueryService() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // name unchanged — service must not be called, so no stub needed
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_studyName_changedToAvailableName() {
+    Study study = createMockStudy();
+    when(datasetService.findAllStudyNames()).thenReturn(Set.of(study.getName()));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setStudyName("A Brand New Name");
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_studyName_changedToExistingName() {
+    String takenName = RandomStringUtils.randomAlphabetic(12);
+    Study study = createMockStudy();
+    when(datasetService.findAllStudyNames()).thenReturn(Set.of(study.getName(), takenName));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setStudyName(takenName);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  // ── Required fields ──────────────────────────────────────────────────────
+
+  @Test
+  void testValidate_studyDescription_null() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setStudyDescription(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_dataTypes_null() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setDataTypes(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_dataTypes_empty() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setDataTypes(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_publicVisibility_null() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setPublicVisibility(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_nihAnvilUse_null() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_piName_null() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setPiName(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  // ── NIH conditional fields ───────────────────────────────────────────────
+
+  @Test
+  void testValidate_dbGaPPhsID_required() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_piInstitution_required_for_dbgap() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setPiInstitution(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_nihGrantContractNumber_required_for_dbgap() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(NihAnvilUse.I_AM_NHGRI_FUNDED_AND_I_HAVE_A_DB_GA_P_PHS_ID_ALREADY);
+    registration.setDbGaPPhsID(RandomStringUtils.randomAlphabetic(8));
+    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setNihGrantContractNumber(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_piInstitution_required_for_seeking_anvil() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setPiInstitution(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_nihGrantContractNumber_required_for_seeking_anvil() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_BUT_I_AM_SEEKING_TO_SUBMIT_DATA_TO_AN_VIL);
+    registration.setPiInstitution(RandomUtils.nextInt(1, 100));
+    registration.setNihGrantContractNumber(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  // ── Consent group membership ─────────────────────────────────────────────
+
+  @Test
+  void testValidate_consentGroupMembership_nonStudyDataset() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // Force a datasetId that is not in the study (mock study uses IDs in 10–99)
+    registration.getConsentGroups().get(0).setDatasetId(10000);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupMembership_studyDataset() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // datasetId already matches the study dataset from createValidRegistration
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Consent group name changes ───────────────────────────────────────────
+
+  @Test
+  void testValidate_consentGroupNameChange_blocked_whenSubmittedNameDiffers() {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setName("Existing Name"));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // createValidRegistration uses a random name which differs from "Existing Name"
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupNameChange_allowed_whenSubmittedNameMatchesStored() {
+    Study study = createMockStudy();
+    String storedName = "Existing Name";
+    study.getDatasets().forEach(d -> d.setName(storedName));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // Round-trip: submitted name == stored name — should not be treated as a rename
+    registration.getConsentGroups().forEach(cg -> cg.setConsentGroupName(storedName));
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupNameChange_allowed_whenDatasetNotInDatasets() {
+    // datasetId is in getDatasetIds() (membership passes) but getDatasets() is empty,
+    // so dataset lookup returns empty — the return false; branch is exercised
+    Study study = new Study();
+    study.setName(RandomStringUtils.randomAlphabetic(10));
+    int datasetId = RandomUtils.nextInt(10, 99);
+    study.addDatasetIds(Set.of(datasetId));
+    // intentionally no datasets added via addDatasets()
+
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest cg =
+        registration.getConsentGroups().isEmpty()
+            ? new ConsentGroupRequest()
+            : registration.getConsentGroups().get(0);
+    cg.setDatasetId(datasetId);
+    cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    if (registration.getConsentGroups().isEmpty()) {
+      registration.setConsentGroups(new ArrayList<>(List.of(cg)));
+    }
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupNameChange_allowed_whenStoredNameIsNull() {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setName(null));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupNameChange_allowed_whenNameIsBlank() {
+    Study study = createMockStudy();
+    study.getDatasets().forEach(d -> d.setName(""));
+    StudyUpdateRequest registration = createValidRegistration(study);
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Consent group removal ────────────────────────────────────────────────
+
+  @Test
+  void testValidate_consentGroupRemoval_fails_whenDatasetOmitted() {
+    Study study = createMockStudy();
+    // Build the registration before adding the extra dataset so the payload omits it
+    StudyUpdateRequest registration = createValidRegistration(study);
+
+    Dataset extraDataset = new Dataset();
+    extraDataset.setName("");
+    extraDataset.setDatasetId(10000);
+    extraDataset.setDacId(RandomUtils.nextInt(1, 100));
+    study.getDatasets().add(extraDataset);
+    ArrayList<Integer> ids = new ArrayList<>(study.getDatasetIds());
+    ids.add(extraDataset.getDatasetId());
+    study.addDatasetIds(new HashSet<>(ids));
+
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_consentGroupRemoval_allowsEmptyList() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setConsentGroups(List.of());
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── New consent group validation ─────────────────────────────────────────
+
+  @Test
+  void testValidate_newConsentGroup_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setAccessManagement(AccessManagement.OPEN);
+    // No datasetId — this is a new consent group
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_newConsentGroup_missingName() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(null);
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setAccessManagement(AccessManagement.OPEN);
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_newConsentGroup_missingParticipants() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(null);
+    newCg.setAccessManagement(AccessManagement.OPEN);
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_newConsentGroup_noPrimaryDataUse() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    // no accessManagement, no data-use flags
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_newConsentGroup_controlled_dacRequired() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setAccessManagement(AccessManagement.CONTROLLED);
+    newCg.setGeneralResearchUse(true);
+    // dataAccessCommitteeId intentionally absent
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_existingConsentGroup_dataUseNotValidated() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    // Existing consent group (has datasetId) with no data-use fields — should not be validated
+    ConsentGroupRequest existingCg = registration.getConsentGroups().get(0);
+    existingCg.setAccessManagement(null);
+    existingCg.setGeneralResearchUse(null);
+    // datasetId is already set (from createValidRegistration)
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Conditional fields (update path) ────────────────────────────────────
+
+  @Test
+  void testValidate_gsrExplanation_required_when_gsr_true() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSR(true);
+    registration.setControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlanExplanation_required() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(null);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_altSharingPlanReasons_required() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setAlternativeDataSharingPlan(true);
+    registration.setAlternativeDataSharingPlanExplanation(RandomStringUtils.randomAlphabetic(10));
+    registration.setAlternativeDataSharingPlanReasons(List.of());
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  // ── Email validation (update path) ──────────────────────────────────────
+
+  @Test
+  void testValidate_piEmail_invalid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setPiEmail("not-an-email");
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_piEmail_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setPiEmail("pi@example.com");
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_invalid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setDataCustodianEmail(List.of("valid@example.com", "not-an-email"));
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_dataCustodianEmail_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setDataCustodianEmail(List.of("a@example.com", "b@example.org"));
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Date validation (update path) ───────────────────────────────────────
+
+  @Test
+  void testValidate_embargoReleaseDate_invalid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setEmbargoReleaseDate("01/15/2025");
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_embargoReleaseDate_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setEmbargoReleaseDate("2025-01-15");
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_altSharingDeliveryDate_invalid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setAlternativeDataSharingPlanTargetDeliveryDate("not-a-date");
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  // ── morDate in new consent groups (update path) ──────────────────────────
+
+  @Test
+  void testValidate_newConsentGroup_morDate_invalid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setAccessManagement(AccessManagement.OPEN);
+    newCg.setMorDate("January 15, 2025");
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertThrows(BadRequestException.class, () -> validator.validate(study, registration));
+  }
+
+  @Test
+  void testValidate_newConsentGroup_morDate_valid() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    ConsentGroupRequest newCg = new ConsentGroupRequest();
+    newCg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+    newCg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+    newCg.setAccessManagement(AccessManagement.OPEN);
+    newCg.setMorDate("2025-06-01");
+    List<ConsentGroupRequest> groups = new ArrayList<>(registration.getConsentGroups());
+    groups.add(newCg);
+    registration.setConsentGroups(groups);
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Null consent groups ──────────────────────────────────────────────────
+
+  @Test
+  void testValidate_nullConsentGroups_passesAllGuards() {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidRegistration(study);
+    registration.setConsentGroups(null);
+    // null consent groups skips membership, name-change, removal, and new-group checks
+    assertDoesNotThrow(() -> validator.validate(study, registration));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private Study createMockStudy() {
+    Study study = new Study();
+    study.setName(RandomStringUtils.randomAlphabetic(10));
+    Dataset dataset = new Dataset();
+    dataset.setName("");
+    dataset.setDatasetId(RandomUtils.nextInt(10, 99));
+    dataset.setDacId(RandomUtils.nextInt(1, 100));
+    study.addDatasets(List.of(dataset));
+    study.addDatasetIds(Set.of(dataset.getDatasetId()));
+    return study;
+  }
+
+  private StudyUpdateRequest createValidRegistration(Study study) {
+    StudyUpdateRequest registration = new StudyUpdateRequest();
+    registration.setStudyName(study.getName());
+    registration.setStudyDescription(RandomStringUtils.randomAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.randomAlphabetic(8)));
+    registration.setPublicVisibility(true);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
+    registration.setPiName(RandomStringUtils.randomAlphabetic(10));
+
+    List<ConsentGroupRequest> consentGroups =
+        study.getDatasets().stream()
+            .map(
+                d -> {
+                  ConsentGroupRequest cg = new ConsentGroupRequest();
+                  cg.setConsentGroupName(RandomStringUtils.randomAlphabetic(10));
+                  cg.setNumberOfParticipants(RandomUtils.nextInt(1, 100));
+                  cg.setDatasetId(d.getDatasetId());
+                  // existing consent groups omit data-use fields — they were already validated
+                  return cg;
+                })
+            .toList();
+    registration.setConsentGroups(new ArrayList<>(consentGroups));
+    return registration;
+  }
+}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3593](https://broadworkbench.atlassian.net/browse/DT-3593)

### Summary

Introduces two new validator classes for the StudyRegistrationRequest and StudyUpdateRequest DTOs added in DT-3592, providing comprehensive server-side validation before those payloads reach service layer logic.

- StudyRegistrationRequestValidator — validates new study registration payloads:
  - Required fields: study name (non-blank), description, data types, public visibility, NIH AnVIL use, and PI name
  - NIH AnVIL use conditional fields: dbGaP phs ID, PI institution, and NIH grant/contract number are required depending on the selected NihAnvilUse value
  - GSR controlled access: explanation is required when controlledAccessRequiredForGenomicSummaryResultsGSR is true
  - Alternative data sharing plan: explanation and at least one reason are required when the plan flag is set
  - Email format: validates PI email and all data custodian emails via Apache Commons EmailValidator
  - Date format: validates embargo release date, alternative data sharing plan delivery/public release dates, and per-consent-group MOR dates against ISO-8601 (YYYY-MM-DD)
  - Consent groups: at least one required; each must have a name, number of participants, exactly one primary data use (open access, GRU, HMB, POA, disease-specific, or other), and a DAC if access is controlled
- StudyUpdateRequestValidator — validates update payloads against the existing study state:
  - All shared field validations above (description, data types, visibility, NIH fields, GSR, emails, dates)
  - Study name uniqueness: if the name changes, checks via DatasetService.findAllStudyNames() that it is not already taken; unchanged names skip the service call
  - Data submitter immutability is enforced structurally — dataSubmitterUserId is absent from StudyUpdateRequest by design
  - Consent group membership: existing consent groups in the payload must belong to the study being updated
  - Consent group name changes: renaming an existing consent group is blocked; only new consent groups (no datasetId) can receive a name
  - Consent group removal: the payload must include all datasets already associated with the study (omitting one is rejected)
  - New consent groups (no datasetId): validated with the same rules as the create path; existing consent groups skip data-use re-validation

#### Tests

Both validators are covered by unit test classes (StudyRegistrationRequestValidatorTest, StudyUpdateRequestValidatorTest) with ~100 test cases total, covering every required field, each conditional braf primary data use, email and date format edge cases, and the update-specific consent group lifecycle rules. The update validator uses Mockito to stub DatasetService.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
