### PR TITLE
[DT-3760] ElectionType Deprecation and Cleanup

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionType.java
@@ -3,11 +3,16 @@ package org.broadinstitute.consent.http.enumeration;
 import java.util.EnumSet;
 import java.util.Optional;
 
+/**
+ * The only election type supported for current use is `DATA_ACCESS`.
+ * `TRANSLATE_DUL`, `RP`, and `DATA_SET` are deprecated and should not be used for new elections.
+ * We are maintaining the deprecated enums to support legacy elections.
+ */
 public enum ElectionType {
   DATA_ACCESS("DataAccess"),
-  TRANSLATE_DUL("TranslateDUL"),
-  RP("RP"),
-  DATA_SET("DataSet");
+  @Deprecated TRANSLATE_DUL("TranslateDUL"),
+  @Deprecated RP("RP"),
+  @Deprecated DATA_SET("DataSet");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionType.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/ElectionType.java
@@ -4,15 +4,18 @@ import java.util.EnumSet;
 import java.util.Optional;
 
 /**
- * The only election type supported for current use is `DATA_ACCESS`.
- * `TRANSLATE_DUL`, `RP`, and `DATA_SET` are deprecated and should not be used for new elections.
- * We are maintaining the deprecated enums to support legacy elections.
+ * The only election type supported for current use is `DATA_ACCESS`. `TRANSLATE_DUL`, `RP`, and
+ * `DATA_SET` are deprecated and should not be used for new elections. We are maintaining the
+ * deprecated enums to support legacy elections.
  */
 public enum ElectionType {
   DATA_ACCESS("DataAccess"),
-  @Deprecated TRANSLATE_DUL("TranslateDUL"),
-  @Deprecated RP("RP"),
-  @Deprecated DATA_SET("DataSet");
+  @Deprecated
+  TRANSLATE_DUL("TranslateDUL"),
+  @Deprecated
+  RP("RP"),
+  @Deprecated
+  DATA_SET("DataSet");
 
   private final String value;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -191,7 +191,7 @@ public class DACAutomationRuleService implements ConsentLogger {
     Vote vote =
         electionDAO.inTransaction(
             _ -> {
-              int electionId = createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
+              int electionId = createOpenElectionForDAR(dar, dataset);
               int voteId =
                   createVoteForElection(electionId, rule.enabledByUserId(), VoteType.RADAR_APPROVE);
               return voteDAO.findVoteById(voteId);
@@ -221,9 +221,9 @@ public class DACAutomationRuleService implements ConsentLogger {
   }
 
   protected int createOpenElectionForDAR(
-      DataAccessRequest dar, Dataset dataset, ElectionType electionType) {
+      DataAccessRequest dar, Dataset dataset) {
     return electionDAO.insertElection(
-        electionType.getValue(),
+        ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
         new Date(),
         dar.getReferenceId(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -220,8 +220,7 @@ public class DACAutomationRuleService implements ConsentLogger {
     return vote;
   }
 
-  protected int createOpenElectionForDAR(
-      DataAccessRequest dar, Dataset dataset) {
+  protected int createOpenElectionForDAR(DataAccessRequest dar, Dataset dataset) {
     return electionDAO.insertElection(
         ElectionType.DATA_ACCESS.getValue(),
         ElectionStatus.OPEN.getValue(),
@@ -234,10 +233,4 @@ public class DACAutomationRuleService implements ConsentLogger {
     return voteDAO.insertVote(userId, electionId, voteType.getValue());
   }
 
-  protected Optional<DACAutomationRule> getEnabledRuleOfInterest(
-      List<DACAutomationRule> dacRules, DACAutomationRuleType ruleType) {
-    return dacRules.stream()
-        .filter(r -> Objects.equals(r.ruleType(), ruleType) && !isNull(r.enabledByUserId()))
-        .findFirst();
-  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -232,5 +232,4 @@ public class DACAutomationRuleService implements ConsentLogger {
   protected int createVoteForElection(int electionId, int userId, VoteType voteType) {
     return voteDAO.insertVote(userId, electionId, voteType.getValue());
   }
-
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1028,7 +1028,7 @@ public class DarCollectionService implements ConsentLogger {
       electionDAO.inTransaction(
           _ -> {
             int dataAccessElectionId =
-                dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset, DATA_ACCESS);
+                dacAutomationRuleService.createOpenElectionForDAR(latestDar, dataset);
 
             Integer dacId = dataset.getDacId();
             Set<User> dacUsers = filterUsersForDac(classification.autoOpenUsers, dacId);

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -592,9 +592,8 @@ public class VoteService implements ConsentLogger {
   }
 
   /**
-   * The Rationale for RP Votes can be updated for any election status. The Rationale for DataAccess
-   * Votes can only be updated for OPEN elections. Votes for elections of other types are not
-   * updatable through this method.
+   * The Rationale for DataAccess Votes can only be updated for OPEN elections.
+   * Votes for elections of other types are not updatable through this method.
    *
    * @param voteIds List of vote ids for DataAccess and RP elections
    * @param rationale The rationale to update
@@ -609,7 +608,8 @@ public class VoteService implements ConsentLogger {
     return findVotesByIds(voteIds);
   }
 
-  private void validateVotesCanUpdate(List<Vote> votes) throws ConsentConflictException {
+  @VisibleForTesting
+  protected void validateVotesCanUpdate(List<Vote> votes) throws ConsentConflictException {
     List<Election> elections =
         electionDAO.findElectionsByIds(votes.stream().map(Vote::getElectionId).toList());
 
@@ -625,12 +625,11 @@ public class VoteService implements ConsentLogger {
           "One or more of these votes are associated with elections not open for voting.");
     }
 
-    // If there are non-DataAccess or non-RP elections, throw an error
+    // If there are non-DataAccess throw an error
     List<Election> disallowedElections =
         elections.stream()
             .filter(
                 election -> !election.getElectionType().equals(ElectionType.DATA_ACCESS.getValue()))
-            .filter(election -> !election.getElectionType().equals(ElectionType.RP.getValue()))
             .toList();
     if (!disallowedElections.isEmpty()) {
       throw new ConsentConflictException(

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -86,33 +86,6 @@ public class VoteService implements ConsentLogger {
   }
 
   /**
-   * Create votes for an election
-   *
-   * @param election The Election
-   * @param electionType The Election type
-   * @param isManualReview Is this a manual review election
-   * @return List of votes
-   */
-  @SuppressWarnings("DuplicatedCode")
-  public List<Vote> createVotes(
-      Election election, ElectionType electionType, Boolean isManualReview) {
-    Dac dac = electionDAO.findDacForElection(election.getElectionId());
-    Set<User> users;
-    if (dac != null) {
-      users = userDAO.findUsersEnabledToVoteByDAC(dac.getDacId());
-    } else {
-      users = userDAO.findNonDacUsersEnabledToVote();
-    }
-    List<Vote> votes = new ArrayList<>();
-    if (users != null) {
-      for (User user : users) {
-        votes.addAll(createVotesForUser(user, election, electionType, isManualReview));
-      }
-    }
-    return votes;
-  }
-
-  /**
    * Create election votes for a user
    *
    * @param user DACUser

--- a/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/VoteService.java
@@ -592,8 +592,8 @@ public class VoteService implements ConsentLogger {
   }
 
   /**
-   * The Rationale for DataAccess Votes can only be updated for OPEN elections.
-   * Votes for elections of other types are not updatable through this method.
+   * The Rationale for DataAccess Votes can only be updated for OPEN elections. Votes for elections
+   * of other types are not updatable through this method.
    *
    * @param voteIds List of vote ids for DataAccess and RP elections
    * @param rationale The rationale to update

--- a/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/AbstractTestHelper.java
@@ -5,10 +5,17 @@ import com.google.gson.JsonParser;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Date;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 
 public abstract class AbstractTestHelper {
+
+  public static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  public static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  public static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   /**
    * This configuration property is set in pom.xml and used to disable test containers for

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -41,11 +40,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ElectionDAOTest extends DAOTestHelper {
 
-  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
-  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
-  private static final Date FIXED_DATE_PLUS_DAY = Date.from(FIXED_INSTANT.plus(Duration.ofDays(1)));
-  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
-  // Must be after FIXED_INSTANT so elections created with FIXED_DATE are included in reminder queries
+  // Must be after FIXED_INSTANT so elections created with FIXED_DATE are included in reminder
+  // queries
   private static final String REMINDER_QUERY_CUTOFF = "2030-01-01T00:00:00Z";
 
   @Test
@@ -159,8 +155,10 @@ class ElectionDAOTest extends DAOTestHelper {
                 electionDAO.updateElectionById(
                     e.getElectionId(), ElectionStatus.CANCELED.getValue(), FIXED_DATE, true));
     // Create a new set of elections
-    Election latestD1Election = createLaterDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
-    Election latestD2Election = createLaterDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
+    Election latestD1Election =
+        createLaterDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
+    Election latestD2Election =
+        createLaterDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
 
     Election latestAccessForD1 =
         electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
@@ -647,7 +645,14 @@ class ElectionDAOTest extends DAOTestHelper {
     data.setMethods(false);
     String referenceId = UUID.randomUUID().toString();
     dataAccessRequestDAO.insertDataAccessRequest(
-        collectionId, referenceId, userId, FIXED_DATE, FIXED_DATE, FIXED_DATE, data, randomAlphabetic(10));
+        collectionId,
+        referenceId,
+        userId,
+        FIXED_DATE,
+        FIXED_DATE,
+        FIXED_DATE,
+        data,
+        randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -666,7 +671,8 @@ class ElectionDAOTest extends DAOTestHelper {
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -700,7 +706,8 @@ class ElectionDAOTest extends DAOTestHelper {
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -721,7 +728,7 @@ class ElectionDAOTest extends DAOTestHelper {
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            FIXED_DATE_PLUS_DAY,
+            Date.from(FIXED_INSTANT.plus(Duration.ofDays(1))),
             referenceId,
             datasetId);
     return electionDAO.findElectionById(electionId);

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ElectionDAOTest extends DAOTestHelper {
 
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  private static final Date FIXED_DATE_PLUS_DAY = Date.from(FIXED_INSTANT.plus(Duration.ofDays(1)));
+  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
+  // Must be after FIXED_INSTANT so elections created with FIXED_DATE are included in reminder queries
+  private static final String REMINDER_QUERY_CUTOFF = "2030-01-01T00:00:00Z";
+
   @Test
   void testGetElectionIdsByReferenceIds() {
     String accessReferenceId1 = UUID.randomUUID().toString();
@@ -67,7 +75,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
@@ -135,7 +143,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     Dataset d2 = createDataset();
@@ -149,10 +157,10 @@ class ElectionDAOTest extends DAOTestHelper {
         .forEach(
             e ->
                 electionDAO.updateElectionById(
-                    e.getElectionId(), ElectionStatus.CANCELED.getValue(), new Date(), true));
+                    e.getElectionId(), ElectionStatus.CANCELED.getValue(), FIXED_DATE, true));
     // Create a new set of elections
-    Election latestD1Election = createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
-    Election latestD2Election = createDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
+    Election latestD1Election = createLaterDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
+    Election latestD2Election = createLaterDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
 
     Election latestAccessForD1 =
         electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
@@ -174,7 +182,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -192,7 +200,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset dataset = createDataset();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
@@ -211,7 +219,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
 
@@ -226,7 +234,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
@@ -234,7 +242,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Election e = createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
     Integer voteId =
         voteDAO.insertVote(u.getUserId(), e.getElectionId(), VoteType.FINAL.getValue());
-    updateVote(true, "rationale", new Date(), voteId, false, e.getElectionId(), new Date(), false);
+    updateVote(true, "rationale", FIXED_DATE, voteId, false, e.getElectionId(), FIXED_DATE, false);
     Vote v = voteDAO.findVoteById(voteId);
 
     Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
@@ -261,7 +269,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d = createDataset();
     User u = createUserWithRoleInDac(UserRoles.CHAIRPERSON.getRoleId(), dac.getDacId());
@@ -271,7 +279,7 @@ class ElectionDAOTest extends DAOTestHelper {
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            new Date(),
+            FIXED_DATE,
             dar.getReferenceId(),
             d.getDatasetId());
     Election e = electionDAO.findElectionById(electionId);
@@ -358,13 +366,11 @@ class ElectionDAOTest extends DAOTestHelper {
     String referenceId = dar.getReferenceId();
     Integer datasetId = dataset.getDatasetId();
 
-    Date d = new Date();
-
     Integer id =
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            d,
+            FIXED_DATE,
             referenceId,
             datasetId);
 
@@ -391,7 +397,7 @@ class ElectionDAOTest extends DAOTestHelper {
     assertNull(before.getLastUpdate());
 
     electionDAO.updateElectionById(
-        before.getElectionId(), ElectionStatus.FINAL.getValue(), new Date());
+        before.getElectionId(), ElectionStatus.FINAL.getValue(), FIXED_DATE);
 
     Election after = electionDAO.findElectionById(before.getElectionId());
 
@@ -414,7 +420,7 @@ class ElectionDAOTest extends DAOTestHelper {
     assertNull(before.getFinalAccessVote());
 
     electionDAO.updateElectionById(
-        before.getElectionId(), ElectionStatus.FINAL.getValue(), new Date(), true);
+        before.getElectionId(), ElectionStatus.FINAL.getValue(), FIXED_DATE, true);
 
     Election after = electionDAO.findElectionById(before.getElectionId());
 
@@ -498,7 +504,7 @@ class ElectionDAOTest extends DAOTestHelper {
     User user = createUser();
     String darCode = "DAR-1234567890";
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
@@ -508,7 +514,7 @@ class ElectionDAOTest extends DAOTestHelper {
         electionDAO.findElectionsByReferenceIdAndDatasetId(dar.getReferenceId(), d1.getDatasetId());
     List<Integer> electionIds = elections.stream().map(Election::getElectionId).toList();
 
-    electionDAO.archiveElectionByIds(electionIds, new Date());
+    electionDAO.archiveElectionByIds(electionIds, FIXED_DATE);
     List<Election> archivedElections = electionDAO.findElectionsByIds(electionIds);
     archivedElections.forEach(e -> assertTrue(e.getArchived()));
   }
@@ -541,7 +547,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Election e3 = createDataAccessElection(referenceId, datasetId);
     Election closed = createDataAccessElection(referenceId, datasetId);
     electionDAO.updateElectionById(
-        closed.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date());
+        closed.getElectionId(), ElectionStatus.CLOSED.getValue(), FIXED_DATE);
 
     List<Election> found = electionDAO.findOpenElectionsByDacId(dac.getDacId());
 
@@ -562,7 +568,7 @@ class ElectionDAOTest extends DAOTestHelper {
 
     List<UserVoteReminder> userVoteReminders =
         electionDAO.findElectionReminders(
-            -1, EmailType.COLLECT.getTypeInt(), Instant.now().toString());
+            -1, EmailType.COLLECT.getTypeInt(), REMINDER_QUERY_CUTOFF);
     assertEquals(1, userVoteReminders.size());
     assertEquals(1, userVoteReminders.getFirst().getUserReminderList().size());
     Reminder reminder = userVoteReminders.getFirst().getUserReminderList().getFirst();
@@ -580,14 +586,14 @@ class ElectionDAOTest extends DAOTestHelper {
 
     List<UserVoteReminder> userVoteReminders =
         electionDAO.findElectionReminders(
-            -1, EmailType.COLLECT.getTypeInt(), Instant.now().toString());
+            -1, EmailType.COLLECT.getTypeInt(), REMINDER_QUERY_CUTOFF);
     assertEquals(0, userVoteReminders.size());
   }
 
   @Test
   void testFindVotesThatNeedReminders_AlreadyEmailed() {
     Vote vote = createElectionAndVote();
-    String referenceId = Instant.now().toString();
+    String referenceId = "fixed-test-reminder-reference-id";
     Integer emailType = EmailType.COLLECT.getTypeInt();
     mailMessageDAO.insert(
         new MailMessageInsert(
@@ -595,7 +601,7 @@ class ElectionDAOTest extends DAOTestHelper {
             vote.getVoteId(),
             vote.getUserId(),
             emailType,
-            Date.from(Instant.now()),
+            FIXED_DATE,
             "Extra, Extra!",
             null,
             null));
@@ -627,27 +633,21 @@ class ElectionDAOTest extends DAOTestHelper {
   }
 
   private DataAccessRequest createDataAccessRequestWithUserIdV3(Integer userId, String darCode) {
-    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, userId, new Date());
+    Integer collectionId = darCollectionDAO.insertDarCollection(darCode, userId, FIXED_DATE);
     for (int i = 0; i < 4; i++) {
       createDataAccessRequest(userId, collectionId);
     }
     return createDataAccessRequest(userId, collectionId);
   }
 
-  /**
-   * Creates a new user, dataset, data access request, and dar collection
-   *
-   * @return Populated DataAccessRequest
-   */
   private DataAccessRequest createDataAccessRequest(Integer userId, Integer collectionId) {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
     data.setHmb(true);
     data.setMethods(false);
     String referenceId = UUID.randomUUID().toString();
-    Date now = new Date();
     dataAccessRequestDAO.insertDataAccessRequest(
-        collectionId, referenceId, userId, now, now, now, data, randomAlphabetic(10));
+        collectionId, referenceId, userId, FIXED_DATE, FIXED_DATE, FIXED_DATE, data, randomAlphabetic(10));
     return dataAccessRequestDAO.findByReferenceId(referenceId);
   }
 
@@ -663,11 +663,10 @@ class ElectionDAOTest extends DAOTestHelper {
   private Dataset createDataset() {
     User user = createUser();
     String name = "Name_" + randomAlphabetic(20);
-    Timestamp now = new Timestamp(new Date().getTime());
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);
+        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -678,7 +677,7 @@ class ElectionDAOTest extends DAOTestHelper {
     dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
-    dsp.setCreateDate(new Date());
+    dsp.setCreateDate(FIXED_DATE);
     list.add(dsp);
     datasetDAO.insertDatasetProperties(list);
   }
@@ -686,7 +685,7 @@ class ElectionDAOTest extends DAOTestHelper {
   private void createLibraryCard(User user) {
     Integer id =
         libraryCardDAO.insertLibraryCard(
-            user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), new Date());
+            user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), FIXED_DATE);
     libraryCardDAO.findLibraryCardById(id);
   }
 
@@ -698,11 +697,10 @@ class ElectionDAOTest extends DAOTestHelper {
   private Dataset createDatasetWithDac(Integer dacId) {
     User user = createUser();
     String name = "Name_" + randomAlphabetic(20);
-    Timestamp now = new Timestamp(new Date().getTime());
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), dacId);
+        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -712,7 +710,18 @@ class ElectionDAOTest extends DAOTestHelper {
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            new Date(),
+            FIXED_DATE,
+            referenceId,
+            datasetId);
+    return electionDAO.findElectionById(electionId);
+  }
+
+  private Election createLaterDataAccessElection(String referenceId, Integer datasetId) {
+    Integer electionId =
+        electionDAO.insertElection(
+            ElectionType.DATA_ACCESS.getValue(),
+            ElectionStatus.OPEN.getValue(),
+            FIXED_DATE_PLUS_DAY,
             referenceId,
             datasetId);
     return electionDAO.findElectionById(electionId);

--- a/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ElectionDAOTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -141,62 +142,31 @@ class ElectionDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d2.getDatasetId());
     // Create OPEN elections
-    List<Integer> firstElectionIds =
-        Stream.of(createElectionsForDarDataset(dar, d1), createElectionsForDarDataset(dar, d2))
-            .flatMap(List::stream)
-            .toList();
+    Election firstD1Election = createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
+    Election firstD2Election = createDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
     // Cancel those elections
-    firstElectionIds.forEach(
-        id ->
-            electionDAO.updateElectionById(
-                id, ElectionStatus.CANCELED.getValue(), new Date(), true));
+    Stream.of(firstD1Election, firstD2Election)
+        .forEach(
+            e ->
+                electionDAO.updateElectionById(
+                    e.getElectionId(), ElectionStatus.CANCELED.getValue(), new Date(), true));
     // Create a new set of elections
-    List<Integer> latestElectionIds =
-        Stream.of(createElectionsForDarDataset(dar, d1), createElectionsForDarDataset(dar, d2))
-            .flatMap(List::stream)
-            .toList();
+    Election latestD1Election = createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
+    Election latestD2Election = createDataAccessElection(dar.getReferenceId(), d2.getDatasetId());
 
     Election latestAccessForD1 =
         electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
             dar.getReferenceId(), d1.getDatasetId(), ElectionType.DATA_ACCESS.getValue());
     assertNotNull(latestAccessForD1);
-    assertFalse(firstElectionIds.contains(latestAccessForD1.getElectionId()));
-    assertTrue(latestElectionIds.contains(latestAccessForD1.getElectionId()));
-
-    Election latestRPForD1 =
-        electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-            dar.getReferenceId(), d1.getDatasetId(), ElectionType.RP.getValue());
-    assertNotNull(latestRPForD1);
-    assertFalse(firstElectionIds.contains(latestRPForD1.getElectionId()));
-    assertTrue(latestElectionIds.contains(latestRPForD1.getElectionId()));
+    assertNotEquals(firstD1Election.getElectionId(), latestAccessForD1.getElectionId());
+    assertEquals(latestD1Election.getElectionId(), latestAccessForD1.getElectionId());
 
     Election latestAccessForD2 =
         electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
             dar.getReferenceId(), d2.getDatasetId(), ElectionType.DATA_ACCESS.getValue());
     assertNotNull(latestAccessForD2);
-    assertFalse(firstElectionIds.contains(latestAccessForD2.getElectionId()));
-    assertTrue(latestElectionIds.contains(latestAccessForD2.getElectionId()));
-
-    Election latestRPForD2 =
-        electionDAO.findLastElectionByReferenceIdDatasetIdAndType(
-            dar.getReferenceId(), d2.getDatasetId(), ElectionType.RP.getValue());
-    assertNotNull(latestRPForD2);
-    assertFalse(firstElectionIds.contains(latestRPForD2.getElectionId()));
-    assertTrue(latestElectionIds.contains(latestRPForD2.getElectionId()));
-  }
-
-  /**
-   * Small helper method for `testFindLastElectionByReferenceIdDatasetIdAndType()` Creates OPEN
-   * Access and RP elections for dar/dataset combination
-   *
-   * @param dar DataAccessRequest
-   * @param d Dataset
-   * @return List of created electionIds
-   */
-  private List<Integer> createElectionsForDarDataset(DataAccessRequest dar, Dataset d) {
-    Election accessElection = createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
-    Election rpElection = createRPElection(dar.getReferenceId(), d.getDatasetId());
-    return List.of(accessElection.getElectionId(), rpElection.getElectionId());
+    assertNotEquals(firstD2Election.getElectionId(), latestAccessForD2.getElectionId());
+    assertEquals(latestD2Election.getElectionId(), latestAccessForD2.getElectionId());
   }
 
   @Test
@@ -208,7 +178,7 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
-    createRPElection(dar.getReferenceId(), d1.getDatasetId());
+    createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
     createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
 
     List<Election> elections =
@@ -274,60 +244,11 @@ class ElectionDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testRPFindElectionWithFinalVoteById() {
-    User u = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-    Dac dac = createDac();
-    User user = createUser();
-    String darCode = "DAR-1234567890";
-    Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
-    Dataset d = createDataset();
-    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
-
-    Election e = createRPElection(dar.getReferenceId(), d.getDatasetId());
-    Vote v = createPopulatedChairpersonVote(u.getUserId(), e.getElectionId());
-
-    Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
-    assertNotNull(election);
-    assertEquals(e.getElectionId(), election.getElectionId());
-    assertEquals(v.getVote(), election.getFinalVote());
-  }
-
-  @Test
-  void testDULFindElectionWithFinalVoteById() {
-    User u = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-    Dac dac = createDac();
-    User user = createUser();
-    String darCode = "DAR-1234567890";
-    Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
-    DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
-    Dataset d = createDataset();
-    datasetDAO.updateDatasetDacId(d.getDatasetId(), dac.getDacId());
-
-    Integer electionId =
-        electionDAO.insertElection(
-            ElectionType.TRANSLATE_DUL.getValue(),
-            ElectionStatus.OPEN.getValue(),
-            new Date(),
-            dar.getReferenceId(),
-            d.getDatasetId());
-    Election e = electionDAO.findElectionById(electionId);
-    Vote v = createPopulatedChairpersonVote(u.getUserId(), e.getElectionId());
-
-    Election election = electionDAO.findElectionWithFinalVoteById(e.getElectionId());
-    assertNotNull(election);
-    assertEquals(e.getElectionId(), election.getElectionId());
-    assertEquals(v.getVote(), election.getFinalVote());
-  }
-
-  @Test
   void testFindElectionsByReferenceIdCase1() {
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset d = createDataset();
     createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
-    createRPElection(dar.getReferenceId(), d.getDatasetId());
+    createDataAccessElection(dar.getReferenceId(), d.getDatasetId());
 
     List<Election> elections = electionDAO.findElectionsByReferenceId(dar.getReferenceId());
     assertNotNull(elections);
@@ -374,14 +295,12 @@ class ElectionDAOTest extends DAOTestHelper {
 
     Election recentClosedAccessElection =
         createDataAccessElection(darReferenceId, dataset.getDatasetId());
-    Election recentClosedRPElection = createRPElection(darReferenceId, datasetId);
     List<Election> elections =
         electionDAO.findLastElectionsByReferenceIds(Collections.singletonList(dar.referenceId));
     List<Integer> electionIds = elections.stream().map(Election::getElectionId).toList();
     assertFalse(elections.isEmpty());
-    assertEquals(2, elections.size());
+    assertEquals(1, elections.size());
     assertTrue(electionIds.contains(recentClosedAccessElection.getElectionId()));
-    assertTrue(electionIds.contains(recentClosedRPElection.getElectionId()));
   }
 
   @Test
@@ -399,35 +318,14 @@ class ElectionDAOTest extends DAOTestHelper {
     String referenceId = dar.getReferenceId();
     int datasetId = dataset.getDatasetId();
     Election accessElection = createDataAccessElection(referenceId, datasetId);
-    Election rpElection = createRPElection(referenceId, datasetId);
     User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     int userId = user.getUserId();
     Vote accessVote = createChairpersonVote(userId, accessElection.getElectionId());
-    Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
-    List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
+    List<Integer> voteIds = List.of(accessVote.getVoteId());
     List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "dataaccess");
 
     assertEquals(1, elections.size());
     assertEquals(accessElection.getElectionId(), elections.getFirst().getElectionId());
-  }
-
-  @Test
-  void testFindElectionsByVoteIdsAndType_RP() {
-    DataAccessRequest dar = createDataAccessRequestV3();
-    Dataset dataset = createDataset();
-    String referenceId = dar.getReferenceId();
-    int datasetId = dataset.getDatasetId();
-    Election accessElection = createDataAccessElection(referenceId, datasetId);
-    Election rpElection = createRPElection(referenceId, datasetId);
-    User user = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-    int userId = user.getUserId();
-    Vote accessVote = createChairpersonVote(userId, accessElection.getElectionId());
-    Vote rpVote = createChairpersonVote(userId, rpElection.getElectionId());
-    List<Integer> voteIds = List.of(accessVote.getVoteId(), rpVote.getVoteId());
-    List<Election> elections = electionDAO.findElectionsByVoteIdsAndType(voteIds, "rp");
-
-    assertEquals(1, elections.size());
-    assertEquals(rpElection.getElectionId(), elections.getFirst().getElectionId());
   }
 
   @Test
@@ -567,16 +465,16 @@ class ElectionDAOTest extends DAOTestHelper {
     Integer datasetId = dataset.getDatasetId();
 
     Election datasetAccessElection = createDataAccessElection(referenceId, datasetId);
-    Election rpElection = createRPElection(referenceId, datasetId);
+    Election secondAccessElection = createDataAccessElection(referenceId, datasetId);
 
     List<Election> found =
         electionDAO.findElectionsByIds(
-            List.of(datasetAccessElection.getElectionId(), rpElection.getElectionId()));
+            List.of(datasetAccessElection.getElectionId(), secondAccessElection.getElectionId()));
 
     assertEquals(2, found.size());
 
     assertTrue(found.contains(datasetAccessElection));
-    assertTrue(found.contains(rpElection));
+    assertTrue(found.contains(secondAccessElection));
   }
 
   @Test
@@ -604,7 +502,7 @@ class ElectionDAOTest extends DAOTestHelper {
     DataAccessRequest dar = createDataAccessRequest(user.getUserId(), collectionId);
     Dataset d1 = createDataset();
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), d1.getDatasetId());
-    createRPElection(dar.getReferenceId(), d1.getDatasetId());
+    createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
     createDataAccessElection(dar.getReferenceId(), d1.getDatasetId());
     List<Election> elections =
         electionDAO.findElectionsByReferenceIdAndDatasetId(dar.getReferenceId(), d1.getDatasetId());
@@ -639,7 +537,7 @@ class ElectionDAOTest extends DAOTestHelper {
     Integer datasetId = dataset.getDatasetId();
 
     Election e1 = createDataAccessElection(referenceId, datasetId);
-    Election e2 = createRPElection(referenceId, datasetId);
+    Election e2 = createDataAccessElection(referenceId, datasetId);
     Election e3 = createDataAccessElection(referenceId, datasetId);
     Election closed = createDataAccessElection(referenceId, datasetId);
     electionDAO.updateElectionById(
@@ -721,12 +619,6 @@ class ElectionDAOTest extends DAOTestHelper {
     Integer v1 =
         voteDAO.insertVote(chairperson.getUserId(), e1.getElectionId(), VoteType.FINAL.getValue());
     return voteDAO.findVoteById(v1);
-  }
-
-  private Vote createPopulatedChairpersonVote(Integer userId, Integer electionId) {
-    Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.CHAIRPERSON.getValue());
-    updateVote(true, "rationale", new Date(), voteId, false, electionId, new Date(), false);
-    return voteDAO.findVoteById(voteId);
   }
 
   private Vote createChairpersonVote(Integer userId, Integer electionId) {
@@ -813,17 +705,6 @@ class ElectionDAOTest extends DAOTestHelper {
         datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), dacId);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
-  }
-
-  private Election createRPElection(String referenceId, Integer datasetId) {
-    Integer electionId =
-        electionDAO.insertElection(
-            ElectionType.RP.getValue(),
-            ElectionStatus.OPEN.getValue(),
-            new Date(),
-            referenceId,
-            datasetId);
-    return electionDAO.findElectionById(electionId);
   }
 
   private Election createDataAccessElection(String referenceId, Integer datasetId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -6,15 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
-import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
@@ -29,6 +28,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MatchDAOTest extends DAOTestHelper {
+
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   @Test
   void testFindMatchesByPurposeId() {
@@ -49,7 +52,7 @@ class MatchDAOTest extends DAOTestHelper {
     match.setConsent(consentId);
     match.setPurpose(UUID.randomUUID().toString());
     match.setFailed(false);
-    match.setCreateDate(new Date());
+    match.setCreateDate(FIXED_DATE);
     match.setMatch(randomBoolean());
     match.setAlgorithmVersion(MatchAlgorithm.V1.getVersion());
     match.setAbstain(false);
@@ -97,7 +100,7 @@ class MatchDAOTest extends DAOTestHelper {
         darReferenceId,
         true,
         false,
-        new Date(),
+        FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         false);
 
@@ -107,7 +110,7 @@ class MatchDAOTest extends DAOTestHelper {
         ignoredAccessElection.getReferenceId(),
         false,
         false,
-        new Date(),
+        FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         false);
 
@@ -118,7 +121,7 @@ class MatchDAOTest extends DAOTestHelper {
         unknownElection.getReferenceId(),
         false,
         false,
-        new Date(),
+        FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         true);
 
@@ -148,7 +151,7 @@ class MatchDAOTest extends DAOTestHelper {
         accessElection.getReferenceId(),
         true,
         false,
-        new Date(),
+        FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         false);
 
@@ -159,7 +162,7 @@ class MatchDAOTest extends DAOTestHelper {
         unknownElection.getReferenceId(),
         false,
         false,
-        new Date(),
+        FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         false);
 
@@ -215,8 +218,8 @@ class MatchDAOTest extends DAOTestHelper {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
-    match.addRationale(RandomStringUtils.randomAlphabetic(100));
-    match.addRationale(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(randomAlphabetic(100));
+    match.addRationale(randomAlphabetic(100));
     Integer matchId =
         matchDAO.insertMatch(
             match.getConsent(),
@@ -243,29 +246,27 @@ class MatchDAOTest extends DAOTestHelper {
             dar.getReferenceId(),
             randomBoolean(),
             false,
-            new Date(),
+            FIXED_DATE,
             MatchAlgorithm.V4.getVersion(),
             false);
     return matchDAO.findMatchById(matchId);
   }
 
-  private Dac createDac() {
-    Integer id =
-        dacDAO.createDac(
-            "Test_" + randomAlphanumeric(20),
-            "Test_" + randomAlphanumeric(20),
-            createUser().getUserId());
-    return dacDAO.findById(id);
+  private void createDac() {
+    dacDAO.createDac(
+        "Test_" + randomAlphanumeric(20),
+        "Test_" + randomAlphanumeric(20),
+        createUser().getUserId());
   }
 
   private Dataset createDataset() {
     User user = createUser();
     String name = "Name_" + randomAlphanumeric(20);
-    Timestamp now = new Timestamp(new Date().getTime());
     String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -276,7 +277,7 @@ class MatchDAOTest extends DAOTestHelper {
     dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
-    dsp.setCreateDate(new Date());
+    dsp.setCreateDate(FIXED_DATE);
     list.add(dsp);
     datasetDAO.insertDatasetProperties(list);
   }
@@ -284,7 +285,7 @@ class MatchDAOTest extends DAOTestHelper {
   private Election createUnknownElection(String referenceId, Integer datasetId) {
     Integer electionId =
         electionDAO.insertElection(
-            "UnknownElection", ElectionStatus.OPEN.getValue(), new Date(), referenceId, datasetId);
+            "UnknownElection", ElectionStatus.OPEN.getValue(), FIXED_DATE, referenceId, datasetId);
     return electionDAO.findElectionById(electionId);
   }
 
@@ -293,7 +294,7 @@ class MatchDAOTest extends DAOTestHelper {
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            new Date(),
+            FIXED_DATE,
             referenceId,
             datasetId);
     return electionDAO.findElectionById(electionId);

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -11,7 +11,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
@@ -37,7 +36,7 @@ class MatchDAOTest extends DAOTestHelper {
 
     List<Match> matches = matchDAO.findMatchesByPurposeId(m.getPurpose());
     assertFalse(matches.isEmpty());
-    Match found = matches.get(0);
+    Match found = matches.getFirst();
     assertEquals(found.getId(), m.getId());
     assertEquals(found.getPurpose(), m.getPurpose());
     assertEquals(found.getConsent(), m.getConsent());
@@ -51,7 +50,7 @@ class MatchDAOTest extends DAOTestHelper {
     match.setPurpose(UUID.randomUUID().toString());
     match.setFailed(false);
     match.setCreateDate(new Date());
-    match.setMatch(RandomUtils.nextBoolean());
+    match.setMatch(randomBoolean());
     match.setAlgorithmVersion(MatchAlgorithm.V1.getVersion());
     match.setAbstain(false);
     return match;
@@ -126,7 +125,7 @@ class MatchDAOTest extends DAOTestHelper {
     List<Match> matchResults =
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
     assertEquals(1, matchResults.size());
-    Match result = matchResults.get(0);
+    Match result = matchResults.getFirst();
     assertEquals(targetElection.getReferenceId(), result.getPurpose());
   }
 
@@ -194,8 +193,8 @@ class MatchDAOTest extends DAOTestHelper {
     Match match = makeMockMatch(UUID.randomUUID().toString());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
-    match.addRationale(RandomStringUtils.randomAlphabetic(100));
-    match.addRationale(RandomStringUtils.randomAlphabetic(100));
+    match.addRationale(randomAlphabetic(100));
+    match.addRationale(randomAlphabetic(100));
     Integer matchId =
         matchDAO.insertMatch(
             match.getConsent(),
@@ -242,7 +241,7 @@ class MatchDAOTest extends DAOTestHelper {
         matchDAO.insertMatch(
             dataset.getDatasetIdentifier(),
             dar.getReferenceId(),
-            RandomUtils.nextBoolean(),
+            randomBoolean(),
             false,
             new Date(),
             MatchAlgorithm.V4.getVersion(),
@@ -253,17 +252,17 @@ class MatchDAOTest extends DAOTestHelper {
   private Dac createDac() {
     Integer id =
         dacDAO.createDac(
-            "Test_" + RandomStringUtils.random(20, true, true),
-            "Test_" + RandomStringUtils.random(20, true, true),
+            "Test_" + randomAlphanumeric(20),
+            "Test_" + randomAlphanumeric(20),
             createUser().getUserId());
     return dacDAO.findById(id);
   }
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
         datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -87,8 +87,8 @@ class MatchDAOTest extends DAOTestHelper {
     Election ignoredAccessElection =
         createDataAccessElection(UUID.randomUUID().toString(), dataset.getDatasetId());
 
-    // Generate RP election to test that the query only references DataAccess elections
-    Election rpElection = createRPElection(UUID.randomUUID().toString(), dataset.getDatasetId());
+    // Generate an unknown election to test that the query only references DataAccess elections
+    Election unknownElection = createUnknownElection(UUID.randomUUID().toString(), dataset.getDatasetId());
     String datasetIdentifier = dataset.getDatasetIdentifier();
 
     // This match represents the match record generated for the target election
@@ -115,7 +115,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
         datasetIdentifier,
-        rpElection.getReferenceId(),
+        unknownElection.getReferenceId(),
         false,
         false,
         new Date(),
@@ -138,8 +138,8 @@ class MatchDAOTest extends DAOTestHelper {
     Election accessElection =
         createDataAccessElection(UUID.randomUUID().toString(), dataset.getDatasetId());
 
-    // Generate RP election for test
-    Election rpElection = createRPElection(darReferenceId, dataset.getDatasetId());
+    // Generate an unknown election for test
+    Election unknownElection = createUnknownElection(darReferenceId, dataset.getDatasetId());
     String datasetIdentifier = dataset.getDatasetIdentifier();
 
     // This match represents the match record generated for the access election
@@ -156,7 +156,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
         datasetIdentifier,
-        rpElection.getReferenceId(),
+        unknownElection.getReferenceId(),
         false,
         false,
         new Date(),
@@ -281,10 +281,10 @@ class MatchDAOTest extends DAOTestHelper {
     datasetDAO.insertDatasetProperties(list);
   }
 
-  private Election createRPElection(String referenceId, Integer datasetId) {
+  private Election createUnknownElection(String referenceId, Integer datasetId) {
     Integer electionId =
         electionDAO.insertElection(
-            ElectionType.RP.getValue(),
+            "UnknownElection",
             ElectionStatus.OPEN.getValue(),
             new Date(),
             referenceId,

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -5,10 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
@@ -28,10 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MatchDAOTest extends DAOTestHelper {
-
-  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
-  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
-  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   @Test
   void testFindMatchesByPurposeId() {

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -88,7 +88,8 @@ class MatchDAOTest extends DAOTestHelper {
         createDataAccessElection(UUID.randomUUID().toString(), dataset.getDatasetId());
 
     // Generate an unknown election to test that the query only references DataAccess elections
-    Election unknownElection = createUnknownElection(UUID.randomUUID().toString(), dataset.getDatasetId());
+    Election unknownElection =
+        createUnknownElection(UUID.randomUUID().toString(), dataset.getDatasetId());
     String datasetIdentifier = dataset.getDatasetIdentifier();
 
     // This match represents the match record generated for the target election
@@ -284,11 +285,7 @@ class MatchDAOTest extends DAOTestHelper {
   private Election createUnknownElection(String referenceId, Integer datasetId) {
     Integer electionId =
         electionDAO.insertElection(
-            "UnknownElection",
-            ElectionStatus.OPEN.getValue(),
-            new Date(),
-            referenceId,
-            datasetId);
+            "UnknownElection", ElectionStatus.OPEN.getValue(), new Date(), referenceId, datasetId);
     return electionDAO.findElectionById(electionId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -459,10 +459,6 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
     signingOfficial.setEmail("1" + researcher.getEmail());
     signingOfficial.setUserId(9);
     DataAccessRequest dar = makeDAR();
-    DataAccessRequestData darData = new DataAccessRequestData();
-    darData.setSigningOfficialEmail(signingOfficial.getEmail());
-    dar.setApprovingSigningOfficialApprovedDate(FIXED_TIMESTAMP);
-    dar.setApprovingSigningOfficialUserId(signingOfficial.getUserId());
 
     String referenceId = dar.getReferenceId();
     List<Integer> datasetIds = List.of(1, 2);

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,6 +32,8 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.enumeration.VoteType;
 import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
@@ -53,10 +56,12 @@ import org.broadinstitute.consent.http.rules.RuleState;
 import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.transaction.TransactionalCallback;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -647,6 +652,49 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testOpenElectionAndApprove_transactionLambdaCreatesElectionAndVote() {
+    DACAutomationRule rule = makeDacAutomationRuleGRU();
+    RuleImplementationInterface ruleImplementation = new GeneralResearchUseV1();
+    DataAccessRequest dar = makeDAR();
+    Dataset dataset = makeDataset();
+
+    int expectedElectionId = 10;
+    int expectedVoteId = 20;
+    Vote expectedVote = new Vote();
+    expectedVote.setVoteId(expectedVoteId);
+
+    DACAutomationRuleService serviceSpy = spy(service);
+    doReturn(expectedElectionId).when(serviceSpy).createOpenElectionForDAR(dar, dataset);
+    doReturn(expectedVoteId)
+        .when(serviceSpy)
+        .createVoteForElection(expectedElectionId, rule.enabledByUserId(), VoteType.RADAR_APPROVE);
+    when(voteDAO.findVoteById(expectedVoteId)).thenReturn(expectedVote);
+
+    // Make inTransaction actually execute its lambda body
+    doAnswer(
+            invocation -> {
+              TransactionalCallback<Vote, ElectionDAO, Exception> cb = invocation.getArgument(0);
+              return cb.inTransaction(electionDAO);
+            })
+        .when(electionDAO)
+        .inTransaction(any());
+
+    // Stub the rest of the method so it completes successfully
+    when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any()))
+        .thenReturn(List.of(expectedVote));
+    when(userDAO.findUserById(rule.enabledByUserId())).thenReturn(user);
+
+    Vote result =
+        serviceSpy.openElectionAndApprove(rule, ruleImplementation, dar, dataset, request);
+
+    assertEquals(expectedVote, result);
+    verify(serviceSpy).createOpenElectionForDAR(dar, dataset);
+    verify(serviceSpy)
+        .createVoteForElection(expectedElectionId, rule.enabledByUserId(), VoteType.RADAR_APPROVE);
+    verify(voteDAO).findVoteById(expectedVoteId);
+  }
+
+  @Test
   void testGetRuleImplementation() {
     DACAutomationRule gruRule = makeDacAutomationRuleGRU();
 
@@ -671,5 +719,120 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
             IllegalArgumentException.class,
             () -> DACAutomationRuleService.getRuleImplementation(mockRule));
     assertEquals("No rule implementation found for type: MOCK_TYPE", exception.getMessage());
+  }
+
+  // createOpenElectionForDAR tests
+
+  @Test
+  void testCreateOpenElectionForDAR_returnsElectionId() {
+    DataAccessRequest dar = makeDAR();
+    Dataset dataset = makeDataset();
+    when(electionDAO.insertElection(
+            eq(ElectionType.DATA_ACCESS.getValue()),
+            eq(ElectionStatus.OPEN.getValue()),
+            any(Date.class),
+            eq(dar.getReferenceId()),
+            eq(dataset.getDatasetId())))
+        .thenReturn(42);
+
+    int result = service.createOpenElectionForDAR(dar, dataset);
+
+    assertEquals(42, result);
+  }
+
+  @Test
+  void testCreateOpenElectionForDAR_usesDataAccessTypeAndOpenStatus() {
+    DataAccessRequest dar = makeDAR();
+    Dataset dataset = makeDataset();
+    ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
+    when(electionDAO.insertElection(any(), any(), any(), any(), any())).thenReturn(1);
+
+    service.createOpenElectionForDAR(dar, dataset);
+
+    verify(electionDAO)
+        .insertElection(typeCaptor.capture(), statusCaptor.capture(), any(), any(), any());
+    assertEquals(ElectionType.DATA_ACCESS.getValue(), typeCaptor.getValue());
+    assertEquals(ElectionStatus.OPEN.getValue(), statusCaptor.getValue());
+  }
+
+  @Test
+  void testCreateOpenElectionForDAR_passesDarReferenceIdAndDatasetId() {
+    DataAccessRequest dar = makeDAR();
+    Dataset dataset = makeDataset(7, "Custom Dataset", 3);
+    ArgumentCaptor<String> referenceIdCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Integer> datasetIdCaptor = ArgumentCaptor.forClass(Integer.class);
+    when(electionDAO.insertElection(any(), any(), any(), any(), any())).thenReturn(1);
+
+    service.createOpenElectionForDAR(dar, dataset);
+
+    verify(electionDAO)
+        .insertElection(
+            any(), any(), any(), referenceIdCaptor.capture(), datasetIdCaptor.capture());
+    assertEquals(dar.getReferenceId(), referenceIdCaptor.getValue());
+    assertEquals(dataset.getDatasetId(), datasetIdCaptor.getValue());
+  }
+
+  @Test
+  void testCreateOpenElectionForDAR_passesNonNullDate() {
+    DataAccessRequest dar = makeDAR();
+    Dataset dataset = makeDataset();
+    ArgumentCaptor<Date> dateCaptor = ArgumentCaptor.forClass(Date.class);
+    when(electionDAO.insertElection(any(), any(), any(), any(), any())).thenReturn(1);
+
+    service.createOpenElectionForDAR(dar, dataset);
+
+    verify(electionDAO).insertElection(any(), any(), dateCaptor.capture(), any(), any());
+    assertNotNull(dateCaptor.getValue());
+  }
+
+  // createVoteForElection tests
+
+  @Test
+  void testCreateVoteForElection_returnsVoteId() {
+    when(voteDAO.insertVote(anyInt(), anyInt(), any())).thenReturn(55);
+
+    int result = service.createVoteForElection(10, 20, VoteType.RADAR_APPROVE);
+
+    assertEquals(55, result);
+  }
+
+  @Test
+  void testCreateVoteForElection_passesArgumentsInCorrectOrder() {
+    int electionId = 100;
+    int userId = 200;
+    ArgumentCaptor<Integer> userIdCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> electionIdCaptor = ArgumentCaptor.forClass(Integer.class);
+    when(voteDAO.insertVote(anyInt(), anyInt(), any())).thenReturn(1);
+
+    service.createVoteForElection(electionId, userId, VoteType.RADAR_APPROVE);
+
+    // insertVote signature is (userId, electionId, type) — note the swap from
+    // createVoteForElection's (electionId, userId, voteType)
+    verify(voteDAO).insertVote(userIdCaptor.capture(), electionIdCaptor.capture(), any());
+    assertEquals(userId, userIdCaptor.getValue());
+    assertEquals(electionId, electionIdCaptor.getValue());
+  }
+
+  @Test
+  void testCreateVoteForElection_passesVoteTypeValue() {
+    ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+    when(voteDAO.insertVote(anyInt(), anyInt(), any())).thenReturn(1);
+
+    service.createVoteForElection(1, 1, VoteType.RADAR_APPROVE);
+
+    verify(voteDAO).insertVote(anyInt(), anyInt(), typeCaptor.capture());
+    assertEquals(VoteType.RADAR_APPROVE.getValue(), typeCaptor.getValue());
+  }
+
+  @Test
+  void testCreateVoteForElection_withFinalVoteType() {
+    ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+    when(voteDAO.insertVote(anyInt(), anyInt(), any())).thenReturn(1);
+
+    service.createVoteForElection(1, 1, VoteType.FINAL);
+
+    verify(voteDAO).insertVote(anyInt(), anyInt(), typeCaptor.capture());
+    assertEquals(VoteType.FINAL.getValue(), typeCaptor.getValue());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -21,11 +21,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -62,7 +61,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class DACAutomationRuleServiceTest {
+class DACAutomationRuleServiceTest extends AbstractTestHelper {
 
   @Mock private Jdbi jdbi;
   @Mock private DataAccessRequestDAO dataAccessRequestDAO;
@@ -88,7 +87,7 @@ class DACAutomationRuleServiceTest {
         DACAutomationRuleType.GRU_V1,
         "Test Rule",
         RuleState.AVAILABLE,
-        Timestamp.from(Instant.now()),
+        FIXED_TIMESTAMP,
         1,
         "admin",
         "admin@example.com");
@@ -210,7 +209,7 @@ class DACAutomationRuleServiceTest {
                     DACAutomationRuleType.GRU_V1,
                     "Test Rule",
                     RuleState.AVAILABLE,
-                    Timestamp.from(Instant.now()),
+                    FIXED_TIMESTAMP,
                     1,
                     "alice",
                     "alice@fake.org")));
@@ -231,7 +230,7 @@ class DACAutomationRuleServiceTest {
                     DACAutomationRuleType.GRU_V1,
                     "Test Rule",
                     RuleState.AVAILABLE,
-                    Timestamp.from(Instant.now()),
+                    FIXED_TIMESTAMP,
                     1,
                     "alice",
                     "alice@fake.org")));
@@ -248,7 +247,7 @@ class DACAutomationRuleServiceTest {
                     DACAutomationRuleType.AUTO_OPEN_DAR_FOR_ALL_MEMBERS,
                     "Test Rule",
                     RuleState.AVAILABLE,
-                    Timestamp.from(Instant.now()),
+                    FIXED_TIMESTAMP,
                     1,
                     "alice",
                     "alice@fake.org"),
@@ -349,13 +348,13 @@ class DACAutomationRuleServiceTest {
         List.of(
             new DACAutomationRuleAudit(
                 RuleAuditAction.ADD,
-                Timestamp.from(Instant.now()),
+                FIXED_TIMESTAMP,
                 DACAutomationRuleType.GRU_V1,
                 "user1@example.com",
                 "User One"),
             new DACAutomationRuleAudit(
                 RuleAuditAction.REMOVE,
-                Timestamp.from(Instant.now()),
+                FIXED_TIMESTAMP,
                 DACAutomationRuleType.HMB_DSV1,
                 "user2@example.com",
                 "User Two"));
@@ -398,7 +397,7 @@ class DACAutomationRuleServiceTest {
             DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL,
             "SO Required Rule",
             RuleState.AVAILABLE,
-            Timestamp.from(Instant.now()),
+            FIXED_TIMESTAMP,
             null,
             "SO Rule",
             activeRule.userEmail());
@@ -462,7 +461,7 @@ class DACAutomationRuleServiceTest {
     DataAccessRequest dar = makeDAR();
     DataAccessRequestData darData = new DataAccessRequestData();
     darData.setSigningOfficialEmail(signingOfficial.getEmail());
-    dar.setApprovingSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
+    dar.setApprovingSigningOfficialApprovedDate(FIXED_TIMESTAMP);
     dar.setApprovingSigningOfficialUserId(signingOfficial.getUserId());
 
     String referenceId = dar.getReferenceId();
@@ -475,7 +474,7 @@ class DACAutomationRuleServiceTest {
             DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL,
             "SO Required Rule",
             RuleState.AVAILABLE,
-            Timestamp.from(Instant.now()),
+            FIXED_TIMESTAMP,
             1,
             "SO Rule",
             activeRule.userEmail());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2854,15 +2854,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any()))
-        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any())).thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset);
   }
 
   @Test
@@ -2927,9 +2924,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(
             dar.getReferenceId(), dataset.getDatasetId()))
         .thenReturn(List.of(oldElection));
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any()))
-        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any())).thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -2956,15 +2951,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any()))
-        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any())).thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset);
     verify(dacAutomationRuleService).createVoteForElection(100, member.getUserId(), VoteType.DAC);
   }
 
@@ -3000,18 +2992,15 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(
             dar.getReferenceId(), closedDataset.getDatasetId()))
         .thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(closedDataset)))
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(closedDataset)))
         .thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     // Only the closed dataset should have an election created
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), eq(openDataset));
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, closedDataset);
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), eq(openDataset));
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, closedDataset);
   }
 
   @Test
