### PR TITLE
[DT-3760] Stop creating RP elections and votes

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
 import static org.broadinstitute.consent.http.enumeration.ElectionType.DATA_ACCESS;
-import static org.broadinstitute.consent.http.enumeration.ElectionType.RP;
 import static org.broadinstitute.consent.http.enumeration.UserRoles.ADMIN;
 import static org.broadinstitute.consent.http.resources.Resource.CHAIRPERSON;
 import static org.broadinstitute.consent.http.resources.Resource.MEMBER;
@@ -1030,7 +1029,6 @@ public class DarCollectionService implements ConsentLogger {
           _ -> {
             int dataAccessElectionId =
                 dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, DATA_ACCESS);
-            dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, RP);
 
             Integer dacId = dataset.getDacId();
             Set<User> dacUsers = filterUsersForDac(classification.autoOpenUsers, dacId);

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1030,12 +1030,11 @@ public class DarCollectionService implements ConsentLogger {
           _ -> {
             int dataAccessElectionId =
                 dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, DATA_ACCESS);
-            int rpElectionId =
-                dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, RP);
+            dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, RP);
 
             Integer dacId = dataset.getDacId();
             Set<User> dacUsers = filterUsersForDac(classification.autoOpenUsers, dacId);
-            createVotesForAllUsers(dacUsers, dataAccessElectionId, rpElectionId, latestDar, dacId);
+            createVotesForAllUsers(dacUsers, dataAccessElectionId, latestDar, dacId);
 
             return null;
           });
@@ -1068,40 +1067,31 @@ public class DarCollectionService implements ConsentLogger {
     }
   }
 
-  /** Creates standard votes for all users for the given elections. */
+  /** Creates standard votes for all users for the data access election. */
   @VisibleForTesting
   protected void createVotesForAllUsers(
-      Set<User> users,
-      int dataAccessElectionId,
-      int rpElectionId,
-      DataAccessRequest dar,
-      Integer dacId) {
+      Set<User> users, int dataAccessElectionId, DataAccessRequest dar, Integer dacId) {
 
     for (User user : users) {
-      createStandardVotes(dataAccessElectionId, rpElectionId, user);
+      createStandardVotes(dataAccessElectionId, user);
 
       if (user.verifyDACRole(CHAIRPERSON, dacId)) {
-        createChairpersonVotes(dataAccessElectionId, rpElectionId, user, dar);
+        createChairpersonVotes(dataAccessElectionId, user, dar);
       }
     }
   }
 
