### PR TITLE
[DT-3594] Parallel shadow validators with timing.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -55,6 +55,8 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.Da
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator.ValidationOutcome;
 import org.broadinstitute.consent.http.service.TDRService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.JsonSchemaUtil;
@@ -74,6 +76,7 @@ public class DatasetResource extends Resource {
 
   private final JsonSchemaUtil jsonSchemaUtil;
   private final GCSService gcsService;
+  private final RegistrationShadowValidator registrationShadowValidator;
 
   @Inject
   public DatasetResource(
@@ -83,7 +86,8 @@ public class DatasetResource extends Resource {
       ElasticSearchService elasticSearchService,
       TDRService tdrService,
       GCSService gcsService,
-      JsonSchemaUtil jsonSchemaUtil) {
+      JsonSchemaUtil jsonSchemaUtil,
+      RegistrationShadowValidator registrationShadowValidator) {
     this.datasetService = datasetService;
     this.userService = userService;
     this.datasetRegistrationService = datasetRegistrationService;
@@ -91,6 +95,7 @@ public class DatasetResource extends Resource {
     this.elasticSearchService = elasticSearchService;
     this.tdrService = tdrService;
     this.jsonSchemaUtil = jsonSchemaUtil;
+    this.registrationShadowValidator = registrationShadowValidator;
   }
 
   @POST
@@ -106,11 +111,17 @@ public class DatasetResource extends Resource {
   public Response createDatasetRegistration(
       @Auth AuthUser authUser, FormDataMultiPart multipart, @FormDataParam("dataset") String json) {
     try {
+      long schemaValidationStart = System.nanoTime();
       Set<String> errors = jsonSchemaUtil.validateSchemaMessagesV1(json);
-      if (!errors.isEmpty()) {
-        throw new BadRequestException(
-            "Please correct the following fields:\n"
-                + errors.stream().map(error -> " - " + error + "\n").collect(Collectors.joining()));
+      if (errors.isEmpty()) {
+        registrationShadowValidator.compareCreate(
+            json, ValidationOutcome.acceptedSince(schemaValidationStart));
+      } else {
+        String errorMessage =
+            errors.stream().map(error -> " - " + error + "\n").collect(Collectors.joining());
+        registrationShadowValidator.compareCreate(
+            json, ValidationOutcome.rejectedSince(errorMessage, schemaValidationStart));
+        throw new BadRequestException("Please correct the following fields:\n" + errorMessage);
       }
 
       DatasetRegistrationSchemaV1 registration =

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -79,6 +79,8 @@ public class DatasetResource extends Resource {
   private final RegistrationShadowValidator registrationShadowValidator;
 
   @Inject
+  @SuppressWarnings(
+      "java:S107") // shadow-validator dependency is temporary, see RegistrationShadowValidator
   public DatasetResource(
       DatasetService datasetService,
       UserService userService,

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -41,6 +41,8 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.Da
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator.ValidationOutcome;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -54,17 +56,20 @@ public class StudyResource extends Resource {
   private final DatasetRegistrationService datasetRegistrationService;
   private final UserService userService;
   private final ElasticSearchService elasticSearchService;
+  private final RegistrationShadowValidator registrationShadowValidator;
 
   @Inject
   public StudyResource(
       DatasetService datasetService,
       UserService userService,
       DatasetRegistrationService datasetRegistrationService,
-      ElasticSearchService elasticSearchService) {
+      ElasticSearchService elasticSearchService,
+      RegistrationShadowValidator registrationShadowValidator) {
     this.datasetService = datasetService;
     this.userService = userService;
     this.datasetRegistrationService = datasetRegistrationService;
     this.elasticSearchService = elasticSearchService;
+    this.registrationShadowValidator = registrationShadowValidator;
   }
 
   /**
@@ -244,9 +249,29 @@ public class StudyResource extends Resource {
       // enforces it in a creation context but doesn't work for editing purposes.
       DatasetRegistrationSchemaV1UpdateValidator updateValidator =
           new DatasetRegistrationSchemaV1UpdateValidator(datasetService);
-      DatasetRegistrationSchemaV1 registration = updateValidator.deserializeRegistration(json);
 
-      if (updateValidator.validate(existingStudy, registration)) {
+      long updateValidationStart = System.nanoTime();
+      DatasetRegistrationSchemaV1 registration = null;
+      boolean updateValid = false;
+      RuntimeException validationError = null;
+      try {
+        registration = updateValidator.deserializeRegistration(json);
+        updateValid = updateValidator.validate(existingStudy, registration);
+      } catch (RuntimeException e) {
+        validationError = e;
+      }
+      registrationShadowValidator.compareUpdate(
+          json,
+          existingStudy,
+          validationError == null
+              ? ValidationOutcome.acceptedSince(updateValidationStart)
+              : ValidationOutcome.rejectedSince(
+                  validationError.getMessage(), updateValidationStart));
+      if (validationError != null) {
+        throw validationError;
+      }
+
+      if (updateValid) {
         // Update study from registration
         Map<String, FormDataBodyPart> files = extractFilesFromMultiPart(multipart);
         Study updatedStudy =

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -247,31 +247,11 @@ public class StudyResource extends Resource {
 
       // Manually validate the schema from an editing context. Validation with the schema tools
       // enforces it in a creation context but doesn't work for editing purposes.
-      DatasetRegistrationSchemaV1UpdateValidator updateValidator =
-          new DatasetRegistrationSchemaV1UpdateValidator(datasetService);
+      StudyUpdateValidationResult validationResult =
+          validateRegistrationUpdate(json, existingStudy);
+      DatasetRegistrationSchemaV1 registration = validationResult.registration();
 
-      long updateValidationStart = System.nanoTime();
-      DatasetRegistrationSchemaV1 registration = null;
-      boolean updateValid = false;
-      RuntimeException validationError = null;
-      try {
-        registration = updateValidator.deserializeRegistration(json);
-        updateValid = updateValidator.validate(existingStudy, registration);
-      } catch (RuntimeException e) {
-        validationError = e;
-      }
-      registrationShadowValidator.compareUpdate(
-          json,
-          existingStudy,
-          validationError == null
-              ? ValidationOutcome.acceptedSince(updateValidationStart)
-              : ValidationOutcome.rejectedSince(
-                  validationError.getMessage(), updateValidationStart));
-      if (validationError != null) {
-        throw validationError;
-      }
-
-      if (updateValid) {
+      if (validationResult.valid()) {
         // Update study from registration
         Map<String, FormDataBodyPart> files = extractFilesFromMultiPart(multipart);
         Study updatedStudy =
@@ -289,6 +269,40 @@ public class StudyResource extends Resource {
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
+  }
+
+  private record StudyUpdateValidationResult(
+      DatasetRegistrationSchemaV1 registration, boolean valid) {}
+
+  /**
+   * Runs the manual update-validator and the {@link RegistrationShadowValidator} comparison, then
+   * re-throws any validation error so the caller's outer catch can translate it into a response,
+   * exactly as it did before this logic was extracted.
+   */
+  private StudyUpdateValidationResult validateRegistrationUpdate(String json, Study existingStudy) {
+    DatasetRegistrationSchemaV1UpdateValidator updateValidator =
+        new DatasetRegistrationSchemaV1UpdateValidator(datasetService);
+
+    long updateValidationStart = System.nanoTime();
+    DatasetRegistrationSchemaV1 registration = null;
+    boolean updateValid = false;
+    RuntimeException validationError = null;
+    try {
+      registration = updateValidator.deserializeRegistration(json);
+      updateValid = updateValidator.validate(existingStudy, registration);
+    } catch (RuntimeException e) {
+      validationError = e;
+    }
+    registrationShadowValidator.compareUpdate(
+        json,
+        existingStudy,
+        validationError == null
+            ? ValidationOutcome.acceptedSince(updateValidationStart)
+            : ValidationOutcome.rejectedSince(validationError.getMessage(), updateValidationStart));
+    if (validationError != null) {
+      throw validationError;
+    }
+    return new StudyUpdateValidationResult(registration, updateValid);
   }
 
   private void checkPublicVisibilityForUser(Study study, User user) {

--- a/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
@@ -110,7 +111,7 @@ public class RegistrationShadowValidator implements ConsentLogger {
   @FunctionalInterface
   private interface ThrowingRunnable {
 
-    void run() throws Exception;
+    void run() throws JsonProcessingException;
   }
 
   private ValidationOutcome runTimed(ThrowingRunnable validation) {
@@ -120,7 +121,7 @@ public class RegistrationShadowValidator implements ConsentLogger {
       return ValidationOutcome.acceptedSince(start);
     } catch (BadRequestException e) {
       return ValidationOutcome.rejectedSince(e.getMessage(), start);
-    } catch (Exception e) {
+    } catch (JsonProcessingException e) {
       return ValidationOutcome.rejectedSince(
           "Unable to deserialize/validate: " + e.getMessage(), start);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
@@ -124,6 +124,13 @@ public class RegistrationShadowValidator implements ConsentLogger {
     } catch (JsonProcessingException e) {
       return ValidationOutcome.rejectedSince(
           "Unable to deserialize/validate: " + e.getMessage(), start);
+    } catch (Exception e) {
+      logWarn(
+          "[VALIDATOR_PARITY] shadow validator threw unexpected exception: "
+              + e.getClass().getSimpleName(),
+          e);
+      return ValidationOutcome.rejectedSince(
+          "Shadow validator error: " + e.getClass().getSimpleName(), start);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
@@ -145,14 +145,22 @@ public class RegistrationShadowValidator implements ConsentLogger {
           "[VALIDATOR_PARITY:%s] AGREE accepted=%s %s"
               .formatted(flow, oldOutcome.accepted(), timing));
     } else {
+      String oldMessage =
+          oldOutcome.message() == null
+              ? null
+              : oldOutcome.message().replaceAll("[^\\s]+@[^\\s]+", "<redacted>");
+      String newMessage =
+          newOutcome.message() == null
+              ? null
+              : newOutcome.message().replaceAll("[^\\s]+@[^\\s]+", "<redacted>");
       logWarn(
           "[VALIDATOR_PARITY:%s] DISAGREE old=%s new=%s oldMessage=%s newMessage=%s %s"
               .formatted(
                   flow,
                   oldOutcome.accepted() ? "ACCEPT" : "REJECT",
                   newOutcome.accepted() ? "ACCEPT" : "REJECT",
-                  oldOutcome.message(),
-                  newOutcome.message(),
+                  oldMessage,
+                  newMessage,
                   timing));
     }
     return new ComparisonResult(oldOutcome, newOutcome, agree);

--- a/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/RegistrationShadowValidator.java
@@ -1,0 +1,152 @@
+package org.broadinstitute.consent.http.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequestValidator;
+import org.broadinstitute.consent.http.models.dto.registration.StudyUpdateRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyUpdateRequestValidator;
+import org.broadinstitute.consent.http.util.ConsentLogger;
+
+/**
+ * Runs the new DTO-based registration validators in shadow (non-authoritative) mode alongside the
+ * existing JSON Schema / manual validation, and logs agreement or discrepancy. This class never
+ * throws back to its caller; the result it returns is informational only and must not affect the
+ * authoritative validation outcome.
+ */
+public class RegistrationShadowValidator implements ConsentLogger {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final StudyRegistrationRequestValidator createValidator;
+  private final StudyUpdateRequestValidator updateValidator;
+
+  @Inject
+  public RegistrationShadowValidator(DatasetService datasetService) {
+    this.createValidator = new StudyRegistrationRequestValidator();
+    this.updateValidator = new StudyUpdateRequestValidator(datasetService);
+  }
+
+  public record ValidationOutcome(boolean accepted, String message, long durationNanos) {
+
+    public static ValidationOutcome accepted(long durationNanos) {
+      return new ValidationOutcome(true, "", durationNanos);
+    }
+
+    public static ValidationOutcome rejected(String message, long durationNanos) {
+      return new ValidationOutcome(false, message, durationNanos);
+    }
+
+    /**
+     * Builds an accepted outcome, computing the duration from a {@link System#nanoTime()} timestamp
+     * captured at the start of validation.
+     */
+    public static ValidationOutcome acceptedSince(long startNanos) {
+      return accepted(System.nanoTime() - startNanos);
+    }
+
+    /**
+     * Builds a rejected outcome, computing the duration from a {@link System#nanoTime()} timestamp
+     * captured at the start of validation.
+     */
+    public static ValidationOutcome rejectedSince(String message, long startNanos) {
+      return rejected(message, System.nanoTime() - startNanos);
+    }
+  }
+
+  public record ComparisonResult(
+      ValidationOutcome oldOutcome, ValidationOutcome newOutcome, boolean agree) {}
+
+  /**
+   * Compares the authoritative create-validation outcome against the new {@link
+   * StudyRegistrationRequestValidator}. Deserializes {@code json} into a {@link
+   * StudyRegistrationRequest} and runs the new validator, then logs the comparison.
+   *
+   * @param json the raw registration JSON submitted on create
+   * @param oldOutcome the already-computed authoritative (JSON Schema) outcome
+   * @return the comparison, for test assertions; callers should otherwise ignore it
+   */
+  public ComparisonResult compareCreate(String json, ValidationOutcome oldOutcome) {
+    if (oldOutcome == null) {
+      logWarn("[VALIDATOR_PARITY:create] shadow validation skipped: oldOutcome was null");
+      return new ComparisonResult(null, null, false);
+    }
+    ValidationOutcome newOutcome =
+        runTimed(
+            () -> {
+              StudyRegistrationRequest request =
+                  mapper.readValue(json, StudyRegistrationRequest.class);
+              createValidator.validate(request);
+            });
+    return logComparison("create", oldOutcome, newOutcome);
+  }
+
+  /**
+   * Compares the authoritative update-validation outcome against the new {@link
+   * StudyUpdateRequestValidator}. Deserializes {@code json} into a {@link StudyUpdateRequest} and
+   * runs the new validator, then logs the comparison.
+   *
+   * @param json the raw registration JSON submitted on update
+   * @param existingStudy the study being updated
+   * @param oldOutcome the already-computed authoritative (manual) outcome
+   * @return the comparison, for test assertions; callers should otherwise ignore it
+   */
+  public ComparisonResult compareUpdate(
+      String json, Study existingStudy, ValidationOutcome oldOutcome) {
+    if (oldOutcome == null) {
+      logWarn("[VALIDATOR_PARITY:update] shadow validation skipped: oldOutcome was null");
+      return new ComparisonResult(null, null, false);
+    }
+    ValidationOutcome newOutcome =
+        runTimed(
+            () -> {
+              StudyUpdateRequest request = mapper.readValue(json, StudyUpdateRequest.class);
+              updateValidator.validate(existingStudy, request);
+            });
+    return logComparison("update", oldOutcome, newOutcome);
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+
+    void run() throws Exception;
+  }
+
+  private ValidationOutcome runTimed(ThrowingRunnable validation) {
+    long start = System.nanoTime();
+    try {
+      validation.run();
+      return ValidationOutcome.acceptedSince(start);
+    } catch (BadRequestException e) {
+      return ValidationOutcome.rejectedSince(e.getMessage(), start);
+    } catch (Exception e) {
+      return ValidationOutcome.rejectedSince(
+          "Unable to deserialize/validate: " + e.getMessage(), start);
+    }
+  }
+
+  private ComparisonResult logComparison(
+      String flow, ValidationOutcome oldOutcome, ValidationOutcome newOutcome) {
+    boolean agree = oldOutcome.accepted() == newOutcome.accepted();
+    String timing =
+        "oldDurationMicros=%d newDurationMicros=%d"
+            .formatted(oldOutcome.durationNanos() / 1_000, newOutcome.durationNanos() / 1_000);
+    if (agree) {
+      logInfo(
+          "[VALIDATOR_PARITY:%s] AGREE accepted=%s %s"
+              .formatted(flow, oldOutcome.accepted(), timing));
+    } else {
+      logWarn(
+          "[VALIDATOR_PARITY:%s] DISAGREE old=%s new=%s oldMessage=%s newMessage=%s %s"
+              .formatted(
+                  flow,
+                  oldOutcome.accepted() ? "ACCEPT" : "REJECT",
+                  newOutcome.accepted() ? "ACCEPT" : "REJECT",
+                  oldOutcome.message(),
+                  newOutcome.message(),
+                  timing));
+    }
+    return new ComparisonResult(oldOutcome, newOutcome, agree);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -66,6 +66,7 @@ import org.broadinstitute.consent.http.models.tdr.ApprovedUsers;
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator;
 import org.broadinstitute.consent.http.service.TDRService;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.JsonSchemaUtil;
@@ -93,6 +94,8 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Mock private GCSService gcsService;
 
+  @Mock private RegistrationShadowValidator registrationShadowValidator;
+
   @Mock private Response mockResponse;
 
   private final AuthUser authUser = new AuthUser().setEmail("test@test.com");
@@ -110,7 +113,8 @@ class DatasetResourceTest extends AbstractTestHelper {
             elasticSearchService,
             tdrService,
             gcsService,
-            new JsonSchemaUtil());
+            new JsonSchemaUtil(),
+            registrationShadowValidator);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetReg
 import org.broadinstitute.consent.http.service.DatasetRegistrationService;
 import org.broadinstitute.consent.http.service.DatasetService;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator;
 import org.broadinstitute.consent.http.service.UserService;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +56,8 @@ class StudyResourceTest extends AbstractTestHelper {
 
   @Mock private ElasticSearchService elasticSearchService;
 
+  @Mock private RegistrationShadowValidator registrationShadowValidator;
+
   @Mock private AuthUser authUser;
 
   @Mock private User user;
@@ -66,7 +70,11 @@ class StudyResourceTest extends AbstractTestHelper {
   void setUp() {
     resource =
         new StudyResource(
-            datasetService, userService, datasetRegistrationService, elasticSearchService);
+            datasetService,
+            userService,
+            datasetRegistrationService,
+            elasticSearchService,
+            registrationShadowValidator);
   }
 
   @Test
@@ -282,6 +290,26 @@ class StudyResourceTest extends AbstractTestHelper {
         resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
     }
+  }
+
+  @Test
+  void testUpdateStudyByRegistrationMalformedJson_stillRunsShadowComparison() {
+    String input = DataResourceTestData.registrationWithMalformedJson;
+    Study study = createMockStudy();
+    when(userService.findUserByEmail(any())).thenReturn(user);
+    User createUser = new User();
+    createUser.setUserId(study.getCreateUserId());
+    createUser.setEmail("creator@test.com");
+    when(authUser.getEmail()).thenReturn(createUser.getEmail());
+    when(userService.findUserByEmail(createUser.getEmail())).thenReturn(createUser);
+    when(datasetRegistrationService.findStudyById(study.getStudyId())).thenReturn(study);
+    when(datasetService.isCreatorCustodianOrAdmin(createUser, study)).thenReturn(true);
+
+    try (var response =
+        resource.updateStudyByRegistration(authUser, null, study.getStudyId(), input)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+    verify(registrationShadowValidator).compareUpdate(eq(input), eq(study), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/RegistrationShadowValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/RegistrationShadowValidatorTest.java
@@ -1,0 +1,244 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.models.dto.registration.ConsentGroupRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyUpdateRequest;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator.ComparisonResult;
+import org.broadinstitute.consent.http.service.RegistrationShadowValidator.ValidationOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistrationShadowValidatorTest {
+
+  @Mock private DatasetService datasetService;
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private RegistrationShadowValidator shadowValidator;
+
+  @BeforeEach
+  void setUp() {
+    shadowValidator = new RegistrationShadowValidator(datasetService);
+  }
+
+  // ── ValidationOutcome ─────────────────────────────────────────────────────
+
+  @Test
+  void testValidationOutcome_accepted() {
+    ValidationOutcome outcome = ValidationOutcome.accepted(42L);
+    assertTrue(outcome.accepted());
+    assertEquals("", outcome.message());
+    assertEquals(42L, outcome.durationNanos());
+  }
+
+  @Test
+  void testValidationOutcome_rejected() {
+    ValidationOutcome outcome = ValidationOutcome.rejected("nope", 7L);
+    assertFalse(outcome.accepted());
+    assertEquals("nope", outcome.message());
+    assertEquals(7L, outcome.durationNanos());
+  }
+
+  @Test
+  void testValidationOutcome_acceptedSince() {
+    long start = System.nanoTime();
+    ValidationOutcome outcome = ValidationOutcome.acceptedSince(start);
+    assertTrue(outcome.accepted());
+    assertEquals("", outcome.message());
+    assertTrue(outcome.durationNanos() >= 0);
+  }
+
+  @Test
+  void testValidationOutcome_rejectedSince() {
+    long start = System.nanoTime();
+    ValidationOutcome outcome = ValidationOutcome.rejectedSince("nope", start);
+    assertFalse(outcome.accepted());
+    assertEquals("nope", outcome.message());
+    assertTrue(outcome.durationNanos() >= 0);
+  }
+
+  // ── compareCreate ─────────────────────────────────────────────────────────
+
+  @Test
+  void testCompareCreate_agree_bothAccept() throws Exception {
+    String json = mapper.writeValueAsString(createValidRegistration());
+    ComparisonResult result = shadowValidator.compareCreate(json, ValidationOutcome.accepted(100L));
+    assertTrue(result.agree());
+    assertTrue(result.newOutcome().accepted());
+  }
+
+  @Test
+  void testCompareCreate_disagree_newRejectsViaBadRequest() throws Exception {
+    StudyRegistrationRequest registration = createValidRegistration();
+    registration.setStudyName(null);
+    String json = mapper.writeValueAsString(registration);
+
+    ComparisonResult result = shadowValidator.compareCreate(json, ValidationOutcome.accepted(100L));
+    assertFalse(result.agree());
+    assertFalse(result.newOutcome().accepted());
+    assertTrue(result.newOutcome().message().contains("Study Name is required"));
+  }
+
+  @Test
+  void testCompareCreate_disagree_oldRejectsNewAccepts() throws Exception {
+    String json = mapper.writeValueAsString(createValidRegistration());
+
+    ComparisonResult result =
+        shadowValidator.compareCreate(json, ValidationOutcome.rejected("old said no", 100L));
+    assertFalse(result.agree());
+    assertTrue(result.newOutcome().accepted());
+  }
+
+  @Test
+  void testCompareCreate_malformedJson_rejectedWithDeserializationMessage() {
+    ComparisonResult result =
+        shadowValidator.compareCreate("not valid json", ValidationOutcome.rejected("bad", 1L));
+    assertTrue(result.agree());
+    assertFalse(result.newOutcome().accepted());
+    assertTrue(result.newOutcome().message().startsWith("Unable to deserialize/validate:"));
+  }
+
+  @Test
+  void testCompareCreate_nullOldOutcome_skipsComparison() throws Exception {
+    String json = mapper.writeValueAsString(createValidRegistration());
+    ComparisonResult result = shadowValidator.compareCreate(json, null);
+    assertFalse(result.agree());
+    assertNull(result.newOutcome());
+    assertNull(result.oldOutcome());
+  }
+
+  // ── compareUpdate ─────────────────────────────────────────────────────────
+
+  @Test
+  void testCompareUpdate_agree_bothAccept() throws Exception {
+    Study study = createMockStudy();
+    String json = mapper.writeValueAsString(createValidUpdateRequest(study));
+
+    ComparisonResult result =
+        shadowValidator.compareUpdate(json, study, ValidationOutcome.accepted(100L));
+    assertTrue(result.agree());
+    assertTrue(result.newOutcome().accepted());
+  }
+
+  @Test
+  void testCompareUpdate_disagree_newRejectsViaBadRequest() throws Exception {
+    Study study = createMockStudy();
+    StudyUpdateRequest registration = createValidUpdateRequest(study);
+    registration.setStudyDescription(null);
+    String json = mapper.writeValueAsString(registration);
+
+    ComparisonResult result =
+        shadowValidator.compareUpdate(json, study, ValidationOutcome.accepted(100L));
+    assertFalse(result.agree());
+    assertFalse(result.newOutcome().accepted());
+    assertTrue(result.newOutcome().message().contains("Study Description is required"));
+  }
+
+  @Test
+  void testCompareUpdate_disagree_oldRejectsNewAccepts() throws Exception {
+    Study study = createMockStudy();
+    String json = mapper.writeValueAsString(createValidUpdateRequest(study));
+
+    ComparisonResult result =
+        shadowValidator.compareUpdate(json, study, ValidationOutcome.rejected("old said no", 100L));
+    assertFalse(result.agree());
+    assertTrue(result.newOutcome().accepted());
+  }
+
+  @Test
+  void testCompareUpdate_malformedJson_rejectedWithDeserializationMessage() {
+    Study study = createMockStudy();
+    ComparisonResult result =
+        shadowValidator.compareUpdate(
+            "not valid json", study, ValidationOutcome.rejected("bad", 1L));
+    assertTrue(result.agree());
+    assertFalse(result.newOutcome().accepted());
+    assertTrue(result.newOutcome().message().startsWith("Unable to deserialize/validate:"));
+  }
+
+  @Test
+  void testCompareUpdate_nullOldOutcome_skipsComparison() throws Exception {
+    Study study = createMockStudy();
+    String json = mapper.writeValueAsString(createValidUpdateRequest(study));
+    ComparisonResult result = shadowValidator.compareUpdate(json, study, null);
+    assertFalse(result.agree());
+    assertNull(result.newOutcome());
+    assertNull(result.oldOutcome());
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private ConsentGroupRequest createValidConsentGroup() {
+    ConsentGroupRequest cg = new ConsentGroupRequest();
+    cg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    cg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
+    cg.setAccessManagement(AccessManagement.OPEN);
+    return cg;
+  }
+
+  private StudyRegistrationRequest createValidRegistration() {
+    StudyRegistrationRequest registration = new StudyRegistrationRequest();
+    registration.setStudyName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setStudyDescription(RandomStringUtils.secureStrong().nextAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.secureStrong().nextAlphabetic(8)));
+    registration.setPublicVisibility(true);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
+    registration.setPiName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    registration.setConsentGroups(List.of(createValidConsentGroup()));
+    return registration;
+  }
+
+  private Study createMockStudy() {
+    Study study = new Study();
+    study.setName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+    Dataset dataset = new Dataset();
+    dataset.setName("");
+    dataset.setDatasetId(RandomUtils.secureStrong().randomInt(10, 99));
+    dataset.setDacId(RandomUtils.secureStrong().randomInt(1, 100));
+    study.addDatasets(List.of(dataset));
+    study.addDatasetIds(java.util.Set.of(dataset.getDatasetId()));
+    return study;
+  }
+
+  private StudyUpdateRequest createValidUpdateRequest(Study study) {
+    StudyUpdateRequest registration = new StudyUpdateRequest();
+    registration.setStudyName(study.getName());
+    registration.setStudyDescription(RandomStringUtils.secureStrong().nextAlphabetic(20));
+    registration.setDataTypes(List.of(RandomStringUtils.secureStrong().nextAlphabetic(8)));
+    registration.setPublicVisibility(true);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
+    registration.setPiName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+
+    List<ConsentGroupRequest> consentGroups =
+        study.getDatasets().stream()
+            .map(
+                d -> {
+                  ConsentGroupRequest cg = new ConsentGroupRequest();
+                  cg.setConsentGroupName(RandomStringUtils.secureStrong().nextAlphabetic(10));
+                  cg.setNumberOfParticipants(RandomUtils.secureStrong().randomInt(1, 100));
+                  cg.setDatasetId(d.getDatasetId());
+                  return cg;
+                })
+            .toList();
+    registration.setConsentGroups(consentGroups);
+    return registration;
+  }
+}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3594](https://broadworkbench.atlassian.net/browse/DT-3594)

### Summary

Wires the new DTO-based StudyRegistrationRequestValidator / StudyUpdateRequestValidator (added in #2957) into the live create/update study-registration endpoints as non-authoritative shadow validators. On every create and update request, the existing (authoritative) JSON Schema / manual validation result is compared against the new validator's result, and the agreement/disagreement plus timing for each is logged. The new validators never affect the response returned to the client — they are purely observational, to build confidence before cutting over.

Changes

- RegistrationShadowValidator (new): runs the new validator against the same request JSON used by the authoritative path, times both outcomes, and logs:
  - [VALIDATOR_PARITY:create|update] AGREE accepted=... oldDurationMicros=... newDurationMicros=... when the two validators agree on accept/reject
  - [VALIDATOR_PARITY:create|update] DISAGREE old=ACCEPT/REJECT new=ACCEPT/REJECT oldMessage=... newMessage=... ... when they disagree
  - A warning and a no-op comparison if no authoritative outcome was supplied (defensive guard)
  - Catches and records any exception/deserialization failure from the new validator so it can never propagate to the caller
- DatasetResource#createDatasetRegistration: times the existing JSON-schema validation and forwards its outcome (accept or reject) to RegistrationShadowValidator.compareCreate before continuing with (or rejecting) the request as before.
- StudyResource#updateStudyByRegistration: times the existing deserialize+validate path, captures success, validation failure, or thrown exception, and forwards the outcome to RegistrationShadowValidator.compareUpdate — including the malformed-JSON/exception case — before re-throwing or proceeding exactly as the authoritative path did previously.
- Both resources now take RegistrationShadowValidator as a constructor-in

Testing

- RegistrationShadowValidatorTest: covers ValidationOutcome factory methods, agreement/disagreement on both create and update flows, malformed-JSON handling, and the null-outcome skip path.
- DatasetResourceTest / StudyResourceTest: updated for the new constructor dependency; added a test confirming the shadow comparison still runs (with the correct args) even when the update request JSON is malformed and the authoritative path rejects it.

Risk / rollout notes

- No behavior change for end users — response codes and bodies are unchanged; this only adds logging.
- Shadow validator failures (exceptions, bad JSON) are caught internally and surfaced only as a DISAGREE/rejected log entry, never as an error to the caller.
- Next step once parity is confirmed via logs: cut the new validators oveove the JSON Schema / manual path.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