@@ -3133,17 +3122,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any()))
-        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), any())).thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset1);
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset2);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset1);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset2);
   }
 
   // ─── Full-flow integration: userDAO → classifyDacsAndUsers → vote creation ──
@@ -3200,12 +3185,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2)))
-        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset2))).thenReturn(300);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
@@ -3288,16 +3269,13 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
 
     // DAC 10 auto-open → elections and votes created
-    verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset1);
+    verify(dacAutomationRuleService).createOpenElectionForDAR(dar, dataset1);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
@@ -3369,12 +3347,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2)))
-        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset2))).thenReturn(300);
     stubInTransactionToExecute();
 
     service.createElectionsForNewDarCollection(1);
@@ -3439,12 +3413,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     // dataset1: DATA_ACCESS=100; dataset2: DATA_ACCESS=300
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2)))
-        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset2))).thenReturn(300);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -3518,12 +3488,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2)))
-        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset2))).thenReturn(300);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
@@ -3596,12 +3562,8 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findLastElectionByReferenceIdDatasetIdAndType(any(), anyInt(), any()))
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1)))
-        .thenReturn(100);
-    when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2)))
-        .thenReturn(300);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset1))).thenReturn(100);
+    when(dacAutomationRuleService.createOpenElectionForDAR(any(), eq(dataset2))).thenReturn(300);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -2027,11 +2027,11 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dataAccessElection.setStatus(ElectionStatus.CLOSED.getValue());
     summary.addElection(dataAccessElection);
 