-  /** Creates standard votes for the given elections. */
-  private void createStandardVotes(int dataAccessElectionId, int rpElectionId, User user) {
+  /** Creates standard votes for the given election. */
+  private void createStandardVotes(int dataAccessElectionId, User user) {
     dacAutomationRuleService.createVoteForElection(
         dataAccessElectionId, user.getUserId(), VoteType.DAC);
-
-    dacAutomationRuleService.createVoteForElection(rpElectionId, user.getUserId(), VoteType.DAC);
   }
 
-  /** Creates chairperson votes for the given elections. */
-  private void createChairpersonVotes(
-      int dataAccessElectionId, int rpElectionId, User user, DataAccessRequest dar) {
+  /** Creates chairperson votes for the given election. */
+  private void createChairpersonVotes(int dataAccessElectionId, User user, DataAccessRequest dar) {
 
     dacAutomationRuleService.createVoteForElection(
         dataAccessElectionId, user.getUserId(), VoteType.CHAIRPERSON);
-    dacAutomationRuleService.createVoteForElection(
-        rpElectionId, user.getUserId(), VoteType.CHAIRPERSON);
 
     dacAutomationRuleService.createVoteForElection(
         dataAccessElectionId, user.getUserId(), VoteType.FINAL);

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -61,9 +61,7 @@ public class DarCollectionServiceDAO {
           //        3a. Chair Vote for chair
           //        3b. Final Vote for chair
           //        3c. Agreement Vote for chair if not manual review
-          //    4. Create an RP Election
-          //    5. Create member votes for rp election
-          //        5a. Chair Vote for chair
+          //    4. Create an RP Election (no votes are created for RP elections)
 
           // Only take actions on the most recent DAR/Progress report in the collection
           // This means a chair cannot reopen an election in any other DAR in the collection besides
@@ -108,21 +106,12 @@ public class DarCollectionServiceDAO {
                           createVoteInsertsForUsers(
                               handle,
                               voteUsers,
-                              ElectionType.DATA_ACCESS.getValue(),
                               dar.getReferenceId(),
                               datasetId,
                               dar.requiresManualReview()));
                       inserts.add(
                           createElectionInsert(
                               handle, ElectionType.RP.getValue(), dar.getReferenceId(), datasetId));
-                      inserts.addAll(
-                          createVoteInsertsForUsers(
-                              handle,
-                              voteUsers,
-                              ElectionType.RP.getValue(),
-                              dar.getReferenceId(),
-                              datasetId,
-                              dar.requiresManualReview()));
                       createdElectionReferenceIds.add(dar.getReferenceId());
                     }
                   });
@@ -132,55 +121,52 @@ public class DarCollectionServiceDAO {
     return createdElectionReferenceIds;
   }
 
+  /** Creates vote inserts for the DataAccess election. Votes are never created for RP elections. */
   private List<Update> createVoteInsertsForUsers(
       Handle handle,
       List<User> voteUsers,
-      String electionType,
       String referenceId,
       Integer datasetId,
       Boolean isManualReview) {
     List<Update> userVotes = new ArrayList<>();
     voteUsers.forEach(
         u -> {
-          // All users get a minimum of one DAC vote type for both RP and DataAccess election types
+          // All users get a minimum of one DAC vote type
           userVotes.add(
               createVoteInsert(
                   handle,
                   VoteType.DAC.getValue(),
-                  electionType,
+                  ElectionType.DATA_ACCESS.getValue(),
                   referenceId,
                   datasetId,
                   u.getUserId()));
-          // Chairpersons get a Chairperson vote for both RP and DataAccess election types
+          // Chairpersons get Chairperson, Final, and Agreement (if not manual review) votes
           if (u.hasUserRole(UserRoles.CHAIRPERSON)) {
             userVotes.add(
                 createVoteInsert(
                     handle,
                     VoteType.CHAIRPERSON.getValue(),
-                    electionType,
+                    ElectionType.DATA_ACCESS.getValue(),
                     referenceId,
                     datasetId,
                     u.getUserId()));
-            // Chairpersons get Final and Agreement votes for DataAccess elections
-            if (ElectionType.DATA_ACCESS.getValue().equals(electionType)) {
+            userVotes.add(
+                createVoteInsert(
+                    handle,
+                    VoteType.FINAL.getValue(),
+                    ElectionType.DATA_ACCESS.getValue(),
+                    referenceId,
+                    datasetId,
+                    u.getUserId()));
+            if (!isManualReview) {
               userVotes.add(
                   createVoteInsert(
                       handle,
-                      VoteType.FINAL.getValue(),
+                      VoteType.AGREEMENT.getValue(),
                       ElectionType.DATA_ACCESS.getValue(),
                       referenceId,
                       datasetId,
                       u.getUserId()));
-              if (!isManualReview) {
-                userVotes.add(
-                    createVoteInsert(
-                        handle,
-                        VoteType.AGREEMENT.getValue(),
-                        ElectionType.DATA_ACCESS.getValue(),
-                        referenceId,
-                        datasetId,
-                        u.getUserId()));
-              }
             }
           }
         });

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -61,7 +61,6 @@ public class DarCollectionServiceDAO {
           //        3a. Chair Vote for chair
           //        3b. Final Vote for chair
           //        3c. Agreement Vote for chair if not manual review
-          //    4. Create an RP Election (no votes are created for RP elections)
 
           // Only take actions on the most recent DAR/Progress report in the collection
           // This means a chair cannot reopen an election in any other DAR in the collection besides

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAO.java
@@ -109,9 +109,6 @@ public class DarCollectionServiceDAO {
                               dar.getReferenceId(),
                               datasetId,
                               dar.requiresManualReview()));
-                      inserts.add(
-                          createElectionInsert(
-                              handle, ElectionType.RP.getValue(), dar.getReferenceId(), datasetId));
                       createdElectionReferenceIds.add(dar.getReferenceId());
                     }
                   });

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2857,15 +2857,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), any(), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any(), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset, ElectionType.RP);
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
   }
 
   @Test
@@ -2933,8 +2932,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), any(), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any(), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -2964,17 +2961,15 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), any(), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any(), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset, ElectionType.RP);
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
     verify(dacAutomationRuleService).createVoteForElection(100, member.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
   }
 
   @Test
