### PR TITLE
[DT-3748] Update the specific version of databind requested to the one supplied.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,16 @@
         <artifactId>jackson-databind</artifactId>
         <version>3.1.4</version>
       </dependency>
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>3.1.4</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>3.1.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE fix: jackson-databind 3.1.1 has a deserialization vulnerability; pin to 3.1.4 -->
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>3.1.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -463,7 +463,10 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- CVE fix: jackson-databind 3.1.1 has a deserialization vulnerability; pin to 3.1.4 -->
+      <!--
+       See https://broadworkbench.atlassian.net/browse/DT-3748
+       Pin tools.jackson.core:jackson-databind to 3.1.4 to address a reported security issue in 3.1.1
+      -->
       <dependency>
         <groupId>tools.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3748](https://broadworkbench.atlassian.net/browse/DT-3748)

### Summary

BEFORE:
[INFO] org.broadinstitute:consent:jar:1.0.1
[INFO] +- io.swagger.parser.v3:swagger-parser:jar:2.1.45:compile
[INFO] |  +- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.1.45:compile
[INFO] |  |  +- io.swagger:swagger-core:jar:1.6.16:compile
[INFO] |  |  |  \- io.swagger:swagger-models:jar:1.6.16:compile
[INFO] |  |  |     \- io.swagger:swagger-annotations:jar:1.6.16:compile
[INFO] |  |  +- io.swagger:swagger-parser:jar:1.0.76:compile
[INFO] |  |  |  \- io.swagger:swagger-parser-safe-url-resolver:jar:1.0.76:compile
[INFO] |  |  +- io.swagger:swagger-compat-spec-parser:jar:1.0.76:compile
[INFO] |  |  |  +- com.github.java-json-tools:json-schema-validator:jar:2.2.14:compile
[INFO] |  |  |  |  +- com.github.java-json-tools:jackson-coreutils-equivalence:jar:1.0:compile
[INFO] |  |  |  |  +- com.github.java-json-tools:json-schema-core:jar:1.2.14:compile
[INFO] |  |  |  |  |  \- com.github.java-json-tools:uri-template:jar:0.10:compile
[INFO] |  |  |  |  \- com.googlecode.libphonenumber:libphonenumber:jar:8.11.1:compile
[INFO] |  |  |  +- org.mozilla:rhino:jar:1.7.15.1:compile
[INFO] |  |  |  \- com.github.java-json-tools:json-patch:jar:1.13:compile
[INFO] |  |  |     +- com.github.java-json-tools:msg-simple:jar:1.2:compile
[INFO] |  |  |     |  \- com.github.java-json-tools:btf:jar:1.3:compile
[INFO] |  |  |     \- com.github.java-json-tools:jackson-coreutils:jar:2.0:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-models:jar:2.2.52:compile
[INFO] |  |  \- io.swagger.parser.v3:swagger-parser-core:jar:2.1.45:compile
[INFO] |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.1.45:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-core:jar:2.2.52:compile
[INFO] |  |  |  \- io.swagger.core.v3:swagger-annotations:jar:2.2.52:compile
[INFO] |  |  +- io.swagger.parser.v3:swagger-parser-safe-url-resolver:jar:2.1.45:compile
[INFO] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.4:compile
[INFO] |  \- org.yaml:snakeyaml:jar:2.6:compile
[INFO] +- com.networknt:json-schema-validator:jar:3.0.5:compile
[INFO] |  +- com.ethlo.time:itu:jar:1.14.0:compile
**[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.1.1:compile**
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.1.1:compile
[INFO] |  \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.1.1:compile
[INFO] |     \- org.snakeyaml:snakeyaml-engine:jar:3.0.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.22.0:compile
[INFO] +- net.gcardone.junidecode:junidecode:jar:0.5.2:compile
[INFO] +- org.owasp:java-file-io:jar:1.0.0:compile
[INFO] +- org.jdbi:jdbi3-core:jar:3.52.1:compile
[INFO] |  \- io.leangen.geantyref:geantyref:jar:2.0.1:compile
[INFO] +- org.jdbi:jdbi3-sqlobject:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-gson2:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-json:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-guava:jar:3.52.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] +- org.parboiled:parboiled-java:jar:1.4.1:compile
[INFO] |  +- org.parboiled:parboiled-core:jar:1.4.1:compile
[INFO] |  +- org.ow2.asm:asm:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-tree:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-analysis:jar:9.2:compile
[INFO] |  \- org.ow2.asm:asm-util:jar:9.2:compile
[INFO] +- com.sendgrid:sendgrid-java:jar:4.10.3:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.4:compile
[INFO] +- org.bouncycastle:bcprov-jdk18on:jar:1.84:compile
[INFO] +- org.apache.httpcomponents.client5:httpclient5:jar:5.6.2:compile
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.2:compile
[INFO] |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
[INFO] +- com.sendgrid:java-http-client:jar:4.5.1:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:compile
[INFO] |  \- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] +- io.sentry:sentry:jar:8.46.0:compile
[INFO] +- org.slf4j:slf4j-api:jar:2.0.18:compile
[INFO] +- io.dropwizard:dropwizard-json-logging:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jackson:jar:5.0.2:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.21.4:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.21.4:compile
[INFO] |  +- io.dropwizard:dropwizard-logging:jar:5.0.2:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.39:compile
[INFO] |  |  +- org.slf4j:jul-to-slf4j:jar:2.0.18:compile
[INFO] |  |  +- io.dropwizard.logback:logback-throttling-appender:jar:1.5.3:compile
[INFO] |  |  \- org.slf4j:log4j-over-slf4j:jar:2.0.18:runtime
[INFO] |  +- org.jspecify:jspecify:jar:1.0.0:compile
[INFO] |  +- jakarta.servlet:jakarta.servlet-api:jar:6.0.0:compile
[INFO] |  \- jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
[INFO] +- io.dropwizard:dropwizard-dependencies:pom:5.0.2:compile
[INFO] +- io.dropwizard:dropwizard-auth:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jersey:jar:5.0.2:compile
[INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:3.1.11:runtime
[INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:3.1.11:runtime
[INFO] |  |  |  \- org.glassfish.hk2:hk2-locator:jar:3.0.6:runtime
[INFO] |  |  +- org.javassist:javassist:jar:3.31.0-GA:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-jersey3:jar:4.2.39:compile
[INFO] |  |  +- com.fasterxml:classmate:jar:1.7.3:compile
[INFO] |  |  +- org.glassfish.hk2:hk2-api:jar:3.0.6:compile
[INFO] |  |  |  +- org.glassfish.hk2:hk2-utils:jar:3.0.6:compile
[INFO] |  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.6:compile
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:3.1.11:runtime
[INFO] |  |  \- org.hibernate.validator:hibernate-validator:jar:8.0.3.Final:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.39:compile
[INFO] |  +- com.github.ben-manes.caffeine:caffeine:jar:3.2.4:compile
[INFO] |  +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
[INFO] |  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile
[INFO] |  +- jakarta.inject:jakarta.inject-api:jar:2.0.1:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:3.1.11:compile
[INFO] |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:3.1.11:compile
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:12.1.10:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:12.1.10:compile
[INFO] |  \- org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.1.10:compile
[INFO] |     \- org.eclipse.jetty:jetty-session:jar:12.1.10:compile
[INFO] +- io.dropwizard:dropwizard-assets:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jetty:jar:5.0.2:compile
[INFO] |  \- io.dropwizard:dropwizard-servlets:jar:5.0.2:compile
[INFO] +- io.dropwizard:dropwizard-http2:jar:5.0.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jetty12:jar:4.2.39:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-io:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-util:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty.http2:jetty-http2-server:jar:12.1.10:compile
[INFO] |  |  \- org.eclipse.jetty.http2:jetty-http2-common:jar:12.1.10:compile
[INFO] |  |     \- org.eclipse.jetty.http2:jetty-http2-hpack:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:12.1.10:runtime
[INFO] |  \- org.eclipse.jetty:jetty-alpn-java-client:jar:12.1.10:runtime
[INFO] +- org.eclipse.jetty.http3:http3-common:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty.http3:http3-qpack:jar:11.0.26:compile
[INFO] |  \- org.eclipse.jetty.quic:quic-common:jar:11.0.26:compile
[INFO] |     \- org.eclipse.jetty.quic:quic-quiche-common:jar:11.0.26:compile
[INFO] |        \- org.mortbay.jetty.quiche:jetty-quiche-native:jar:0.22.0:compile
[INFO] +- io.dropwizard:dropwizard-client:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-util:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-validation:jar:5.0.2:compile
[INFO] |  |  \- org.glassfish.expressly:expressly:jar:5.0.0:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:3.1.11:compile
[INFO] |  \- io.dropwizard.metrics:metrics-httpclient5:jar:4.2.39:compile
[INFO] +- io.dropwizard:dropwizard-core:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-configuration:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-metrics:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-health:jar:5.0.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jetty12-ee10:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jakarta-servlets:jar:4.2.39:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.39:compile
[INFO] |  |  \- com.helger:profiler:jar:1.1.1:compile
[INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.39:compile
[INFO] |  +- io.dropwizard:dropwizard-request-logging:jar:5.0.2:compile
[INFO] |  |  \- ch.qos.logback.access:logback-access-jetty12:jar:2.0.12:compile
[INFO] |  +- net.sourceforge.argparse4j:argparse4j:jar:0.9.0:compile
[INFO] |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-jna:jar:2.0.3:compile
[INFO] |  |  \- net.java.dev.jna:jna-jpms:jar:5.14.0:compile
[INFO] |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:3.1.11:compile
[INFO] |     +- org.jboss.logging:jboss-logging:jar:3.6.3.Final:compile
[INFO] |     \- jakarta.el:jakarta.el-api:jar:5.0.1:compile
[INFO] +- io.dropwizard:dropwizard-jdbi3:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-db:jar:5.0.2:compile
[INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:11.0.22:compile
[INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:11.0.22:compile
[INFO] |  \- io.dropwizard.metrics:metrics-jdbi3:jar:4.2.39:compile
[INFO] +- io.dropwizard:dropwizard-forms:jar:5.0.2:compile
[INFO] |  \- org.glassfish.jersey.media:jersey-media-multipart:jar:3.1.11:compile
[INFO] |     \- org.jvnet.mimepull:mimepull:jar:1.9.15:compile
[INFO] +- ch.qos.logback.access:logback-access-common:jar:2.0.12:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.5.25:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.5.25:compile
[INFO] +- io.netty:netty-codec-dns:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-codec-base:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-http:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-codec-compression:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-handler:jar:4.2.15.Final:compile
[INFO] |     \- io.netty:netty-transport-native-unix-common:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-http2:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-transport:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-resolver:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-socks:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-resolver-dns:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-handler-proxy:jar:4.2.15.Final:compile
[INFO] +- io.dropwizard:dropwizard-testing:jar:5.0.2:test
[INFO] |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.21.4:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.21.4:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:3.1.11:compile
[INFO] |  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:3.1.11:test
[INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:3.1.11:test
[INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:3.1.11:test
[INFO] |  |  +- org.junit.jupiter:junit-jupiter:jar:6.1.0:test
[INFO] |  |  |  +- org.junit.jupiter:junit-jupiter-params:jar:6.1.0:test
[INFO] |  |  |  \- org.junit.jupiter:junit-jupiter-engine:jar:6.1.0:test
[INFO] |  |  \- org.hamcrest:hamcrest:jar:3.0:test
[INFO] |  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:3.1.11:test
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:2.1.4:compile
[INFO] |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.5:compile
[INFO] +- org.mockito:mockito-core:jar:5.23.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.18.8-jdk5:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.17.7:test
[INFO] |  \- org.objenesis:objenesis:jar:3.3:test
[INFO] +- org.mockito:mockito-junit-jupiter:jar:5.23.0:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:6.1.0:test
[INFO] |     +- org.opentest4j:opentest4j:jar:1.3.0:test
[INFO] |     \- org.junit.platform:junit-platform-commons:jar:6.1.0:test
[INFO] +- org.junit.platform:junit-platform-launcher:jar:6.1.0:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:6.1.0:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.liquibase:liquibase-core:jar:4.33.0:compile
[INFO] |  +- com.opencsv:opencsv:jar:5.11.2:compile
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.1:compile
[INFO] |  \- org.apache.commons:commons-text:jar:1.15.0:compile
[INFO] +- com.sun.mail:javax.mail:jar:1.6.2:compile
[INFO] |  \- javax.activation:activation:jar:1.1:compile
[INFO] +- org.freemarker:freemarker:jar:2.3.34:compile
[INFO] +- org.jsoup:jsoup:jar:1.22.2:test
[INFO] +- com.google.guava:guava:jar:33.6.0-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.3:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.42.0:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:3.1:compile
[INFO] +- org.postgresql:postgresql:jar:42.7.11:compile
[INFO] +- net.sourceforge.owlapi:owlapi-distribution:jar:5.5.1:compile
[INFO] |  +- net.sourceforge.owlapi:owlapi-compatibility:jar:5.5.1:compile
[INFO] |  |  \- net.sourceforge.owlapi:owlapi-apibinding:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-api:jar:5.5.1:compile
[INFO] |  |     |  \- javax.inject:javax.inject:jar:1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-impl:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-parsers:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-oboformat:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-tools:jar:5.5.1:compile
[INFO] |  |     \- net.sourceforge.owlapi:owlapi-rio:jar:5.5.1:compile
[INFO] |  +- org.apache.commons:commons-rdf-api:jar:0.5.0:compile
[INFO] |  +- org.tukaani:xz:jar:1.9:compile
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:2.0.18:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-exception:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-text:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-io:jar:5.0.2:compile
[INFO] |  |  \- org.eclipse.rdf4j:rdf4j-common-iterator:jar:5.0.2:compile
[INFO] |  |     \- org.eclipse.rdf4j:rdf4j-common-order:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model-api:jar:5.0.2:compile
[INFO] |  |  \- org.eclipse.rdf4j:rdf4j-common-annotation:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model-vocabulary:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-api:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-xml:jar:5.0.2:compile
[INFO] |  |  \- no.hasmac:hasmac-json-ld:jar:0.9.0:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-languages:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-datatypes:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-binary:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-n3:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-nquads:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-ntriples:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-rdfjson:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-jsonld:jar:5.0.2:compile
[INFO] |  |  +- jakarta.json:jakarta.json-api:jar:2.0.1:compile
[INFO] |  |  +- org.glassfish:jakarta.json:jar:2.0.1:compile
[INFO] |  |  \- org.apache.httpcomponents:httpclient-cache:jar:4.5.14:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-rdfxml:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-trix:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-turtle:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-trig:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-hdt:jar:5.0.2:compile
[INFO] |  +- com.github.jsonld-java:jsonld-java:jar:0.13.6:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient-osgi:jar:4.5.13:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpmime:jar:4.5.13:compile
[INFO] |  |  |  \- org.apache.httpcomponents:fluent-hc:jar:4.5.13:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore-osgi:jar:4.4.14:compile
[INFO] |  +- com.github.vsonnier:hppcrt:jar:0.7.5:compile
[INFO] |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] +- org.testcontainers:postgresql:jar:1.21.4:test
[INFO] |  \- org.testcontainers:jdbc:jar:1.21.4:test
[INFO] |     \- org.testcontainers:database-commons:jar:1.21.4:test
[INFO] |        \- org.testcontainers:testcontainers:jar:1.21.4:test
[INFO] |           +- junit:junit:jar:4.13.2:test
[INFO] |           +- org.apache.commons:commons-compress:jar:1.24.0:test
[INFO] |           +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |           +- com.github.docker-java:docker-java-api:jar:3.4.2:test
[INFO] |           \- com.github.docker-java:docker-java-transport-zerodep:jar:3.4.2:test
[INFO] |              +- com.github.docker-java:docker-java-transport:jar:3.4.2:test
[INFO] |              \- net.java.dev.jna:jna:jar:5.13.0:test
[INFO] +- org.wiremock:wiremock-jetty12:jar:3.13.2:test
[INFO] |  +- org.wiremock:wiremock:jar:3.13.2:test
[INFO] |  |  +- org.xmlunit:xmlunit-core:jar:2.11.0:test
[INFO] |  |  +- org.xmlunit:xmlunit-legacy:jar:2.11.0:test
[INFO] |  |  +- org.xmlunit:xmlunit-placeholders:jar:2.11.0:test
[INFO] |  |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.40.1:test
[INFO] |  |  |  \- org.hamcrest:hamcrest-core:jar:2.2:test
[INFO] |  |  +- com.jayway.jsonpath:json-path:jar:2.10.0:test
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.6.0:test
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:2.6.0:test
[INFO] |  |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:compile
[INFO] |  |  +- com.github.jknack:handlebars:jar:4.3.1:test
[INFO] |  |  +- com.github.jknack:handlebars-helpers:jar:4.3.1:test
[INFO] |  |  \- commons-fileupload:commons-fileupload:jar:1.6.0:test
[INFO] |  +- org.eclipse.jetty:jetty-proxy:jar:12.1.10:test
[INFO] |  |  \- org.eclipse.jetty:jetty-client:jar:12.1.10:test
[INFO] |  |     \- org.eclipse.jetty.compression:jetty-compression-gzip:jar:12.1.10:test
[INFO] |  |        \- org.eclipse.jetty.compression:jetty-compression-common:jar:12.1.10:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-client:jar:12.1.10:runtime
[INFO] |  +- org.eclipse.jetty.ee10:jetty-ee10-servlets:jar:12.1.10:test
[INFO] |  \- org.eclipse.jetty.ee10:jetty-ee10-webapp:jar:12.1.10:test
[INFO] |     +- org.eclipse.jetty:jetty-xml:jar:12.1.10:test
[INFO] |     \- org.eclipse.jetty.ee:jetty-ee-webapp:jar:12.1.10:test
[INFO] +- com.google.api-client:google-api-client:jar:2.9.0:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.22.0:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.36.0:compile
[INFO] |  +- com.google.auth:google-auth-library-credentials:jar:1.30.0:compile
[INFO] |  +- com.google.auth:google-auth-library-oauth2-http:jar:1.30.0:compile
[INFO] |  +- com.google.http-client:google-http-client-gson:jar:2.0.0:compile
[INFO] |  +- com.google.http-client:google-http-client-apache-v2:jar:2.0.0:compile
[INFO] |  \- com.google.http-client:google-http-client:jar:2.0.0:compile
[INFO] +- com.google.cloud:google-cloud-storage:jar:2.69.0:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.21.4:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:7.0.0:compile
[INFO] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.4:compile
[INFO] |  +- io.grpc:grpc-context:jar:1.81.0:compile
[INFO] |  +- io.opencensus:opencensus-contrib-http-util:jar:0.31.1:compile
[INFO] |  +- com.google.http-client:google-http-client-jackson2:jar:2.1.0:compile
[INFO] |  +- com.google.apis:google-api-services-storage:jar:v1-rev20260204-2.0.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core:jar:2.71.0:compile
[INFO] |  +- com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-http:jar:2.71.0:compile
[INFO] |  +- com.google.http-client:google-http-client-appengine:jar:2.1.0:compile
[INFO] |  +- com.google.api:gax-httpjson:jar:2.81.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-grpc:jar:2.71.0:compile
[INFO] |  +- com.google.api:gax:jar:2.81.0:compile
[INFO] |  +- com.google.api:gax-grpc:jar:2.81.0:compile
[INFO] |  +- io.grpc:grpc-inprocess:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-alts:jar:1.81.0:compile
[INFO] |  +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2:compile
[INFO] |  +- io.grpc:grpc-auth:jar:1.81.0:compile
[INFO] |  +- com.google.api:api-common:jar:2.64.0:compile
[INFO] |  +- io.opencensus:opencensus-api:jar:0.31.1:compile
[INFO] |  +- io.opentelemetry:opentelemetry-context:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-common:jar:1.62.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-iam-v1:jar:1.67.0:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:4.33.2:compile
[INFO] |  +- io.grpc:grpc-core:jar:1.81.0:compile
[INFO] |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[INFO] |  +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.27:compile
[INFO] |  +- io.perfmark:perfmark-api:jar:0.27.0:runtime
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-protobuf-lite:jar:1.81.0:runtime
[INFO] |  +- com.google.api.grpc:proto-google-common-protos:jar:2.72.0:compile
[INFO] |  +- org.threeten:threetenbp:jar:1.7.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- com.google.api.grpc:grpc-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- com.google.api.grpc:gapic-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-trace:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-logs:jar:1.62.0:compile
[INFO] |  +- io.grpc:grpc-opentelemetry:jar:1.81.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-api:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-metrics:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-common:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry.semconv:opentelemetry-semconv:jar:1.29.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:exporter-metrics:jar:0.33.0:compile
[INFO] |  +- com.google.cloud:google-cloud-monitoring:jar:3.52.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-monitoring-v3:jar:3.52.0:compile
[INFO] |  +- io.grpc:grpc-grpclb:jar:1.81.0:compile
[INFO] |  +- com.google.cloud.opentelemetry:shared-resourcemapping:jar:0.33.0:runtime
[INFO] |  +- io.opentelemetry.contrib:opentelemetry-gcp-resources:jar:1.37.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:detector-resources-support:jar:0.33.0:runtime
[INFO] |  +- org.checkerframework:checker-qual:jar:3.49.0:compile
[INFO] |  +- io.grpc:grpc-api:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-netty-shaded:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-util:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-stub:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-googleapis:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-xds:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-services:jar:1.81.0:runtime
[INFO] |  +- com.google.re2j:re2j:jar:1.8:runtime
[INFO] |  \- io.grpc:grpc-rls:jar:1.81.0:runtime
[INFO] +- commons-io:commons-io:jar:2.22.0:compile
[INFO] +- com.google.apis:google-api-services-oauth2:jar:v2-rev20200213-2.0.0:compile
[INFO] +- com.google.inject:guice:jar:7.0.0:compile
[INFO] |  \- aopalliance:aopalliance:jar:1.0:compile
[INFO] +- com.google.code.gson:gson:jar:2.14.0:compile
[INFO] +- org.apache.commons:commons-collections4:jar:4.5.0:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.20.0:compile
[INFO] +- org.elasticsearch.client:elasticsearch-rest-client:jar:9.4.2:compile
[INFO] |  +- org.apache.httpcomponents:httpasyncclient:jar:4.1.5:compile
[INFO] |  +- org.apache.httpcomponents:httpcore-nio:jar:4.4.16:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.webjars:swagger-ui:jar:5.32.8:compile
[INFO] +- commons-validator:commons-validator:jar:1.10.1:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- commons-beanutils:commons-beanutils:jar:1.11.0:compile
[INFO] +- com.cloudbees.thirdparty:zendesk-java-client:jar:1.5.2:compile
[INFO] |  +- org.asynchttpclient:async-http-client:jar:3.0.9:compile
[INFO] |  |  +- io.netty:netty-codec:jar:4.2.10.Final:compile
[INFO] |  |  |  +- io.netty:netty-codec-protobuf:jar:4.2.10.Final:compile
[INFO] |  |  |  \- io.netty:netty-codec-marshalling:jar:4.2.10.Final:compile
[INFO] |  |  +- com.sun.activation:jakarta.activation:jar:2.0.1:compile
[INFO] |  |  \- org.jetbrains:annotations:jar:26.1.0:compile
[INFO] |  \- com.damnhandy:handy-uri-templates:jar:2.1.8:compile
[INFO] |     \- joda-time:joda-time:jar:2.10.2:compile
[INFO] \- org.skyscreamer:jsonassert:jar:2.0-rc1:test
[INFO]    \- org.json:json:jar:20240303:test

AFTER:
[INFO] --- dependency:3.11.0:tree (default-cli) @ consent ---
[INFO] org.broadinstitute:consent:jar:1.0.1
[INFO] +- io.swagger.parser.v3:swagger-parser:jar:2.1.45:compile
[INFO] |  +- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.1.45:compile
[INFO] |  |  +- io.swagger:swagger-core:jar:1.6.16:compile
[INFO] |  |  |  \- io.swagger:swagger-models:jar:1.6.16:compile
[INFO] |  |  |     \- io.swagger:swagger-annotations:jar:1.6.16:compile
[INFO] |  |  +- io.swagger:swagger-parser:jar:1.0.76:compile
[INFO] |  |  |  \- io.swagger:swagger-parser-safe-url-resolver:jar:1.0.76:compile
[INFO] |  |  +- io.swagger:swagger-compat-spec-parser:jar:1.0.76:compile
[INFO] |  |  |  +- com.github.java-json-tools:json-schema-validator:jar:2.2.14:compile
[INFO] |  |  |  |  +- com.github.java-json-tools:jackson-coreutils-equivalence:jar:1.0:compile
[INFO] |  |  |  |  +- com.github.java-json-tools:json-schema-core:jar:1.2.14:compile
[INFO] |  |  |  |  |  \- com.github.java-json-tools:uri-template:jar:0.10:compile
[INFO] |  |  |  |  \- com.googlecode.libphonenumber:libphonenumber:jar:8.11.1:compile
[INFO] |  |  |  +- org.mozilla:rhino:jar:1.7.15.1:compile
[INFO] |  |  |  \- com.github.java-json-tools:json-patch:jar:1.13:compile
[INFO] |  |  |     +- com.github.java-json-tools:msg-simple:jar:1.2:compile
[INFO] |  |  |     |  \- com.github.java-json-tools:btf:jar:1.3:compile
[INFO] |  |  |     \- com.github.java-json-tools:jackson-coreutils:jar:2.0:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-models:jar:2.2.52:compile
[INFO] |  |  \- io.swagger.parser.v3:swagger-parser-core:jar:2.1.45:compile
[INFO] |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.1.45:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-core:jar:2.2.52:compile
[INFO] |  |  |  \- io.swagger.core.v3:swagger-annotations:jar:2.2.52:compile
[INFO] |  |  +- io.swagger.parser.v3:swagger-parser-safe-url-resolver:jar:2.1.45:compile
[INFO] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.4:compile
[INFO] |  \- org.yaml:snakeyaml:jar:2.6:compile
[INFO] +- com.networknt:json-schema-validator:jar:3.0.5:compile
[INFO] |  +- com.ethlo.time:itu:jar:1.14.0:compile
**[INFO] |  +- tools.jackson.core:jackson-databind:jar:3.1.4:compile**
[INFO] |  |  \- tools.jackson.core:jackson-core:jar:3.1.4:compile
[INFO] |  \- tools.jackson.dataformat:jackson-dataformat-yaml:jar:3.1.1:compile
[INFO] |     \- org.snakeyaml:snakeyaml-engine:jar:3.0.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.22.0:compile
[INFO] +- net.gcardone.junidecode:junidecode:jar:0.5.2:compile
[INFO] +- org.owasp:java-file-io:jar:1.0.0:compile
[INFO] +- org.jdbi:jdbi3-core:jar:3.52.1:compile
[INFO] |  \- io.leangen.geantyref:geantyref:jar:2.0.1:compile
[INFO] +- org.jdbi:jdbi3-sqlobject:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-gson2:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-json:jar:3.52.1:compile
[INFO] +- org.jdbi:jdbi3-guava:jar:3.52.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.22:compile
[INFO] +- org.parboiled:parboiled-java:jar:1.4.1:compile
[INFO] |  +- org.parboiled:parboiled-core:jar:1.4.1:compile
[INFO] |  +- org.ow2.asm:asm:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-tree:jar:9.2:compile
[INFO] |  +- org.ow2.asm:asm-analysis:jar:9.2:compile
[INFO] |  \- org.ow2.asm:asm-util:jar:9.2:compile
[INFO] +- com.sendgrid:sendgrid-java:jar:4.10.3:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.21.4:compile
[INFO] +- org.bouncycastle:bcprov-jdk18on:jar:1.84:compile
[INFO] +- org.apache.httpcomponents.client5:httpclient5:jar:5.6.2:compile
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.2:compile
[INFO] |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
[INFO] +- com.sendgrid:java-http-client:jar:4.5.1:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:compile
[INFO] |  \- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] +- io.sentry:sentry:jar:8.46.0:compile
[INFO] +- org.slf4j:slf4j-api:jar:2.0.18:compile
[INFO] +- io.dropwizard:dropwizard-json-logging:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jackson:jar:5.0.2:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.21.4:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-blackbird:jar:2.21.4:compile
[INFO] |  +- io.dropwizard:dropwizard-logging:jar:5.0.2:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-logback:jar:4.2.39:compile
[INFO] |  |  +- org.slf4j:jul-to-slf4j:jar:2.0.18:compile
[INFO] |  |  +- io.dropwizard.logback:logback-throttling-appender:jar:1.5.3:compile
[INFO] |  |  \- org.slf4j:log4j-over-slf4j:jar:2.0.18:runtime
[INFO] |  +- org.jspecify:jspecify:jar:1.0.0:compile
[INFO] |  +- jakarta.servlet:jakarta.servlet-api:jar:6.0.0:compile
[INFO] |  \- jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
[INFO] +- io.dropwizard:dropwizard-dependencies:pom:5.0.2:compile
[INFO] +- io.dropwizard:dropwizard-auth:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jersey:jar:5.0.2:compile
[INFO] |  |  +- org.glassfish.jersey.ext:jersey-metainf-services:jar:3.1.11:runtime
[INFO] |  |  +- org.glassfish.jersey.inject:jersey-hk2:jar:3.1.11:runtime
[INFO] |  |  |  \- org.glassfish.hk2:hk2-locator:jar:3.0.6:runtime
[INFO] |  |  +- org.javassist:javassist:jar:3.31.0-GA:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-jersey3:jar:4.2.39:compile
[INFO] |  |  +- com.fasterxml:classmate:jar:1.7.3:compile
[INFO] |  |  +- org.glassfish.hk2:hk2-api:jar:3.0.6:compile
[INFO] |  |  |  +- org.glassfish.hk2:hk2-utils:jar:3.0.6:compile
[INFO] |  |  |  \- org.glassfish.hk2.external:aopalliance-repackaged:jar:3.0.6:compile
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:3.1.11:runtime
[INFO] |  |  \- org.hibernate.validator:hibernate-validator:jar:8.0.3.Final:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-caffeine:jar:4.2.39:compile
[INFO] |  +- com.github.ben-manes.caffeine:caffeine:jar:3.2.4:compile
[INFO] |  +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
[INFO] |  +- jakarta.ws.rs:jakarta.ws.rs-api:jar:3.1.0:compile
[INFO] |  +- jakarta.inject:jakarta.inject-api:jar:2.0.1:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-common:jar:3.1.11:compile
[INFO] |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-server:jar:3.1.11:compile
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:12.1.10:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:12.1.10:compile
[INFO] |  \- org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.1.10:compile
[INFO] |     \- org.eclipse.jetty:jetty-session:jar:12.1.10:compile
[INFO] +- io.dropwizard:dropwizard-assets:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-jetty:jar:5.0.2:compile
[INFO] |  \- io.dropwizard:dropwizard-servlets:jar:5.0.2:compile
[INFO] +- io.dropwizard:dropwizard-http2:jar:5.0.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jetty12:jar:4.2.39:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-io:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-util:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty.http2:jetty-http2-server:jar:12.1.10:compile
[INFO] |  |  \- org.eclipse.jetty.http2:jetty-http2-common:jar:12.1.10:compile
[INFO] |  |     \- org.eclipse.jetty.http2:jetty-http2-hpack:jar:12.1.10:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:12.1.10:runtime
[INFO] |  \- org.eclipse.jetty:jetty-alpn-java-client:jar:12.1.10:runtime
[INFO] +- org.eclipse.jetty.http3:http3-common:jar:11.0.26:compile
[INFO] |  +- org.eclipse.jetty.http3:http3-qpack:jar:11.0.26:compile
[INFO] |  \- org.eclipse.jetty.quic:quic-common:jar:11.0.26:compile
[INFO] |     \- org.eclipse.jetty.quic:quic-quiche-common:jar:11.0.26:compile
[INFO] |        \- org.mortbay.jetty.quiche:jetty-quiche-native:jar:0.22.0:compile
[INFO] +- io.dropwizard:dropwizard-client:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-lifecycle:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-util:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-validation:jar:5.0.2:compile
[INFO] |  |  \- org.glassfish.expressly:expressly:jar:5.0.0:compile
[INFO] |  +- org.glassfish.jersey.core:jersey-client:jar:3.1.11:compile
[INFO] |  \- io.dropwizard.metrics:metrics-httpclient5:jar:4.2.39:compile
[INFO] +- io.dropwizard:dropwizard-core:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-configuration:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-metrics:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-health:jar:5.0.2:compile
[INFO] |  +- io.dropwizard.metrics:metrics-annotation:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jetty12-ee10:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jvm:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jmx:jar:4.2.39:compile
[INFO] |  +- io.dropwizard.metrics:metrics-jakarta-servlets:jar:4.2.39:compile
[INFO] |  |  +- io.dropwizard.metrics:metrics-json:jar:4.2.39:compile
[INFO] |  |  \- com.helger:profiler:jar:1.1.1:compile
[INFO] |  +- io.dropwizard.metrics:metrics-healthchecks:jar:4.2.39:compile
[INFO] |  +- io.dropwizard:dropwizard-request-logging:jar:5.0.2:compile
[INFO] |  |  \- ch.qos.logback.access:logback-access-jetty12:jar:2.0.12:compile
[INFO] |  +- net.sourceforge.argparse4j:argparse4j:jar:0.9.0:compile
[INFO] |  +- org.eclipse.jetty.toolchain.setuid:jetty-setuid-jna:jar:2.0.3:compile
[INFO] |  |  \- net.java.dev.jna:jna-jpms:jar:5.14.0:compile
[INFO] |  \- org.glassfish.jersey.ext:jersey-bean-validation:jar:3.1.11:compile
[INFO] |     +- org.jboss.logging:jboss-logging:jar:3.6.3.Final:compile
[INFO] |     \- jakarta.el:jakarta.el-api:jar:5.0.1:compile
[INFO] +- io.dropwizard:dropwizard-jdbi3:jar:5.0.2:compile
[INFO] |  +- io.dropwizard:dropwizard-db:jar:5.0.2:compile
[INFO] |  |  \- org.apache.tomcat:tomcat-jdbc:jar:11.0.22:compile
[INFO] |  |     \- org.apache.tomcat:tomcat-juli:jar:11.0.22:compile
[INFO] |  \- io.dropwizard.metrics:metrics-jdbi3:jar:4.2.39:compile
[INFO] +- io.dropwizard:dropwizard-forms:jar:5.0.2:compile
[INFO] |  \- org.glassfish.jersey.media:jersey-media-multipart:jar:3.1.11:compile
[INFO] |     \- org.jvnet.mimepull:mimepull:jar:1.9.15:compile
[INFO] +- ch.qos.logback.access:logback-access-common:jar:2.0.12:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.5.25:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.5.25:compile
[INFO] +- io.netty:netty-codec-dns:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-codec-base:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-http:jar:4.2.15.Final:compile
[INFO] |  +- io.netty:netty-codec-compression:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-handler:jar:4.2.15.Final:compile
[INFO] |     \- io.netty:netty-transport-native-unix-common:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-http2:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-transport:jar:4.2.15.Final:compile
[INFO] |  \- io.netty:netty-resolver:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-codec-socks:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-resolver-dns:jar:4.2.15.Final:compile
[INFO] +- io.netty:netty-handler-proxy:jar:4.2.15.Final:compile
[INFO] +- io.dropwizard:dropwizard-testing:jar:5.0.2:test
[INFO] |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:jar:2.21.4:compile
[INFO] |  |  +- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:jar:2.21.4:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:jar:2.21.4:compile
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:3.1.11:compile
[INFO] |  +- org.glassfish.jersey.connectors:jersey-apache5-connector:jar:3.1.11:test
[INFO] |  +- org.glassfish.jersey.test-framework:jersey-test-framework-core:jar:3.1.11:test
[INFO] |  |  +- org.glassfish.jersey.media:jersey-media-jaxb:jar:3.1.11:test
[INFO] |  |  +- org.junit.jupiter:junit-jupiter:jar:6.1.0:test
[INFO] |  |  |  +- org.junit.jupiter:junit-jupiter-params:jar:6.1.0:test
[INFO] |  |  |  \- org.junit.jupiter:junit-jupiter-engine:jar:6.1.0:test
[INFO] |  |  \- org.hamcrest:hamcrest:jar:3.0:test
[INFO] |  +- org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:jar:3.1.11:test
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:2.1.4:compile
[INFO] |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:4.0.5:compile
[INFO] +- org.mockito:mockito-core:jar:5.23.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.18.8-jdk5:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.17.7:test
[INFO] |  \- org.objenesis:objenesis:jar:3.3:test
[INFO] +- org.mockito:mockito-junit-jupiter:jar:5.23.0:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:6.1.0:test
[INFO] |     +- org.opentest4j:opentest4j:jar:1.3.0:test
[INFO] |     \- org.junit.platform:junit-platform-commons:jar:6.1.0:test
[INFO] +- org.junit.platform:junit-platform-launcher:jar:6.1.0:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:6.1.0:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.liquibase:liquibase-core:jar:4.33.0:compile
[INFO] |  +- com.opencsv:opencsv:jar:5.11.2:compile
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.1:compile
[INFO] |  \- org.apache.commons:commons-text:jar:1.15.0:compile
[INFO] +- com.sun.mail:javax.mail:jar:1.6.2:compile
[INFO] |  \- javax.activation:activation:jar:1.1:compile
[INFO] +- org.freemarker:freemarker:jar:2.3.34:compile
[INFO] +- org.jsoup:jsoup:jar:1.22.2:test
[INFO] +- com.google.guava:guava:jar:33.6.0-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.3:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.42.0:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:3.1:compile
[INFO] +- org.postgresql:postgresql:jar:42.7.11:compile
[INFO] +- net.sourceforge.owlapi:owlapi-distribution:jar:5.5.1:compile
[INFO] |  +- net.sourceforge.owlapi:owlapi-compatibility:jar:5.5.1:compile
[INFO] |  |  \- net.sourceforge.owlapi:owlapi-apibinding:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-api:jar:5.5.1:compile
[INFO] |  |     |  \- javax.inject:javax.inject:jar:1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-impl:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-parsers:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-oboformat:jar:5.5.1:compile
[INFO] |  |     +- net.sourceforge.owlapi:owlapi-tools:jar:5.5.1:compile
[INFO] |  |     \- net.sourceforge.owlapi:owlapi-rio:jar:5.5.1:compile
[INFO] |  +- org.apache.commons:commons-rdf-api:jar:0.5.0:compile
[INFO] |  +- org.tukaani:xz:jar:1.9:compile
[INFO] |  +- org.slf4j:jcl-over-slf4j:jar:2.0.18:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-exception:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-text:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-io:jar:5.0.2:compile
[INFO] |  |  \- org.eclipse.rdf4j:rdf4j-common-iterator:jar:5.0.2:compile
[INFO] |  |     \- org.eclipse.rdf4j:rdf4j-common-order:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model-api:jar:5.0.2:compile
[INFO] |  |  \- org.eclipse.rdf4j:rdf4j-common-annotation:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-model-vocabulary:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-api:jar:5.0.2:compile
[INFO] |  |  +- org.eclipse.rdf4j:rdf4j-common-xml:jar:5.0.2:compile
[INFO] |  |  \- no.hasmac:hasmac-json-ld:jar:0.9.0:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-languages:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-datatypes:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-binary:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-n3:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-nquads:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-ntriples:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-rdfjson:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-jsonld:jar:5.0.2:compile
[INFO] |  |  +- jakarta.json:jakarta.json-api:jar:2.0.1:compile
[INFO] |  |  +- org.glassfish:jakarta.json:jar:2.0.1:compile
[INFO] |  |  \- org.apache.httpcomponents:httpclient-cache:jar:4.5.14:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-rdfxml:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-trix:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-turtle:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-trig:jar:5.0.2:compile
[INFO] |  +- org.eclipse.rdf4j:rdf4j-rio-hdt:jar:5.0.2:compile
[INFO] |  +- com.github.jsonld-java:jsonld-java:jar:0.13.6:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient-osgi:jar:4.5.13:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpmime:jar:4.5.13:compile
[INFO] |  |  |  \- org.apache.httpcomponents:fluent-hc:jar:4.5.13:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore-osgi:jar:4.4.14:compile
[INFO] |  +- com.github.vsonnier:hppcrt:jar:0.7.5:compile
[INFO] |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] +- org.testcontainers:postgresql:jar:1.21.4:test
[INFO] |  \- org.testcontainers:jdbc:jar:1.21.4:test
[INFO] |     \- org.testcontainers:database-commons:jar:1.21.4:test
[INFO] |        \- org.testcontainers:testcontainers:jar:1.21.4:test
[INFO] |           +- junit:junit:jar:4.13.2:test
[INFO] |           +- org.apache.commons:commons-compress:jar:1.24.0:test
[INFO] |           +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |           +- com.github.docker-java:docker-java-api:jar:3.4.2:test
[INFO] |           \- com.github.docker-java:docker-java-transport-zerodep:jar:3.4.2:test
[INFO] |              +- com.github.docker-java:docker-java-transport:jar:3.4.2:test
[INFO] |              \- net.java.dev.jna:jna:jar:5.13.0:test
[INFO] +- org.wiremock:wiremock-jetty12:jar:3.13.2:test
[INFO] |  +- org.wiremock:wiremock:jar:3.13.2:test
[INFO] |  |  +- org.xmlunit:xmlunit-core:jar:2.11.0:test
[INFO] |  |  +- org.xmlunit:xmlunit-legacy:jar:2.11.0:test
[INFO] |  |  +- org.xmlunit:xmlunit-placeholders:jar:2.11.0:test
[INFO] |  |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.40.1:test
[INFO] |  |  |  \- org.hamcrest:hamcrest-core:jar:2.2:test
[INFO] |  |  +- com.jayway.jsonpath:json-path:jar:2.10.0:test
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.6.0:test
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:2.6.0:test
[INFO] |  |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:compile
[INFO] |  |  +- com.github.jknack:handlebars:jar:4.3.1:test
[INFO] |  |  +- com.github.jknack:handlebars-helpers:jar:4.3.1:test
[INFO] |  |  \- commons-fileupload:commons-fileupload:jar:1.6.0:test
[INFO] |  +- org.eclipse.jetty:jetty-proxy:jar:12.1.10:test
[INFO] |  |  \- org.eclipse.jetty:jetty-client:jar:12.1.10:test
[INFO] |  |     \- org.eclipse.jetty.compression:jetty-compression-gzip:jar:12.1.10:test
[INFO] |  |        \- org.eclipse.jetty.compression:jetty-compression-common:jar:12.1.10:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-client:jar:12.1.10:runtime
[INFO] |  +- org.eclipse.jetty.ee10:jetty-ee10-servlets:jar:12.1.10:test
[INFO] |  \- org.eclipse.jetty.ee10:jetty-ee10-webapp:jar:12.1.10:test
[INFO] |     +- org.eclipse.jetty:jetty-xml:jar:12.1.10:test
[INFO] |     \- org.eclipse.jetty.ee:jetty-ee-webapp:jar:12.1.10:test
[INFO] +- com.google.api-client:google-api-client:jar:2.9.0:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.22.0:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.36.0:compile
[INFO] |  +- com.google.auth:google-auth-library-credentials:jar:1.30.0:compile
[INFO] |  +- com.google.auth:google-auth-library-oauth2-http:jar:1.30.0:compile
[INFO] |  +- com.google.http-client:google-http-client-gson:jar:2.0.0:compile
[INFO] |  +- com.google.http-client:google-http-client-apache-v2:jar:2.0.0:compile
[INFO] |  \- com.google.http-client:google-http-client:jar:2.0.0:compile
[INFO] +- com.google.cloud:google-cloud-storage:jar:2.69.0:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.21.4:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:7.0.0:compile
[INFO] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.4:compile
[INFO] |  +- io.grpc:grpc-context:jar:1.81.0:compile
[INFO] |  +- io.opencensus:opencensus-contrib-http-util:jar:0.31.1:compile
[INFO] |  +- com.google.http-client:google-http-client-jackson2:jar:2.1.0:compile
[INFO] |  +- com.google.apis:google-api-services-storage:jar:v1-rev20260204-2.0.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core:jar:2.71.0:compile
[INFO] |  +- com.google.auto.value:auto-value-annotations:jar:1.11.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-http:jar:2.71.0:compile
[INFO] |  +- com.google.http-client:google-http-client-appengine:jar:2.1.0:compile
[INFO] |  +- com.google.api:gax-httpjson:jar:2.81.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-grpc:jar:2.71.0:compile
[INFO] |  +- com.google.api:gax:jar:2.81.0:compile
[INFO] |  +- com.google.api:gax-grpc:jar:2.81.0:compile
[INFO] |  +- io.grpc:grpc-inprocess:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-alts:jar:1.81.0:compile
[INFO] |  +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.2:compile
[INFO] |  +- io.grpc:grpc-auth:jar:1.81.0:compile
[INFO] |  +- com.google.api:api-common:jar:2.64.0:compile
[INFO] |  +- io.opencensus:opencensus-api:jar:0.31.1:compile
[INFO] |  +- io.opentelemetry:opentelemetry-context:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-common:jar:1.62.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-iam-v1:jar:1.67.0:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:4.33.2:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:4.33.2:compile
[INFO] |  +- io.grpc:grpc-core:jar:1.81.0:compile
[INFO] |  +- com.google.android:annotations:jar:4.1.1.4:runtime
[INFO] |  +- org.codehaus.mojo:animal-sniffer-annotations:jar:1.27:compile
[INFO] |  +- io.perfmark:perfmark-api:jar:0.27.0:runtime
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-protobuf-lite:jar:1.81.0:runtime
[INFO] |  +- com.google.api.grpc:proto-google-common-protos:jar:2.72.0:compile
[INFO] |  +- org.threeten:threetenbp:jar:1.7.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- com.google.api.grpc:grpc-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- com.google.api.grpc:gapic-google-cloud-storage-v2:jar:2.69.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-trace:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-logs:jar:1.62.0:compile
[INFO] |  +- io.grpc:grpc-opentelemetry:jar:1.81.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-api:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-metrics:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-common:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:jar:1.62.0:compile
[INFO] |  +- io.opentelemetry.semconv:opentelemetry-semconv:jar:1.29.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:exporter-metrics:jar:0.33.0:compile
[INFO] |  +- com.google.cloud:google-cloud-monitoring:jar:3.52.0:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-monitoring-v3:jar:3.52.0:compile
[INFO] |  +- io.grpc:grpc-grpclb:jar:1.81.0:compile
[INFO] |  +- com.google.cloud.opentelemetry:shared-resourcemapping:jar:0.33.0:runtime
[INFO] |  +- io.opentelemetry.contrib:opentelemetry-gcp-resources:jar:1.37.0-alpha:compile
[INFO] |  +- com.google.cloud.opentelemetry:detector-resources-support:jar:0.33.0:runtime
[INFO] |  +- org.checkerframework:checker-qual:jar:3.49.0:compile
[INFO] |  +- io.grpc:grpc-api:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-netty-shaded:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-util:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-stub:jar:1.81.0:compile
[INFO] |  +- io.grpc:grpc-googleapis:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-xds:jar:1.81.0:runtime
[INFO] |  +- io.grpc:grpc-services:jar:1.81.0:runtime
[INFO] |  +- com.google.re2j:re2j:jar:1.8:runtime
[INFO] |  \- io.grpc:grpc-rls:jar:1.81.0:runtime
[INFO] +- commons-io:commons-io:jar:2.22.0:compile
[INFO] +- com.google.apis:google-api-services-oauth2:jar:v2-rev20200213-2.0.0:compile
[INFO] +- com.google.inject:guice:jar:7.0.0:compile
[INFO] |  \- aopalliance:aopalliance:jar:1.0:compile
[INFO] +- com.google.code.gson:gson:jar:2.14.0:compile
[INFO] +- org.apache.commons:commons-collections4:jar:4.5.0:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.20.0:compile
[INFO] +- org.elasticsearch.client:elasticsearch-rest-client:jar:9.4.2:compile
[INFO] |  +- org.apache.httpcomponents:httpasyncclient:jar:4.1.5:compile
[INFO] |  +- org.apache.httpcomponents:httpcore-nio:jar:4.4.16:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.webjars:swagger-ui:jar:5.32.8:compile
[INFO] +- commons-validator:commons-validator:jar:1.10.1:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- commons-beanutils:commons-beanutils:jar:1.11.0:compile
[INFO] +- com.cloudbees.thirdparty:zendesk-java-client:jar:1.5.2:compile
[INFO] |  +- org.asynchttpclient:async-http-client:jar:3.0.9:compile
[INFO] |  |  +- io.netty:netty-codec:jar:4.2.10.Final:compile
[INFO] |  |  |  +- io.netty:netty-codec-protobuf:jar:4.2.10.Final:compile
[INFO] |  |  |  \- io.netty:netty-codec-marshalling:jar:4.2.10.Final:compile
[INFO] |  |  +- com.sun.activation:jakarta.activation:jar:2.0.1:compile
[INFO] |  |  \- org.jetbrains:annotations:jar:26.1.0:compile
[INFO] |  \- com.damnhandy:handy-uri-templates:jar:2.1.8:compile
[INFO] |     \- joda-time:joda-time:jar:2.10.2:compile
[INFO] \- org.skyscreamer:jsonassert:jar:2.0-rc1:test
[INFO]    \- org.json:json:jar:20240303:test

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