-    Election rpElection = new Election();
-    rpElection.setElectionId(2);
-    rpElection.setElectionType(ElectionType.RP.getValue());
-    rpElection.setStatus(ElectionStatus.OPEN.getValue());
-    summary.addElection(rpElection);
+    Election unknownElection = new Election();
+    unknownElection.setElectionId(2);
+    unknownElection.setElectionType("Unknown");
+    unknownElection.setStatus(ElectionStatus.OPEN.getValue());
+    summary.addElection(unknownElection);
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
             user.getUserId(), List.of(), collectionId))
@@ -2067,12 +2067,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     dataAccessElection.setStatus(ElectionStatus.CLOSED.getValue());
     summary.addElection(dataAccessElection);
 
-    Election rpElection = new Election();
-    rpElection.setElectionId(2);
-    rpElection.setDatasetId(datasetId);
-    rpElection.setElectionType(ElectionType.RP.getValue());
-    rpElection.setStatus(ElectionStatus.CLOSED.getValue());
-    summary.addElection(rpElection);
+    Election unknownElection = new Election();
+    unknownElection.setElectionId(2);
+    unknownElection.setDatasetId(datasetId);
+    unknownElection.setElectionType("Unknown");
+    unknownElection.setStatus(ElectionStatus.CLOSED.getValue());
+    summary.addElection(unknownElection);
 
     when(darCollectionSummaryDAO.getDarCollectionSummaryForDACByCollectionId(
             user.getUserId(), List.of(), collectionId))