@@ -3012,19 +3007,17 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(closedDataset), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(closedDataset), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    // Only the closed dataset should have elections created
+    // Only the closed dataset should have an election created
     verify(dacAutomationRuleService, never())
         .createOpenElectionForDAR(any(), eq(openDataset), any());
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, closedDataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, closedDataset, ElectionType.RP);
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
   }
 
   @Test
@@ -3149,18 +3142,16 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), any(), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any(), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, dataset1, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset1, ElectionType.RP);
     verify(dacAutomationRuleService)
         .createOpenElectionForDAR(dar, dataset2, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset2, ElectionType.RP);
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
   }
 
   // ─── Full-flow integration: userDAO → classifyDacsAndUsers → vote creation ──
@@ -3221,14 +3212,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(300);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.RP)))
-        .thenReturn(400);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
@@ -3255,9 +3240,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
-    // No votes are created for the RP elections (200, 400)
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
+    // No RP elections (and therefore no RP votes) are created
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 10 vote-creation calls: cross-DAC users received no votes in the wrong elections.
     verify(dacAutomationRuleService, times(10)).createVoteForElection(anyInt(), anyInt(), any());
@@ -3317,9 +3302,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
@@ -3402,14 +3384,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(300);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.RP)))
-        .thenReturn(400);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
@@ -3473,19 +3449,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    // dataset1: DATA_ACCESS=100, RP=200; dataset2: DATA_ACCESS=300, RP=400
+    // dataset1: DATA_ACCESS=100; dataset2: DATA_ACCESS=300
     when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(300);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.RP)))
-        .thenReturn(400);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -3514,9 +3484,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
 
-    // No votes are created for the RP elections (200, 400)
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
+    // No RP elections (and therefore no RP votes) are created
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 10 vote-creation calls: cross-DAC users and member CHAIRPERSON votes are excluded.
     // Any cross-DAC contamination or spurious role promotion would push this count above 10.
