### PR TITLE
[DT-3774] Fix missing `dac_approval` column in `DacDAO.findAll()` 

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DacDAO.java
@@ -61,6 +61,7 @@ public interface DacDAO extends Transactional<DacDAO> {
         d.update_date AS dataset_update_date,
         d.update_user_id,
         d.data_use AS dataset_data_use,
+        d.dac_approval AS dataset_dac_approval,
         d.sharing_plan_document,
         d.sharing_plan_document_name,
         daa.daa_id AS daa_daa_id,

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
@@ -72,8 +72,8 @@ public class DacReducer
           dataset.setDataUse(dataUseParser.parseDataUse(duStr));
         }
 
-        Boolean dacApproval = rowView.getColumn("dataset_dac_approval", Boolean.class);
-        dataset.setDacApproval(dacApproval);
+        hasOptionalColumn(rowView, "dataset_dac_approval", Boolean.class)
+            .ifPresent(dataset::setDacApproval);
 
         if (dataset != null) {
           dac.addDataset(dataset);

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DacReducer.java
@@ -72,6 +72,9 @@ public class DacReducer
           dataset.setDataUse(dataUseParser.parseDataUse(duStr));
         }
 
+        Boolean dacApproval = rowView.getColumn("dataset_dac_approval", Boolean.class);
+        dataset.setDacApproval(dacApproval);
+
         if (dataset != null) {
           dac.addDataset(dataset);
         }

--- a/src/main/java/org/broadinstitute/consent/http/models/Dac.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dac.java
@@ -128,6 +128,10 @@ public class Dac {
     this.associatedDaa = associatedDaa;
   }
 
+  public List<Dataset> getDatasets() {
+    return datasets;
+  }
+
   public void addDataset(Dataset dataset) {
     if (Objects.isNull(datasets)) {
       datasets = new ArrayList<>();

--- a/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DacDAOTest.java
@@ -171,6 +171,47 @@ class DacDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindAllWithDatasetApproval() {
+    Integer dacId = createRandomDAC();
+    User user = createUser();
+    Integer approvedDatasetId =
+        datasetDAO.insertDataset(
+            randomAlphabetic(20),
+            new Timestamp(new Date().getTime()),
+            user.getUserId(),
+            randomAlphabetic(20),
+            new DataUseBuilder().setGeneralUse(true).build().toString(),
+            dacId);
+    Integer pendingDatasetId =
+        datasetDAO.insertDataset(
+            randomAlphabetic(20),
+            new Timestamp(new Date().getTime()),
+            user.getUserId(),
+            randomAlphabetic(20),
+            new DataUseBuilder().setGeneralUse(true).build().toString(),
+            dacId);
+    datasetDAO.updateDatasetApproval(true, Instant.now(), user.getUserId(), approvedDatasetId);
+
+    List<Dac> dacs = dacDAO.findAll();
+    Dac dac = dacs.stream().filter(d -> d.getDacId().equals(dacId)).findFirst().orElseThrow();
+    List<Dataset> datasets = dac.getDatasets();
+
+    Dataset approvedDataset =
+        datasets.stream()
+            .filter(d -> d.getDatasetId().equals(approvedDatasetId))
+            .findFirst()
+            .orElseThrow();
+    assertTrue(approvedDataset.getDacApproval());
+
+    Dataset pendingDataset =
+        datasets.stream()
+            .filter(d -> d.getDatasetId().equals(pendingDatasetId))
+            .findFirst()
+            .orElseThrow();
+    assertNull(pendingDataset.getDacApproval());
+  }
+
+  @Test
   void testFindAllWithDAAs() {
     User user = createUser();
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3774

### Summary

`GET /api/dac` never selected `dac_approval` for the datasets embedded in each DAC, so `dacApproval` was always `null` on that response — causing the Manage DAC table's dataset counts to disagree with the DAC profile page (which uses a different endpoint that does select this column). Added the column to the query and mapped it in `DacReducer`, added a `Dac.getDatasets()` accessor, and added a DAO test covering approved vs. pending datasets.     

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