@@ -2855,16 +2855,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any(), eq(ElectionType.DATA_ACCESS)))
+            any(), any()))
         .thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
+        .createOpenElectionForDAR(dar, dataset);
   }
 
   @Test
@@ -2905,7 +2903,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     verify(electionDAO)
         .findLastElectionByReferenceIdDatasetIdAndType(
             dar.getReferenceId(), dataset.getDatasetId(), ElectionType.DATA_ACCESS.getValue());
-    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any(), any());
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any());
     verify(electionDAO, never()).inTransaction(any());
   }
 
@@ -2930,7 +2928,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             dar.getReferenceId(), dataset.getDatasetId()))
         .thenReturn(List.of(oldElection));
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any(), eq(ElectionType.DATA_ACCESS)))
+            any(), any()))
         .thenReturn(100);
     stubInTransactionToExecute();
 
@@ -2959,16 +2957,14 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any(), eq(ElectionType.DATA_ACCESS)))
+            any(), any()))
         .thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
+        .createOpenElectionForDAR(dar, dataset);
     verify(dacAutomationRuleService).createVoteForElection(100, member.getUserId(), VoteType.DAC);
   }
 
@@ -3005,7 +3001,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
             dar.getReferenceId(), closedDataset.getDatasetId()))
         .thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(closedDataset), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(closedDataset)))
         .thenReturn(100);
     stubInTransactionToExecute();
 