@@ -3567,14 +3537,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(300);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.RP)))
-        .thenReturn(400);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -3597,9 +3561,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.AGREEMENT);
-    // No votes are created for the RP elections (200, 400)
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
+    // No RP elections (and therefore no RP votes) are created
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
   }
 
   /**
@@ -3654,14 +3618,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.RP)))
-        .thenReturn(200);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
             any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
         .thenReturn(300);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.RP)))
-        .thenReturn(400);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -3689,9 +3647,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.AGREEMENT);
-    // No votes are created for the RP elections (200, 400)
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
-    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
+    // No RP elections (and therefore no RP votes) are created
+    verify(dacAutomationRuleService, never())
+        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 9 vote-creation calls: cross-DAC isolation and the sharedUser's member (not chair)
     // role in DAC 20 are both enforced — any leakage or spurious promotion pushes the count above

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2974,7 +2974,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
     verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset, ElectionType.RP);
     verify(dacAutomationRuleService).createVoteForElection(100, member.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(200, member.getUserId(), VoteType.DAC);
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
   }
 
   @Test
@@ -3032,7 +3032,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(), 1, 2, dar, 1);
+    service.createVotesForAllUsers(Set.of(), 1, dar, 1);
 
     verifyNoInteractions(dacAutomationRuleService);
   }
@@ -3043,10 +3043,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(member), 10, 20, dar, 1);
+    service.createVotesForAllUsers(Set.of(member), 10, dar, 1);
 
     verify(dacAutomationRuleService).createVoteForElection(10, member.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, member.getUserId(), VoteType.DAC);
     verifyNoMoreInteractions(dacAutomationRuleService);
   }
 
@@ -3057,14 +3056,11 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData()); // all flags null → requiresManualReview() == false
 
-    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar, dacId);
+    service.createVotesForAllUsers(Set.of(chair), 10, dar, dacId);
 
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, chair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chair.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(20, chair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chair.getUserId(), VoteType.AGREEMENT);
@@ -3080,17 +3076,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     data.setPoa(true); // triggers requiresManualReview() == true
     dar.setData(data);
 
-    service.createVotesForAllUsers(Set.of(chair), 10, 20, dar, dacId);
+    service.createVotesForAllUsers(Set.of(chair), 10, dar, dacId);
 
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, chair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chair.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(20, chair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.FINAL);
-    // Exactly 5 vote-creation calls: AGREEMENT is not created when requiresManualReview is true.
-    verify(dacAutomationRuleService, times(5)).createVoteForElection(anyInt(), anyInt(), any());
+    // Exactly 3 vote-creation calls: AGREEMENT is not created when requiresManualReview is true.
+    verify(dacAutomationRuleService, times(3)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   @Test
@@ -3101,21 +3094,17 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(chair, member), 10, 20, dar, dacId);
+    service.createVotesForAllUsers(Set.of(chair, member), 10, dar, dacId);
 
     // chair gets DAC + CHAIRPERSON + FINAL + AGREEMENT votes
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, chair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chair.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(20, chair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService).createVoteForElection(10, chair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chair.getUserId(), VoteType.AGREEMENT);
-    // member gets only DAC votes
+    // member gets only a DAC vote
     verify(dacAutomationRuleService).createVoteForElection(10, member.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService).createVoteForElection(20, member.getUserId(), VoteType.DAC);
     verifyNoMoreInteractions(dacAutomationRuleService);
   }
 
@@ -3128,12 +3117,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataAccessRequest dar = new DataAccessRequest();
     dar.setData(new DataAccessRequestData());
 
-    service.createVotesForAllUsers(Set.of(chairOfOtherDac), 10, 20, dar, electionDacId);
+    service.createVotesForAllUsers(Set.of(chairOfOtherDac), 10, dar, electionDacId);
 
     verify(dacAutomationRuleService)
         .createVoteForElection(10, chairOfOtherDac.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(20, chairOfOtherDac.getUserId(), VoteType.DAC);
     verifyNoMoreInteractions(dacAutomationRuleService);
   }
 
@@ -3250,8 +3237,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(200, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.FINAL);
@@ -3259,13 +3244,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
     // DAC 20 election — only chairDac20 and memberDac20
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, chairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
@@ -3274,11 +3255,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
+    // No votes are created for the RP elections (200, 400)
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
 
-    // Exactly 16 vote-creation calls: cross-DAC users received no votes in the wrong elections.
-    verify(dacAutomationRuleService, times(16)).createVoteForElection(anyInt(), anyInt(), any());
+    // Exactly 10 vote-creation calls: cross-DAC users received no votes in the wrong elections.
+    verify(dacAutomationRuleService, times(10)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**
@@ -3512,41 +3494,33 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(200, chairDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(200, chairDac10.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(200, memberDac10.getUserId(), VoteType.DAC);
 
     // ── dataset2 (DAC 20): chairDac20 gets full chair votes; memberDac20 gets DAC votes only ──
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(400, chairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, chairDac20.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, memberDac20.getUserId(), VoteType.DAC);
 
-    // Exactly 16 vote-creation calls: cross-DAC users and member CHAIRPERSON votes are excluded.
-    // Any cross-DAC contamination or spurious role promotion would push this count above 16.
-    verify(dacAutomationRuleService, times(16)).createVoteForElection(anyInt(), anyInt(), any());
+    // No votes are created for the RP elections (200, 400)
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
+
+    // Exactly 10 vote-creation calls: cross-DAC users and member CHAIRPERSON votes are excluded.
+    // Any cross-DAC contamination or spurious role promotion would push this count above 10.
+    verify(dacAutomationRuleService, times(10)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**
@@ -3609,11 +3583,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedChair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(200, sharedChair.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedChair.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(200, sharedChair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedChair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
@@ -3622,15 +3592,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(400, sharedChair.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, sharedChair.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.AGREEMENT);
+    // No votes are created for the RP elections (200, 400)
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
   }
 
   /**
@@ -3702,11 +3671,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(200, sharedUser.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(200, sharedUser.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, sharedUser.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
@@ -3715,26 +3680,23 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     // sharedUser is member of DAC 20, not chair → only DAC votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedUser.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, sharedUser.getUserId(), VoteType.DAC);
     // separateChairDac20 is chair of DAC 20 → full chair votes
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
-        .createVoteForElection(400, separateChairDac20.getUserId(), VoteType.DAC);
-    verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
-    verify(dacAutomationRuleService)
-        .createVoteForElection(400, separateChairDac20.getUserId(), VoteType.CHAIRPERSON);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.AGREEMENT);
+    // No votes are created for the RP elections (200, 400)
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(200), anyInt(), any());
+    verify(dacAutomationRuleService, never()).createVoteForElection(eq(400), anyInt(), any());
 
-    // Exactly 14 vote-creation calls: cross-DAC isolation and the sharedUser's member (not chair)
+    // Exactly 9 vote-creation calls: cross-DAC isolation and the sharedUser's member (not chair)
     // role in DAC 20 are both enforced — any leakage or spurious promotion pushes the count above
-    // 14.
-    verify(dacAutomationRuleService, times(14)).createVoteForElection(anyInt(), anyInt(), any());
+    // 9.
+    verify(dacAutomationRuleService, times(9)).createVoteForElection(anyInt(), anyInt(), any());
   }
 
   /**

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -69,14 +69,14 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
             createdElections.stream().map(Election::getElectionId).toList());
 
     assertTrue(referenceIds.contains(dar.getReferenceId()));
-    // Ensure that we have an access and rp election
+    // Ensure that we have an access election and no rp election
     assertFalse(createdElections.isEmpty());
     assertTrue(
         createdElections.stream()
             .anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+            .noneMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
     // Ensure that we have primary vote types
     assertFalse(createdVotes.isEmpty());
     assertTrue(
@@ -85,13 +85,6 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
     assertTrue(
         createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
-    // Ensure that no votes were created for the RP election
-    List<Integer> rpElectionIds =
-        createdElections.stream()
-            .filter(e -> e.getElectionType().equals(ElectionType.RP.getValue()))
-            .map(Election::getElectionId)
-            .toList();
-    assertTrue(voteDAO.findVotesByElectionIds(rpElectionIds).isEmpty());
   }
 
   /**
@@ -132,15 +125,14 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
             createdElections.stream().map(Election::getElectionId).toList());
 
     assertTrue(referenceIds.contains(dar.getReferenceId()));
-    assertEquals(2, createdElections.size()); //
-    // Ensure that we have an access and rp election
-    assertFalse(createdElections.isEmpty());
+    // Ensure that we have an access election and no rp election
+    assertEquals(1, createdElections.size());
     assertTrue(
         createdElections.stream()
             .anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+            .noneMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
     // Ensure that we have primary vote types
     assertFalse(createdVotes.isEmpty());
     assertTrue(
@@ -168,7 +160,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertTrue(referenceIds2.contains(dar.getReferenceId()));
 
     createdElections = electionDAO.findElectionsByReferenceId(dar.getReferenceId());
-    assertEquals(4, createdElections.size());
+    assertEquals(2, createdElections.size());
 
     // Verify we have elections for both DACs
     assertTrue(
@@ -270,16 +262,16 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     List<Election> createdElections =
         electionDAO.findLastElectionsByReferenceIds(List.of(dar.getReferenceId()));
 
-    // Ensure that we have the right number of access and rp elections, i.e. 1 each
+    // Ensure that we have exactly one access election and no rp election
     assertFalse(createdElections.isEmpty());
-    assertEquals(2, createdElections.size());
+    assertEquals(1, createdElections.size());
     assertEquals(
         1,
         createdElections.stream()
             .filter(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue()))
             .count());
     assertEquals(
-        1,
+        0,
         createdElections.stream()
             .filter(e -> e.getElectionType().equals(ElectionType.RP.getValue()))
             .count());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -85,6 +85,13 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertTrue(createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.DAC.getValue())));
     assertTrue(
         createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
+    // Ensure that no votes were created for the RP election
+    List<Integer> rpElectionIds =
+        createdElections.stream()
+            .filter(e -> e.getElectionType().equals(ElectionType.RP.getValue()))
+            .map(Election::getElectionId)
+            .toList();
+    assertTrue(voteDAO.findVotesByElectionIds(rpElectionIds).isEmpty());
   }
 
   /**
@@ -143,9 +150,9 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertTrue(
         createdVotes.stream().anyMatch(v -> v.getType().equals(VoteType.AGREEMENT.getValue())));
 
-    assertEquals(
-        8,
-        createdVotes.size()); // 1 dataset X 2 elections/dataset X 4 votes/election each = 8 votes.
+    // 1 dataset X 5 votes for the access election (member DAC + chair DAC/CHAIRPERSON/FINAL/
+    // AGREEMENT); no votes are created for the RP election.
+    assertEquals(5, createdVotes.size());
 
     // Find the dac chairperson for the second Dataset in the DAR.
 
@@ -175,10 +182,8 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     createdVotes =
         voteDAO.findVotesByElectionIds(
             createdElections.stream().map(Election::getElectionId).toList());
-    assertEquals(
-        16,
-        createdVotes
-            .size()); // 2 datasets X 2 elections/dataset X 4 votes/election each = 16 votes.
+    // 2 datasets X 5 votes for each access election; no votes are created for the RP elections.
+    assertEquals(10, createdVotes.size());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3760

### Summary
This PR removes the creation of RP elections and votes. There is more work to do in future PRs.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