@@ -3013,11 +3009,9 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     // Only the closed dataset should have an election created
     verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), eq(openDataset), any());
+        .createOpenElectionForDAR(any(), eq(openDataset));
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, closedDataset, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
+        .createOpenElectionForDAR(dar, closedDataset);
   }
 
   @Test
@@ -3140,18 +3134,16 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), any(), eq(ElectionType.DATA_ACCESS)))
+            any(), any()))
         .thenReturn(100);
     stubInTransactionToExecute();
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset1, ElectionType.DATA_ACCESS);
+        .createOpenElectionForDAR(dar, dataset1);
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset2, ElectionType.DATA_ACCESS);
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
+        .createOpenElectionForDAR(dar, dataset2);
   }
 
   // ─── Full-flow integration: userDAO → classifyDacsAndUsers → vote creation ──
@@ -3209,10 +3201,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset2)))
         .thenReturn(300);
     stubInTransactionToExecute();
 
@@ -3240,9 +3232,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
-    // No RP elections (and therefore no RP votes) are created
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 10 vote-creation calls: cross-DAC users received no votes in the wrong elections.
     verify(dacAutomationRuleService, times(10)).createVoteForElection(anyInt(), anyInt(), any());
@@ -3300,7 +3289,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     stubInTransactionToExecute();
 
@@ -3308,7 +3297,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     // DAC 10 auto-open → elections and votes created
     verify(dacAutomationRuleService)
-        .createOpenElectionForDAR(dar, dataset1, ElectionType.DATA_ACCESS);
+        .createOpenElectionForDAR(dar, dataset1);
     verify(dacAutomationRuleService)
         .createVoteForElection(100, chairDac10.getUserId(), VoteType.DAC);
     verify(dacAutomationRuleService)
@@ -3317,7 +3306,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(100, memberDac10.getUserId(), VoteType.DAC);
 
     // DAC 20 manual → no election created, no votes for chairDac20
-    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), eq(dataset2), any());
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), eq(dataset2));
     verify(dacAutomationRuleService, never())
         .createVoteForElection(anyInt(), eq(chairDac20.getUserId()), any());
   }
@@ -3381,10 +3370,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset2)))
         .thenReturn(300);
     stubInTransactionToExecute();
 
@@ -3451,10 +3440,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     // dataset1: DATA_ACCESS=100; dataset2: DATA_ACCESS=300
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset2)))
         .thenReturn(300);
     stubInTransactionToExecute();
 
@@ -3483,10 +3472,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, chairDac20.getUserId(), VoteType.AGREEMENT);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, memberDac20.getUserId(), VoteType.DAC);
-
-    // No RP elections (and therefore no RP votes) are created
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 10 vote-creation calls: cross-DAC users and member CHAIRPERSON votes are excluded.
     // Any cross-DAC contamination or spurious role promotion would push this count above 10.
@@ -3534,10 +3519,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset2)))
         .thenReturn(300);
     stubInTransactionToExecute();
 
@@ -3561,9 +3546,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, sharedChair.getUserId(), VoteType.AGREEMENT);
-    // No RP elections (and therefore no RP votes) are created
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
   }
 
   /**
@@ -3615,10 +3597,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .thenReturn(null);
     when(electionDAO.findElectionsByReferenceIdAndDatasetId(any(), anyInt())).thenReturn(List.of());
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset1), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset1)))
         .thenReturn(100);
     when(dacAutomationRuleService.createOpenElectionForDAR(
-            any(), eq(dataset2), eq(ElectionType.DATA_ACCESS)))
+            any(), eq(dataset2)))
         .thenReturn(300);
     stubInTransactionToExecute();
 
@@ -3647,9 +3629,6 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.FINAL);
     verify(dacAutomationRuleService)
         .createVoteForElection(300, separateChairDac20.getUserId(), VoteType.AGREEMENT);
-    // No RP elections (and therefore no RP votes) are created
-    verify(dacAutomationRuleService, never())
-        .createOpenElectionForDAR(any(), any(), eq(ElectionType.RP));
 
     // Exactly 9 vote-creation calls: cross-DAC isolation and the sharedUser's member (not chair)
     // role in DAC 20 are both enforced — any leakage or spurious promotion pushes the count above
@@ -3715,7 +3694,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     service.createElectionsForNewDarCollection(1);
 
     // No elections or votes created when auto-open is off
-    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any(), any());
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any());
     verify(dacAutomationRuleService, never()).createVoteForElection(anyInt(), anyInt(), any());
   }
 
@@ -4317,7 +4296,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     service.createElectionsAndVotesForAutoOpenDacs(classification, dar);
 
-    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any(), any());
+    verify(dacAutomationRuleService, never()).createOpenElectionForDAR(any(), any());
     verify(dacAutomationRuleService, never()).createVoteForElection(anyInt(), anyInt(), any());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -17,10 +17,7 @@ import static org.mockito.Mockito.when;
 import com.google.gson.JsonArray;
 import freemarker.template.TemplateException;
 import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -71,10 +68,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceTest extends AbstractTestHelper {
-
-  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
-  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
-  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   private VoteService service;
 

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -72,6 +72,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class VoteServiceTest extends AbstractTestHelper {
 
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
+
   private VoteService service;
 
   @Mock private Jdbi jdbi;
@@ -360,7 +364,7 @@ class VoteServiceTest extends AbstractTestHelper {
     dar1.addDatasetId(d1.getDatasetId());
     dar1.setCollectionId(1);
     dar1.setData(data1);
-    dar1.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar1.setSubmissionDate(FIXED_TIMESTAMP);
     dar1.setParentId(5);
     dar1.setReferenceId(referenceId1);
     d1.setProperties(Set.of(depositorProp));
@@ -708,7 +712,6 @@ class VoteServiceTest extends AbstractTestHelper {
     DatasetProperty depositorProp = new DatasetProperty();
     depositorProp.setPropertyName("Data Depositor");
     depositorProp.setPropertyValue("depositor@test.com");
-    depositorProp.setSchemaProperty("dataDepositorEmail");
     depositorProp.setPropertyType(PropertyType.String);
 
     Dataset d1 = new Dataset();
@@ -1055,7 +1058,7 @@ class VoteServiceTest extends AbstractTestHelper {
                 DatasetRegistrationSchemaV1Builder.url,
                 dataLocationUrl,
                 PropertyType.String,
-                new Date())));
+                FIXED_DATE)));
 
     Dataset dataset2 = new Dataset();
     dataset1.setDatasetId(2);
@@ -1084,12 +1087,12 @@ class VoteServiceTest extends AbstractTestHelper {
     parent.setId(1);
     parent.setReferenceId(UUID.randomUUID().toString());
     parent.setDatasetIds(List.of(dataset.getDatasetId()));
-    parent.setSubmissionDate(Timestamp.from(Instant.now()));
+    parent.setSubmissionDate(FIXED_TIMESTAMP);
 
     DataAccessRequest child = new DataAccessRequest();
     child.setReferenceId(UUID.randomUUID().toString());
     child.setParentId(parent.getId());
-    child.setSubmissionDate(Timestamp.from(Instant.now()));
+    child.setSubmissionDate(FIXED_TIMESTAMP);
     child.setDatasetIds(List.of(dataset.getDatasetId()));
 
     User researcher = createUserWithRole(UserRoles.RESEARCHER);

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1173,20 +1172,6 @@ class VoteServiceTest extends AbstractTestHelper {
     role.setName(userRoles.getRoleName());
     newUser.setRoles(Collections.singletonList(role));
     return newUser;
-  }
-
-  private void setUpUserAndElectionVotes(UserRoles userRoles) {
-    User localUser = new User();
-    localUser.setUserId(randomInt(1, 10));
-    UserRole chairRole = new UserRole();
-    chairRole.setUserId(localUser.getUserId());
-    chairRole.setRoleId(userRoles.getRoleId());
-    chairRole.setName(userRoles.getRoleName());
-    localUser.setRoles(Collections.singletonList(chairRole));
-    when(userDAO.findNonDacUsersEnabledToVote()).thenReturn(Collections.singleton(localUser));
-    Vote v = new Vote();
-    v.setVoteId(1);
-    when(voteDAO.findVoteById(anyInt())).thenReturn(v);
   }
 
   private Vote setUpTestVote() {

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -64,6 +64,7 @@ import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
+import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -207,28 +208,6 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testChairCreateVotesTranslateDUL() {
-    setUpUserAndElectionVotes(UserRoles.CHAIRPERSON);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.TRANSLATE_DUL, false);
-    assertFalse(votes.isEmpty());
-    // Should create 2 votes:
-    // Chairperson as a chair
-    // Chairperson as a dac member
-    assertEquals(2, votes.size());
-  }
-
-  @Test
-  void testMemberCreateVotesTranslateDUL() {
-    setUpUserAndElectionVotes(UserRoles.MEMBER);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.TRANSLATE_DUL, false);
-    assertFalse(votes.isEmpty());
-    // Should create 1 member vote
-    assertEquals(1, votes.size());
-  }
-
-  @Test
   void testChairCreateVotesRP() {
     setUpUserAndElectionVotes(UserRoles.CHAIRPERSON);
 
@@ -250,25 +229,24 @@ class VoteServiceTest extends AbstractTestHelper {
     assertEquals(1, votes.size());
   }
 
+  // TODO: Rewrite the test intention here
+  @Ignore
   @Test
   void testUpdateVotesWithValue_NoRationale() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote();
-    when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any())).thenReturn(List.of(v));
 
     Election accessElection = new Election();
     accessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
     accessElection.setStatus(ElectionStatus.OPEN.getValue());
-    Election rpElection = new Election();
-    rpElection.setElectionType(ElectionType.RP.getValue());
-    rpElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, rpElection));
+    Election unknownElection = new Election();
+    unknownElection.setElectionType("Unknown");
+    unknownElection.setStatus(ElectionStatus.OPEN.getValue());
+    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
 
-    try {
-      service.updateVotesWithValue(List.of(v), true, null, user);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertThrows(
+        ConsentConflictException.class,
+        () -> service.updateVotesWithValue(List.of(v), true, null, user));
   }
 
   @Test
@@ -320,66 +298,60 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_OpenRPElection() {
-    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.OPEN);
+  void testUpdateVotesWithValue_OpenNonDataAccessElection() {
+    testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus.OPEN);
   }
 
   @Test
-  void testUpdateVotesWithValue_ClosedRPElection() {
-    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.CLOSED);
+  void testUpdateVotesWithValue_ClosedNonDataAccessElection() {
+    testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus.CLOSED);
   }
 
   @Test
-  void testUpdateVotesWithValue_CanceledRPElection() {
-    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.CANCELED);
+  void testUpdateVotesWithValue_CanceledNonDataAccessElection() {
+    testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus.CANCELED);
   }
 
   @Test
-  void testUpdateVotesWithValue_FinalRPElection() {
-    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.FINAL);
+  void testUpdateVotesWithValue_FinalNonDataAccessElection() {
+    testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus.FINAL);
   }
 
   @Test
-  void testUpdateVotesWithValue_PendingApprovalRPElection() {
-    testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus.PENDING_APPROVAL);
+  void testUpdateVotesWithValue_PendingApprovalNonDataAccessElection() {
+    testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus.PENDING_APPROVAL);
   }
 
   @Test
   void testUpdateVotesWithValue_MultipleElectionTypes() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote();
-    when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any())).thenReturn(List.of(v));
 
     Election accessElection = new Election();
     accessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
     accessElection.setStatus(ElectionStatus.OPEN.getValue());
-    Election rpElection = new Election();
-    rpElection.setElectionType(ElectionType.RP.getValue());
-    rpElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, rpElection));
+    Election unknownElection = new Election();
+    unknownElection.setElectionType("Unknown");
+    unknownElection.setStatus(ElectionStatus.OPEN.getValue());
+    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
 
-    try {
-      service.updateVotesWithValue(List.of(v), true, "rationale", user);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertThrows(
+        ConsentConflictException.class,
+        () -> service.updateVotesWithValue(List.of(v), true, "rationale", user));
   }
 
-  private void testUpdateVotesWithValue_RPElectionWithStatus(ElectionStatus status) {
+  private void testUpdateVotesWithValue_NonDataAccessElectionWithStatus(ElectionStatus status) {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote();
-    when(voteServiceDAO.updateVotesWithValue(any(), anyBoolean(), any())).thenReturn(List.of(v));
 
     Election rpElection = new Election();
-    rpElection.setElectionType(ElectionType.RP.getValue());
+    rpElection.setElectionType("Unknown Status");
     rpElection.setStatus(status.getValue());
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(rpElection));
 
-    try {
-      service.updateVotesWithValue(List.of(v), true, "rationale", user);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertThrows(
+        ConsentConflictException.class,
+        () -> service.updateVotesWithValue(List.of(v), true, "rationale", user));
   }
 
   @Test
@@ -395,23 +367,20 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testUpdateRationaleByVoteIds_DataAccessAndRPElections() {
-    doNothing().when(voteDAO).updateRationaleByVoteIds(any(), any());
+  void testUpdateRationaleByVoteIds_DataAccessAndNonDataAccessElections() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
 
     Election accessElection = new Election();
     accessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
     accessElection.setStatus(ElectionStatus.OPEN.getValue());
-    Election rpElection = new Election();
-    rpElection.setElectionType(ElectionType.RP.getValue());
-    rpElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, rpElection));
+    Election unknownElection = new Election();
+    unknownElection.setElectionType("Unknown");
+    unknownElection.setStatus(ElectionStatus.OPEN.getValue());
+    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
 
-    try {
-      service.updateRationaleByVoteIds(List.of(1), "rationale");
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertThrows(
+        ConsentConflictException.class,
+        () -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -419,17 +388,6 @@ class VoteServiceTest extends AbstractTestHelper {
     Election election = new Election();
     election.setElectionType(ElectionType.DATA_ACCESS.getValue());
     election.setStatus(ElectionStatus.CLOSED.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
-    List<Integer> votes = List.of(1);
-    assertThrows(
-        ConsentConflictException.class, () -> service.updateRationaleByVoteIds(votes, "rationale"));
-  }
-
-  @Test
-  void testUpdateRationaleByVoteIds_NonDataAccessElection() {
-    Election election = new Election();
-    election.setElectionType(ElectionType.TRANSLATE_DUL.getValue());
-    election.setStatus(ElectionStatus.OPEN.getValue());
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(election));
     List<Integer> votes = List.of(1);
     assertThrows(
@@ -1315,5 +1273,156 @@ class VoteServiceTest extends AbstractTestHelper {
     v.setIsReminderSent(true);
     v.setVote(true);
     return v;
+  }
+
+  // validateVotesCanUpdate tests
+
+  @Test
+  void testValidateVotesCanUpdate_openDataAccessElections_noException() {
+    Vote v1 = new Vote();
+    v1.setVoteId(1);
+    v1.setElectionId(10);
+    Vote v2 = new Vote();
+    v2.setVoteId(2);
+    v2.setElectionId(11);
+
+    Election e1 = new Election();
+    e1.setElectionId(10);
+    e1.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    e1.setStatus(ElectionStatus.OPEN.getValue());
+
+    Election e2 = new Election();
+    e2.setElectionId(11);
+    e2.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    e2.setStatus(ElectionStatus.OPEN.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10, 11))).thenReturn(List.of(e1, e2));
+
+    assertDoesNotThrow(() -> service.validateVotesCanUpdate(List.of(v1, v2)));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_emptyVotesList_noException() {
+    when(electionDAO.findElectionsByIds(List.of())).thenReturn(List.of());
+
+    assertDoesNotThrow(() -> service.validateVotesCanUpdate(List.of()));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_closedDataAccessElection_throwsConflict() {
+    Vote v = new Vote();
+    v.setVoteId(1);
+    v.setElectionId(10);
+
+    Election e = new Election();
+    e.setElectionId(10);
+    e.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    e.setStatus(ElectionStatus.CLOSED.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10))).thenReturn(List.of(e));
+
+    List<Vote> votes = List.of(v);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_canceledDataAccessElection_throwsConflict() {
+    Vote v = new Vote();
+    v.setVoteId(1);
+    v.setElectionId(10);
+
+    Election e = new Election();
+    e.setElectionId(10);
+    e.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    e.setStatus(ElectionStatus.CANCELED.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10))).thenReturn(List.of(e));
+
+    List<Vote> votes = List.of(v);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_finalDataAccessElection_throwsConflict() {
+    Vote v = new Vote();
+    v.setVoteId(1);
+    v.setElectionId(10);
+
+    Election e = new Election();
+    e.setElectionId(10);
+    e.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    e.setStatus(ElectionStatus.FINAL.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10))).thenReturn(List.of(e));
+
+    List<Vote> votes = List.of(v);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_nonDataAccessElectionType_throwsConflict() {
+    Vote v = new Vote();
+    v.setVoteId(1);
+    v.setElectionId(10);
+
+    Election e = new Election();
+    e.setElectionId(10);
+    e.setElectionType("RP");
+    e.setStatus(ElectionStatus.OPEN.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10))).thenReturn(List.of(e));
+
+    List<Vote> votes = List.of(v);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_mixedDataAccessOpenAndClosed_throwsConflict() {
+    Vote v1 = new Vote();
+    v1.setVoteId(1);
+    v1.setElectionId(10);
+    Vote v2 = new Vote();
+    v2.setVoteId(2);
+    v2.setElectionId(11);
+
+    Election openElection = new Election();
+    openElection.setElectionId(10);
+    openElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    openElection.setStatus(ElectionStatus.OPEN.getValue());
+
+    Election closedElection = new Election();
+    closedElection.setElectionId(11);
+    closedElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    closedElection.setStatus(ElectionStatus.CLOSED.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10, 11))).thenReturn(List.of(openElection, closedElection));
+
+    List<Vote> votes = List.of(v1, v2);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
+  }
+
+  @Test
+  void testValidateVotesCanUpdate_dataAccessOpenAndNonDataAccessType_throwsConflict() {
+    Vote v1 = new Vote();
+    v1.setVoteId(1);
+    v1.setElectionId(10);
+    Vote v2 = new Vote();
+    v2.setVoteId(2);
+    v2.setElectionId(11);
+
+    Election dataAccessElection = new Election();
+    dataAccessElection.setElectionId(10);
+    dataAccessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
+    dataAccessElection.setStatus(ElectionStatus.OPEN.getValue());
+
+    Election rpElection = new Election();
+    rpElection.setElectionId(11);
+    rpElection.setElectionType("RP");
+    rpElection.setStatus(ElectionStatus.OPEN.getValue());
+
+    when(electionDAO.findElectionsByIds(List.of(10, 11))).thenReturn(List.of(dataAccessElection, rpElection));
+
+    List<Vote> votes = List.of(v1, v2);
+    assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -64,7 +64,6 @@ import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -229,8 +228,6 @@ class VoteServiceTest extends AbstractTestHelper {
     assertEquals(1, votes.size());
   }
 
-  // TODO: Rewrite the test intention here
-  @Ignore
   @Test
   void testUpdateVotesWithValue_NoRationale() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
@@ -239,15 +236,13 @@ class VoteServiceTest extends AbstractTestHelper {
     Election accessElection = new Election();
     accessElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
     accessElection.setStatus(ElectionStatus.OPEN.getValue());
-    Election unknownElection = new Election();
-    unknownElection.setElectionType("Unknown");
-    unknownElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any()))
-        .thenReturn(List.of(accessElection, unknownElection));
+    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection));
 
-    assertThrows(
-        ConsentConflictException.class,
-        () -> service.updateVotesWithValue(List.of(v), true, null, user));
+    try {
+      service.updateVotesWithValue(List.of(v), true, null, user);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -242,7 +242,8 @@ class VoteServiceTest extends AbstractTestHelper {
     Election unknownElection = new Election();
     unknownElection.setElectionType("Unknown");
     unknownElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
+    when(electionDAO.findElectionsByIds(any()))
+        .thenReturn(List.of(accessElection, unknownElection));
 
     assertThrows(
         ConsentConflictException.class,
@@ -333,7 +334,8 @@ class VoteServiceTest extends AbstractTestHelper {
     Election unknownElection = new Election();
     unknownElection.setElectionType("Unknown");
     unknownElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
+    when(electionDAO.findElectionsByIds(any()))
+        .thenReturn(List.of(accessElection, unknownElection));
 
     assertThrows(
         ConsentConflictException.class,
@@ -376,7 +378,8 @@ class VoteServiceTest extends AbstractTestHelper {
     Election unknownElection = new Election();
     unknownElection.setElectionType("Unknown");
     unknownElection.setStatus(ElectionStatus.OPEN.getValue());
-    when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection, unknownElection));
+    when(electionDAO.findElectionsByIds(any()))
+        .thenReturn(List.of(accessElection, unknownElection));
 
     assertThrows(
         ConsentConflictException.class,
@@ -1395,7 +1398,8 @@ class VoteServiceTest extends AbstractTestHelper {
     closedElection.setElectionType(ElectionType.DATA_ACCESS.getValue());
     closedElection.setStatus(ElectionStatus.CLOSED.getValue());
 
-    when(electionDAO.findElectionsByIds(List.of(10, 11))).thenReturn(List.of(openElection, closedElection));
+    when(electionDAO.findElectionsByIds(List.of(10, 11)))
+        .thenReturn(List.of(openElection, closedElection));
 
     List<Vote> votes = List.of(v1, v2);
     assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));
@@ -1420,7 +1424,8 @@ class VoteServiceTest extends AbstractTestHelper {
     rpElection.setElectionType("RP");
     rpElection.setStatus(ElectionStatus.OPEN.getValue());
 
-    when(electionDAO.findElectionsByIds(List.of(10, 11))).thenReturn(List.of(dataAccessElection, rpElection));
+    when(electionDAO.findElectionsByIds(List.of(10, 11)))
+        .thenReturn(List.of(dataAccessElection, rpElection));
 
     List<Vote> votes = List.of(v1, v2);
     assertThrows(ConsentConflictException.class, () -> service.validateVotesCanUpdate(votes));

--- a/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/VoteServiceTest.java
@@ -1,12 +1,10 @@
 package org.broadinstitute.consent.http.service;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -170,65 +168,6 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testChairCreateVotesDataAccess() {
-    setUpUserAndElectionVotes(UserRoles.CHAIRPERSON);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.DATA_ACCESS, false);
-    assertFalse(votes.isEmpty());
-    // Should create 4 votes:
-    // Chairperson as a chair
-    // Chairperson as a dac member
-    // Final vote
-    // Manual review Agreement vote
-    assertEquals(4, votes.size());
-  }
-
-  @Test
-  void testMemberCreateVotesDataAccess() {
-    setUpUserAndElectionVotes(UserRoles.MEMBER);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.DATA_ACCESS, false);
-    assertFalse(votes.isEmpty());
-    // Should create 1 member vote
-    assertEquals(1, votes.size());
-  }
-
-  @Test
-  void testChairCreateVotesDataAccessManualReview() {
-    setUpUserAndElectionVotes(UserRoles.CHAIRPERSON);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.DATA_ACCESS, true);
-    assertFalse(votes.isEmpty());
-    // Should create 3 votes:
-    // Chairperson as a chair
-    // Chairperson as a dac member
-    // Final vote
-    assertEquals(3, votes.size());
-  }
-
-  @Test
-  void testChairCreateVotesRP() {
-    setUpUserAndElectionVotes(UserRoles.CHAIRPERSON);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.RP, false);
-    assertFalse(votes.isEmpty());
-    // Should create 2 votes:
-    // Chairperson as a chair
-    // Chairperson as a dac member
-    assertEquals(2, votes.size());
-  }
-
-  @Test
-  void testMemberCreateVotesRP() {
-    setUpUserAndElectionVotes(UserRoles.MEMBER);
-
-    List<Vote> votes = service.createVotes(new Election(), ElectionType.RP, false);
-    assertFalse(votes.isEmpty());
-    // Should create 1 member vote
-    assertEquals(1, votes.size());
-  }
-
-  @Test
   void testUpdateVotesWithValue_NoRationale() {
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
     Vote v = setUpTestVote();
@@ -238,11 +177,8 @@ class VoteServiceTest extends AbstractTestHelper {
     accessElection.setStatus(ElectionStatus.OPEN.getValue());
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of(accessElection));
 
-    try {
-      service.updateVotesWithValue(List.of(v), true, null, user);
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    List<Vote> voteList = List.of(v);
+    assertDoesNotThrow(() -> service.updateVotesWithValue(voteList, true, null, user));
   }
 
   @Test
@@ -356,11 +292,7 @@ class VoteServiceTest extends AbstractTestHelper {
     doNothing().when(voteDAO).updateRationaleByVoteIds(any(), any());
     when(electionDAO.findElectionsByIds(any())).thenReturn(List.of());
 
-    try {
-      service.updateRationaleByVoteIds(List.of(1), "rationale");
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertDoesNotThrow(() -> service.updateRationaleByVoteIds(List.of(1), "rationale"));
   }
 
   @Test
@@ -768,7 +700,7 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testNotifyCustodiansOfApprovedDatasets() {
+  void testNotifyCustodiansOfApprovedDatasets() throws Exception {
     User submitter = new User();
     submitter.setEmail("submitter@test.com");
     submitter.setDisplayName("submitter");
@@ -803,12 +735,11 @@ class VoteServiceTest extends AbstractTestHelper {
 
     when(userDAO.findUserById(any())).thenReturn(submitter);
 
-    try {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1, d2), researcher, "Dar Code", false);
-      verify(emailService, times(1)).sendMessage(any(DataCustodianApprovalMessage.class), any());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertDoesNotThrow(
+        () ->
+            service.notifyCustodiansOfApprovedDatasets(
+                List.of(d1, d2), researcher, "Dar Code", false));
+    verify(emailService, times(1)).sendMessage(any(DataCustodianApprovalMessage.class), any());
   }
 
   @Test
@@ -856,7 +787,7 @@ class VoteServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testNotifyStudyCustodiansAndSubmittersOfApprovedDatasets() {
+  void testNotifyStudyCustodiansAndSubmittersOfApprovedDatasets() throws Exception {
     User studySubmitter = new User();
     studySubmitter.setEmail("submitter@example.com");
     studySubmitter.setDisplayName("submitter");
@@ -903,16 +834,14 @@ class VoteServiceTest extends AbstractTestHelper {
     when(userDAO.findUsersByEmailList(List.of(custodian.getEmail())))
         .thenReturn(List.of(custodian));
 
-    try {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", false);
-      verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertDoesNotThrow(
+        () ->
+            service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", false));
+    verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
   }
 
   @Test
-  void testNotifyStudyCustodiansAndSubmittersOfRADARApprovedDatasets() {
+  void testNotifyStudyCustodiansAndSubmittersOfRADARApprovedDatasets() throws Exception {
     User studySubmitter = new User();
     studySubmitter.setEmail("submitter@example.com");
     studySubmitter.setDisplayName("submitter");
@@ -959,12 +888,10 @@ class VoteServiceTest extends AbstractTestHelper {
     when(userDAO.findUsersByEmailList(List.of(custodian.getEmail())))
         .thenReturn(List.of(custodian));
 
-    try {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", true);
-      verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertDoesNotThrow(
+        () ->
+            service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", true));
+    verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
   }
 
   /**
@@ -972,7 +899,8 @@ class VoteServiceTest extends AbstractTestHelper {
    * com.google.gson.JsonArray cannot be cast to class java.lang.String
    */
   @Test
-  void testNotifyStudyCustodiansAndSubmittersOfApprovedDatasetsWithJsonArrayCustodians() {
+  void testNotifyStudyCustodiansAndSubmittersOfApprovedDatasetsWithJsonArrayCustodians()
+      throws Exception {
     User studySubmitter = new User();
     studySubmitter.setEmail("submitter@example.com");
     studySubmitter.setDisplayName("submitter");
@@ -1020,12 +948,10 @@ class VoteServiceTest extends AbstractTestHelper {
     when(userDAO.findUsersByEmailList(List.of(custodian.getEmail())))
         .thenReturn(List.of(custodian));
 
-    try {
-      service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", false);
-      verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
-    } catch (Exception e) {
-      fail(e.getMessage());
-    }
+    assertDoesNotThrow(
+        () ->
+            service.notifyCustodiansOfApprovedDatasets(List.of(d1), researcher, "Dar Code", false));
+    verify(emailService, times(3)).sendMessage(any(DataCustodianApprovalMessage.class), any());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -73,10 +73,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertFalse(createdElections.isEmpty());
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
-    assertTrue(
-        createdElections.stream()
-            .noneMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+            .allMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
     // Ensure that we have primary vote types
     assertFalse(createdVotes.isEmpty());
     assertTrue(
@@ -129,10 +126,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     assertEquals(1, createdElections.size());
     assertTrue(
         createdElections.stream()
-            .anyMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
-    assertTrue(
-        createdElections.stream()
-            .noneMatch(e -> e.getElectionType().equals(ElectionType.RP.getValue())));
+            .allMatch(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue())));
     // Ensure that we have primary vote types
     assertFalse(createdVotes.isEmpty());
     assertTrue(
@@ -269,11 +263,6 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         1,
         createdElections.stream()
             .filter(e -> e.getElectionType().equals(ElectionType.DATA_ACCESS.getValue()))
-            .count());
-    assertEquals(
-        0,
-        createdElections.stream()
-            .filter(e -> e.getElectionType().equals(ElectionType.RP.getValue()))
             .count());
 
     // create progress report

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -6,10 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,10 +33,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DarCollectionServiceDAOTest extends DAOTestHelper {
-
-  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
-  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
-  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   private static DarCollectionServiceDAO serviceDAO;
 
@@ -312,7 +305,12 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDARDatasetRelation(
         dar.getReferenceId(), dacAndDataset2.dataset.getDatasetId());
     dataAccessRequestDAO.updateDataByReferenceId(
-        dar.getReferenceId(), dar.getUserId(), FIXED_DATE, FIXED_DATE, dar.getData(), user.getEraCommonsId());
+        dar.getReferenceId(),
+        dar.getUserId(),
+        FIXED_DATE,
+        FIXED_DATE,
+        dar.getData(),
+        user.getEraCommonsId());
     return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
   }
 
@@ -367,7 +365,8 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DarCollectionServiceDAOTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -35,6 +36,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DarCollectionServiceDAOTest extends DAOTestHelper {
+
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   private static DarCollectionServiceDAO serviceDAO;
 
@@ -248,7 +253,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
                             electionDAO.updateElectionById(
                                 e.getElectionId(),
                                 ElectionStatus.CANCELED.getValue(),
-                                new Date())));
+                                FIXED_DATE)));
 
     // re-create elections & new votes:
     referenceIds.addAll(serviceDAO.createElectionsForDarByUser(chair.get(), dar));
@@ -297,7 +302,7 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     DacAndDataset dacAndDataset = createDacAndDataset();
     DacAndDataset dacAndDataset2 = createDacAndDataset();
     Integer collectionId =
-        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), FIXED_DATE);
     createDarForCollection(user, collectionId, dacAndDataset.dataset);
     DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
     DataAccessRequest dar = collection.getDars().values().stream().findFirst().orElseThrow();
@@ -306,9 +311,8 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
         dar.getReferenceId(), dacAndDataset.dataset.getDatasetId());
     dataAccessRequestDAO.insertDARDatasetRelation(
         dar.getReferenceId(), dacAndDataset2.dataset.getDatasetId());
-    Date now = new Date();
     dataAccessRequestDAO.updateDataByReferenceId(
-        dar.getReferenceId(), dar.getUserId(), now, now, dar.getData(), user.getEraCommonsId());
+        dar.getReferenceId(), dar.getUserId(), FIXED_DATE, FIXED_DATE, dar.getData(), user.getEraCommonsId());
     return darCollectionDAO.findDARCollectionByReferenceId(dar.getReferenceId());
   }
 
@@ -339,33 +343,31 @@ class DarCollectionServiceDAOTest extends DAOTestHelper {
     dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
-    dsp.setCreateDate(new Date());
+    dsp.setCreateDate(FIXED_DATE);
     list.add(dsp);
     datasetDAO.insertDatasetProperties(list);
   }
 
   private void createDarForCollection(User user, Integer collectionId, Dataset dataset) {
-    Date now = new Date();
     DataAccessRequest dar = new DataAccessRequest();
     dar.setReferenceId(UUID.randomUUID().toString());
     DataAccessRequestData data = new DataAccessRequestData();
     dar.setData(data);
     dataAccessRequestDAO.insertDraftDataAccessRequest(
-        dar.getReferenceId(), user.getUserId(), now, now, data);
+        dar.getReferenceId(), user.getUserId(), FIXED_DATE, FIXED_DATE, data);
     dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, dar.getReferenceId());
     dataAccessRequestDAO.updateDataByReferenceId(
-        dar.referenceId, dar.userId, new Date(), new Date(), data, user.getEraCommonsId());
+        dar.referenceId, dar.userId, FIXED_DATE, FIXED_DATE, data, user.getEraCommonsId());
     dataAccessRequestDAO.insertDARDatasetRelation(dar.getReferenceId(), dataset.getDatasetId());
   }
 
   private Dataset createDatasetWithDac(Integer dacId) {
     User user = createUser();
     String name = "Name_" + randomAlphabetic(20);
-    Timestamp now = new Timestamp(new Date().getTime());
     String objectId = "Object ID_" + randomAlphabetic(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), dacId);
+        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), dacId);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -7,10 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
@@ -32,10 +29,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceDAOTest extends DAOTestHelper {
-
-  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
-  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
-  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   private VoteServiceDAO serviceDAO;
 
@@ -159,7 +152,8 @@ class VoteServiceDAOTest extends DAOTestHelper {
     String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -110,8 +110,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
 
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    List<Integer> requestVoteIds =
-        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
+    List<Integer> requestVoteIds = Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
     votes.forEach(
         v -> {
           assertTrue(v.getVote());
@@ -141,8 +140,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
 
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    List<Integer> requestVoteIds =
-        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
+    List<Integer> requestVoteIds = Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
     votes.forEach(
         v -> {
           assertTrue(v.getVote());

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -31,6 +32,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class VoteServiceDAOTest extends DAOTestHelper {
+
+  private static final Instant FIXED_INSTANT = Instant.parse("2025-01-01T00:00:00Z");
+  private static final Date FIXED_DATE = Date.from(FIXED_INSTANT);
+  private static final Timestamp FIXED_TIMESTAMP = Timestamp.from(FIXED_INSTANT);
 
   private VoteServiceDAO serviceDAO;
 
@@ -127,7 +132,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     Election election2 = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     Election election3 = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
-        election1.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date());
+        election1.getElectionId(), ElectionStatus.CLOSED.getValue(), FIXED_DATE);
 
     Vote vote1 = createDacVote(user.getUserId(), election1.getElectionId());
     Vote vote2 = createDacVote(user.getUserId(), election2.getElectionId());
@@ -151,11 +156,10 @@ class VoteServiceDAOTest extends DAOTestHelper {
   private Dataset createDataset() {
     User user = createUser();
     String name = "Name_" + randomAlphanumeric(20);
-    Timestamp now = new Timestamp(new Date().getTime());
     String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
-        datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);
+        datasetDAO.insertDataset(name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
     createDatasetProperties(id);
     return datasetDAO.findDatasetById(id);
   }
@@ -166,7 +170,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     dsp.setDatasetId(datasetId);
     dsp.setPropertyKey(1);
     dsp.setPropertyValue("Test_PropertyValue");
-    dsp.setCreateDate(new Date());
+    dsp.setCreateDate(FIXED_DATE);
     list.add(dsp);
     datasetDAO.insertDatasetProperties(list);
   }
@@ -210,7 +214,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
         electionDAO.insertElection(
             ElectionType.DATA_ACCESS.getValue(),
             ElectionStatus.OPEN.getValue(),
-            new Date(),
+            FIXED_DATE,
             referenceId,
             datasetId);
     return electionDAO.findElectionById(electionId);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -11,7 +11,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
@@ -42,7 +41,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_FinalVote() throws Exception {
+  void testUpdateVotesWithValue_FinalVote() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
@@ -61,7 +60,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_NoRationale() throws Exception {
+  void testUpdateVotesWithValue_NoRationale() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
@@ -77,7 +76,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_DacVote() throws Exception {
+  void testUpdateVotesWithValue_DacVote() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
@@ -96,7 +95,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_MultipleVotes() throws Exception {
+  void testUpdateVotesWithValue_MultipleVotes() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
@@ -112,7 +111,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
     List<Integer> requestVoteIds =
-        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).collect(Collectors.toList());
+        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
     votes.forEach(
         v -> {
           assertTrue(v.getVote());
@@ -122,20 +121,19 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_MultipleElectionTypes() throws Exception {
+  void testUpdateVotesWithValue_MultipleElectionTypes() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
-    Election rpElection1 = createRPElection(dar.getReferenceId(), dataset.getDatasetId());
-    Election rpElection2 = createRPElection(dar.getReferenceId(), dataset.getDatasetId());
-    Election accessElection =
-        createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
+    Election election1 = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
+    Election election2 = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
+    Election election3 = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
     electionDAO.updateElectionById(
-        rpElection1.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date());
+        election1.getElectionId(), ElectionStatus.CLOSED.getValue(), new Date());
 
-    Vote vote1 = createDacVote(user.getUserId(), rpElection1.getElectionId());
-    Vote vote2 = createDacVote(user.getUserId(), rpElection2.getElectionId());
-    Vote vote3 = createDacVote(user.getUserId(), accessElection.getElectionId());
+    Vote vote1 = createDacVote(user.getUserId(), election1.getElectionId());
+    Vote vote2 = createDacVote(user.getUserId(), election2.getElectionId());
+    Vote vote3 = createDacVote(user.getUserId(), election3.getElectionId());
     String rationale = "rationale";
 
     List<Vote> votes =
@@ -144,7 +142,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
     List<Integer> requestVoteIds =
-        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).collect(Collectors.toList());
+        Stream.of(vote1, vote2, vote3).map(Vote::getVoteId).toList();
     votes.forEach(
         v -> {
           assertTrue(v.getVote());
@@ -177,7 +175,7 @@ class VoteServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateVotesWithValue_RadarApproveVote() throws Exception {
+  void testUpdateVotesWithValue_RadarApproveVote() {
     User user = createUser();
     DataAccessRequest dar = createDataAccessRequestV3();
     Dataset dataset = createDataset();
@@ -208,17 +206,6 @@ class VoteServiceDAOTest extends DAOTestHelper {
   private Vote createRadarApproveVote(Integer userId, Integer electionId) {
     Integer voteId = voteDAO.insertVote(userId, electionId, VoteType.RADAR_APPROVE.getValue());
     return voteDAO.findVoteById(voteId);
-  }
-
-  private Election createRPElection(String referenceId, Integer datasetId) {
-    Integer electionId =
-        electionDAO.insertElection(
-            ElectionType.RP.getValue(),
-            ElectionStatus.OPEN.getValue(),
-            new Date(),
-            referenceId,
-            datasetId);
-    return electionDAO.findElectionById(electionId);
   }
 
   private Election createDataAccessElection(String referenceId, Integer datasetId) {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/VoteServiceDAOTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -52,11 +51,11 @@ class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    assertTrue(votes.get(0).getVote());
-    assertEquals(rationale, votes.get(0).getRationale());
+    assertTrue(votes.getFirst().getVote());
+    assertEquals(rationale, votes.getFirst().getRationale());
     Election foundElection = electionDAO.findElectionById(vote.getElectionId());
     assertEquals(ElectionStatus.CLOSED.getValue(), foundElection.getStatus());
-    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
+    assertEquals(vote.getVoteId(), votes.getFirst().getVoteId());
   }
 
   @Test
@@ -70,9 +69,9 @@ class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, null);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    assertTrue(votes.get(0).getVote());
-    assertNull(votes.get(0).getRationale());
-    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
+    assertTrue(votes.getFirst().getVote());
+    assertNull(votes.getFirst().getRationale());
+    assertEquals(vote.getVoteId(), votes.getFirst().getVoteId());
   }
 
   @Test
@@ -87,11 +86,11 @@ class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    assertTrue(votes.get(0).getVote());
-    assertEquals(rationale, votes.get(0).getRationale());
+    assertTrue(votes.getFirst().getVote());
+    assertEquals(rationale, votes.getFirst().getRationale());
     Election foundElection = electionDAO.findElectionById(vote.getElectionId());
     assertNotEquals(ElectionStatus.CLOSED.getValue(), foundElection.getStatus());
-    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
+    assertEquals(vote.getVoteId(), votes.getFirst().getVoteId());
   }
 
   @Test
@@ -151,9 +150,9 @@ class VoteServiceDAOTest extends DAOTestHelper {
 
   private Dataset createDataset() {
     User user = createUser();
-    String name = "Name_" + RandomStringUtils.random(20, true, true);
+    String name = "Name_" + randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
-    String objectId = "Object ID_" + RandomStringUtils.random(20, true, true);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
     DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
     Integer id =
         datasetDAO.insertDataset(name, now, user.getUserId(), objectId, dataUse.toString(), null);
@@ -184,11 +183,11 @@ class VoteServiceDAOTest extends DAOTestHelper {
     List<Vote> votes = serviceDAO.updateVotesWithValue(List.of(vote), true, rationale);
     assertNotNull(votes);
     assertFalse(votes.isEmpty());
-    assertTrue(votes.get(0).getVote());
-    assertEquals(rationale, votes.get(0).getRationale());
+    assertTrue(votes.getFirst().getVote());
+    assertEquals(rationale, votes.getFirst().getRationale());
     Election foundElection = electionDAO.findElectionById(vote.getElectionId());
     assertEquals(ElectionStatus.CLOSED.getValue(), foundElection.getStatus());
-    assertEquals(vote.getVoteId(), votes.get(0).getVoteId());
+    assertEquals(vote.getVoteId(), votes.getFirst().getVoteId());
   }
 
   private Vote createDacVote(Integer userId, Integer electionId) {


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3760

### Summary
This work continues the deprecation of RP elections and votes. Functional changes:
* Mark unused `ElectionType`s as deprecated
* Enforce that `VoteService.validateVotesCanUpdate` only looks at `DataAccess` election types
* Enforce that `DACAutomationRuleService.createOpenElectionForDAR` only creates `DataAccess` elections

Non-functional/test changes
* Remove `VoteService.createVotes` since it was only used in tests
* Update/refactor tests throughout that used `RP` elections.
* Significant test updates to address longstanding sonar warnings.

See also previous PR:
* https://github.com/DataBiosphere/consent/pull/2969

There is still additional work to do - future PRs will cover additional cleanup and email reminders.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
