### PR TITLE
[DT-3760] Cleanup RP/DUL votes in Email messages

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -6,30 +6,23 @@ import org.broadinstitute.consent.http.models.User;
 
 public class NewCaseMessage extends MailMessage {
 
-  private static final String NEWCASE_DUL = "Log vote on Data Use Limitations case id: %s.";
-  private static final String NEWCASE_DAR = "Log votes on Data Access Request case id: %s.";
-  private final String type;
+  private static final String NEW_CASE_DAR = "Log votes on Data Access Request case id: %s.";
   private final String referenceId;
 
-  public NewCaseMessage(User toUser, String referenceId, String type) {
+  public NewCaseMessage(User toUser, String referenceId) {
     super(toUser, EmailType.NEW_CASE);
     this.referenceId = referenceId;
-    this.type = type;
   }
 
   @Override
   public String createSubject() {
-    if (type.equals("Data Use Limitations")) {
-      return String.format(NEWCASE_DUL, referenceId);
-    } else {
-      return String.format(NEWCASE_DAR, referenceId);
-    }
+    return String.format(NEW_CASE_DAR, referenceId);
   }
 
   @Override
   public Map<String, Object> createModel() {
     return Map.of(
-        "userName", toUser.getDisplayName(), "electionType", type, "entityName", referenceId);
+        "userName", toUser.getDisplayName(), "electionType", "Data Access Request", "entityName", referenceId);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/NewCaseMessage.java
@@ -22,7 +22,12 @@ public class NewCaseMessage extends MailMessage {
   @Override
   public Map<String, Object> createModel() {
     return Map.of(
-        "userName", toUser.getDisplayName(), "electionType", "Data Access Request", "entityName", referenceId);
+        "userName",
+        toUser.getDisplayName(),
+        "electionType",
+        "Data Access Request",
+        "entityName",
+        referenceId);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
+++ b/src/main/java/org/broadinstitute/consent/http/mail/message/ReminderMessage.java
@@ -7,36 +7,23 @@ import org.broadinstitute.consent.http.models.Vote;
 
 public class ReminderMessage extends MailMessage {
 
-  private static final String REMINDER_DUL =
-      "Urgent: Log vote on Data Use Limitations case id: %s.";
   private static final String REMINDER_DAR =
       "Urgent: Log votes on Data Access Request case id: %s.";
-  private static final String REMINDER_RP =
-      "Urgent: Log votes on Research Purpose Review case id: %s.";
 
   private final Vote vote;
-  private final String electionType;
   private final String darCode;
   private final String voteUrl;
 
-  public ReminderMessage(
-      User toUser, Vote vote, String darCode, String electionType, String voteUrl) {
+  public ReminderMessage(User toUser, Vote vote, String darCode, String voteUrl) {
     super(toUser, EmailType.REMINDER);
     this.vote = vote;
     this.darCode = darCode;
-    this.electionType = electionType;
     this.voteUrl = voteUrl;
   }
 
   @Override
   public String createSubject() {
-    if (electionType.equals("Data Use Limitations")) {
-      return String.format(REMINDER_DUL, darCode);
-    }
-    if (electionType.equals("Data Access Request")) {
-      return String.format(REMINDER_DAR, darCode);
-    }
-    return String.format(REMINDER_RP, darCode);
+    return String.format(REMINDER_DAR, darCode);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -1178,9 +1178,8 @@ public class DarCollectionService implements ConsentLogger {
   @VisibleForTesting
   protected void sendDarNewCollectionElectionMessage(List<User> users, String darCode)
       throws IOException, TemplateException {
-    String electionType = "Data Access Request";
     for (User user : users) {
-      emailService.sendMessage(new NewCaseMessage(user, darCode, electionType), user.getUserId());
+      emailService.sendMessage(new NewCaseMessage(user, darCode), user.getUserId());
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -506,8 +506,7 @@ public class DataAccessRequestService implements ConsentLogger {
   }
 
   private boolean isUserPreAuthorizedForAllDaas(User user, List<Integer> datasetIds) {
-    Set<Integer> datasetDaas =
-        new HashSet<>(daaDAO.findDaaIdsByDatasetIds(datasetIds));
+    Set<Integer> datasetDaas = new HashSet<>(daaDAO.findDaaIdsByDatasetIds(datasetIds));
 
     Set<Integer> userDaas = new HashSet<>(user.getLibraryCard().getDaaIds());
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DaaDAO;
@@ -320,7 +319,7 @@ public class DataAccessRequestService implements ConsentLogger {
       if (!progressReport.getIsCloseoutProgressReport()) {
         daaDAO.insertDarDAARelationship(id, progressReport.getData().getDaaIds());
       }
-    } catch (JdbiException e) {
+    } catch (JdbiException _) {
       throw new BadRequestException(
           "Unable to create progress report for Data Access Request " + parentDar.getReferenceId());
     }
@@ -424,7 +423,7 @@ public class DataAccessRequestService implements ConsentLogger {
             "Signing Officials must be in the same institution as the creator of the closeout request.");
       }
 
-    } catch (NotFoundException e) {
+    } catch (NotFoundException _) {
       // log the state.  we'll allow the SO to process a closeout even if the  user can't be found.
       logWarn(
           String.format(
@@ -467,7 +466,7 @@ public class DataAccessRequestService implements ConsentLogger {
         if (!selectedSigningOfficial.hasUserRole(UserRoles.SIGNINGOFFICIAL)) {
           throw new BadRequestException("The selected signing official is not a signing official");
         }
-      } catch (NotFoundException nfe) {
+      } catch (NotFoundException _) {
         throw new BadRequestException(
             "The selected signing official in the closeout was not found.");
       }
@@ -508,9 +507,9 @@ public class DataAccessRequestService implements ConsentLogger {
 
   private boolean isUserPreAuthorizedForAllDaas(User user, List<Integer> datasetIds) {
     Set<Integer> datasetDaas =
-        daaDAO.findDaaIdsByDatasetIds(datasetIds).stream().collect(Collectors.toSet());
+        new HashSet<>(daaDAO.findDaaIdsByDatasetIds(datasetIds));
 
-    Set<Integer> userDaas = user.getLibraryCard().getDaaIds().stream().collect(Collectors.toSet());
+    Set<Integer> userDaas = new HashSet<>(user.getLibraryCard().getDaaIds());
 
     return userDaas.containsAll(datasetDaas);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -826,8 +826,7 @@ public class DataAccessRequestService implements ConsentLogger {
   }
 
   @VisibleForTesting
-  protected void sendReminderMessage(
-      User user, Vote vote, String darCode, String url)
+  protected void sendReminderMessage(User user, Vote vote, String darCode, String url)
       throws TemplateException, IOException {
     emailService.sendMessage(new ReminderMessage(user, vote, darCode, url), user.getUserId());
   }
@@ -842,11 +841,7 @@ public class DataAccessRequestService implements ConsentLogger {
         darCollectionDAO.findDARCollectionByReferenceId(election.getReferenceId());
     User user = findUserById(vote.getUserId());
     String voteUrl = serverUrl + "dar_collection/%d".formatted(collection.getDarCollectionId());
-    sendReminderMessage(
-        user,
-        vote,
-        collection.getDarCode(),
-        voteUrl);
+    sendReminderMessage(user, vote, collection.getDarCode(), voteUrl);
     voteDAO.updateVoteReminderFlag(voteId, true);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.db.ElectionDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.db.VoteDAO;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
 import org.broadinstitute.consent.http.enumeration.EmailType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.exceptions.InvalidEmailAddressException;
@@ -826,20 +827,26 @@ public class DataAccessRequestService implements ConsentLogger {
 
   @VisibleForTesting
   protected void sendReminderMessage(
-      User user, Vote vote, String darCode, String electionType, String url)
+      User user, Vote vote, String darCode, String url)
       throws TemplateException, IOException {
-    emailService.sendMessage(
-        new ReminderMessage(user, vote, darCode, electionType, url), user.getUserId());
+    emailService.sendMessage(new ReminderMessage(user, vote, darCode, url), user.getUserId());
   }
 
   public void sendReminderMessage(Integer voteId) throws IOException, TemplateException {
     Vote vote = voteDAO.findVoteById(voteId);
     Election election = electionDAO.findElectionWithFinalVoteById(vote.getElectionId());
+    if (!ElectionType.DATA_ACCESS.getValue().equals(election.getElectionType())) {
+      throw new IllegalArgumentException("ElectionType must be DATA_ACCESS");
+    }
     DarCollection collection =
         darCollectionDAO.findDARCollectionByReferenceId(election.getReferenceId());
     User user = findUserById(vote.getUserId());
     String voteUrl = serverUrl + "dar_collection/%d".formatted(collection.getDarCollectionId());
-    sendReminderMessage(user, vote, collection.getDarCode(), election.getElectionType(), voteUrl);
+    sendReminderMessage(
+        user,
+        vote,
+        collection.getDarCode(),
+        voteUrl);
     voteDAO.updateVoteReminderFlag(voteId, true);
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -833,7 +833,9 @@ public class DataAccessRequestService implements ConsentLogger {
     Vote vote = voteDAO.findVoteById(voteId);
     Election election = electionDAO.findElectionWithFinalVoteById(vote.getElectionId());
     if (!ElectionType.DATA_ACCESS.getValue().equals(election.getElectionType())) {
-      throw new IllegalArgumentException("ElectionType must be DATA_ACCESS");
+      throw new IllegalArgumentException(
+          "ElectionType must be '%s', but found '%s'"
+              .formatted(ElectionType.DATA_ACCESS.getValue(), election.getElectionType()));
     }
     DarCollection collection =
         darCollectionDAO.findDARCollectionByReferenceId(election.getReferenceId());

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/NewCaseMessageTest.java
@@ -11,17 +11,15 @@ class NewCaseMessageTest extends AbstractMailMessageTest {
 
   @Test
   void testMessageSubject() {
-    var message = new NewCaseMessage(new User(), "DUL-123", "Data Use Limitations");
-    assertEquals("Log vote on Data Use Limitations case id: DUL-123.", message.createSubject());
-    var message2 = new NewCaseMessage(new User(), "DAR-123", "Data Access");
-    assertEquals("Log votes on Data Access Request case id: DAR-123.", message2.createSubject());
+    var message = new NewCaseMessage(new User(), "DAR-123");
+    assertEquals("Log votes on Data Access Request case id: DAR-123.", message.createSubject());
   }
 
   @Test
   void testCreateModel_AddsRequiredFields() {
     User toUser = new User();
     toUser.setDisplayName("Test User");
-    var message = new NewCaseMessage(toUser, "DUL-123", "Data Use Limitations");
+    var message = new NewCaseMessage(toUser, "DAR-123");
 
     assertRequiredModelFields(
         message,
@@ -29,9 +27,9 @@ class NewCaseMessageTest extends AbstractMailMessageTest {
             "userName",
             "Test User",
             "electionType",
-            "Data Use Limitations",
+            "Data Access Request",
             "entityName",
-            "DUL-123"));
+            "DAR-123"));
   }
 
   @Test
@@ -42,7 +40,7 @@ class NewCaseMessageTest extends AbstractMailMessageTest {
     User toUser = new User();
     toUser.setDisplayName(userName);
 
-    var message = new NewCaseMessage(toUser, referenceId, "Data Use Limitations");
+    var message = new NewCaseMessage(toUser, referenceId);
     assertEquals(referenceId, message.getEntityReferenceId());
 
     var rendered = renderTemplate(message, serverUrl);
@@ -54,7 +52,7 @@ class NewCaseMessageTest extends AbstractMailMessageTest {
     assertTrue(
         rendered
             .content()
-            .contains("Data Use Limitations Review case id " + referenceId + ", has been created"));
+            .contains("Data Access Request Review case id " + referenceId + ", has been created"));
     assertTrue(rendered.content().contains(serverUrl));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mail/message/ReminderMessageTest.java
@@ -13,17 +13,9 @@ class ReminderMessageTest extends AbstractMailMessageTest {
 
   @Test
   void testMessageSubject() {
-    var message =
-        new ReminderMessage(new User(), new Vote(), "DUL-123", "Data Use Limitations", "");
+    var message = new ReminderMessage(new User(), new Vote(), "DAR-123", "");
     assertEquals(
-        "Urgent: Log vote on Data Use Limitations case id: DUL-123.", message.createSubject());
-    var message2 =
-        new ReminderMessage(new User(), new Vote(), "DAR-123", "Data Access Request", "");
-    assertEquals(
-        "Urgent: Log votes on Data Access Request case id: DAR-123.", message2.createSubject());
-    var message3 = new ReminderMessage(new User(), new Vote(), "RP-123", "Research Purpose", "");
-    assertEquals(
-        "Urgent: Log votes on Research Purpose Review case id: RP-123.", message3.createSubject());
+        "Urgent: Log votes on Data Access Request case id: DAR-123.", message.createSubject());
   }
 
   @Test
@@ -35,7 +27,7 @@ class ReminderMessageTest extends AbstractMailMessageTest {
     vote.setElectionId(123);
     String darCode = "DUL-123";
     String voteUrl = "http://testVoteUrl";
-    var message = new ReminderMessage(toUser, vote, darCode, "Data Use Limitations", voteUrl);
+    var message = new ReminderMessage(toUser, vote, darCode, voteUrl);
     assertEquals(vote.getVoteId(), message.getVoteId());
     assertEquals(vote.getElectionId().toString(), message.getEntityReferenceId());
 
@@ -60,7 +52,7 @@ class ReminderMessageTest extends AbstractMailMessageTest {
     vote.setElectionId(123);
     String voteUrl = "http://testVoteUrl";
 
-    var message = new ReminderMessage(toUser, vote, "DUL-123", "Data Use Limitations", voteUrl);
+    var message = new ReminderMessage(toUser, vote, "DUL-123", voteUrl);
 
     Map<String, Object> model = message.createModel("http://defaultServerUrl");
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -25,13 +25,11 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import freemarker.template.TemplateException;
-import jakarta.validation.Valid;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -369,7 +367,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
     dar.setReferenceId("id");
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
@@ -393,9 +391,9 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   void testUpdateByReferenceIdThrowsOnDraft() {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setCollectionId(randomInt(0, 100));
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     dar.addDatasetIds(List.of(1, 2, 3));
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setSubmissionDate(FIXED_TIMESTAMP);
     assertThrows(
         SubmittedDARCannotBeEditedException.class, () -> service.updateByReferenceId(user, dar));
   }
@@ -406,7 +404,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
     dar.setReferenceId("id");
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     assertThrows(
         NIHComplianceRuleException.class,
         () -> service.createDataAccessRequest(user, dar, request));
@@ -418,7 +416,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(progressReport.getDatasetIds());
     parentDar.setUserId(user.getUserId());
@@ -451,7 +449,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
     progressReport.setDatasetIds(List.of(1, 2));
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(1);
     parentDar.setDatasetIds(List.of(1, 2));
     User user = createUserWithPrerequisites();
@@ -494,7 +492,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
     progressReport.getData().setDmi(new DataManagementIncident(List.of("incident 1"), "A bad day"));
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(progressReport.getDatasetIds());
     parentDar.setUserId(user.getUserId());
@@ -528,7 +526,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
     progressReport.getData().setDaaIds(Set.of(1));
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     user.getLibraryCard().setDaaIds(List.of(2));
     mockApprovedDatasets(progressReport.getDatasetIds());
@@ -564,11 +562,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     signingOfficial.setSigningOfficialRole();
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     progressReport.setDatasetIds(List.of(3, 4, 5));
     parentDar.setDatasetIds(List.of(3, 4, 5));
-    progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
     progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
@@ -603,7 +601,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   @Test
   void findDatasetDaaSnapshotsByReferenceId() {
     DataAccessRequest dar = generateDataAccessRequest();
-    Timestamp capturedAt = Timestamp.from(Instant.now());
+    Timestamp capturedAt = FIXED_TIMESTAMP;
     when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
     when(daaDAO.findDatasetDaaSnapshotsByReferenceId(dar.getReferenceId()))
         .thenReturn(
@@ -636,7 +634,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(progressReport.getDatasetIds());
     parentDar.setUserId(user.getUserId());
@@ -653,7 +651,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
     progressReport.setCollectionId(parentDar.getCollectionId());
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(progressReport.getDatasetIds());
     parentDar.setUserId(user.getUserId());
@@ -674,7 +672,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   }
 
   private User createRequestingUser() {
-    User requestingUser = new User(1, "requestor@test.com", "Requestor", new Date(), roles);
+    User requestingUser = new User(1, "requestor@test.com", "Requestor", FIXED_DATE, roles);
     requestingUser.setInstitutionId(1);
     Institution institution = new Institution();
     institution.setName("Test Institution");
@@ -704,7 +702,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setDatasetIds(Collections.emptyList());
     mockApprovedDatasets(progressReport.getDatasetIds());
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     BadRequestException exception =
         assertThrows(
@@ -720,7 +718,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.getData().setProgressReportSummary(null);
     mockApprovedDatasets(progressReport.getDatasetIds());
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     BadRequestException exception =
         assertThrows(
@@ -736,7 +734,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setDatasetIds(List.of(3, 4, 5)); // IDs not all in parent DAR
     mockApprovedDatasets(progressReport.getDatasetIds());
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     BadRequestException exception =
@@ -753,11 +751,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     progressReport.setDatasetIds(List.of(3, 4, 5));
     parentDar.setDatasetIds(List.of(3, 4, 5));
-    progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
     progressReport.setParentId(parentDar.getId());
     progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
     mockApprovedDatasets(progressReport.getDatasetIds());
@@ -780,11 +778,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     signingOfficial.setInstitutionId(user.getInstitutionId() + 1);
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     progressReport.setDatasetIds(List.of(3, 4, 5));
     parentDar.setDatasetIds(List.of(3, 4, 5));
-    progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
     progressReport.setParentId(parentDar.getId());
     progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
     mockApprovedDatasets(progressReport.getDatasetIds());
@@ -808,11 +806,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     signingOfficial.setInstitutionId(user.getInstitutionId());
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     progressReport.setDatasetIds(List.of(3, 4, 5));
     parentDar.setDatasetIds(List.of(3, 4, 5));
-    progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
     progressReport.setParentId(parentDar.getId());
     progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
     mockApprovedDatasets(progressReport.getDatasetIds());
@@ -836,11 +834,11 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     signingOfficial.setSigningOfficialRole();
     DataAccessRequest progressReport = generateProgressReport();
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setUserId(user.getUserId());
     progressReport.setDatasetIds(List.of(3, 4, 5));
     parentDar.setDatasetIds(List.of(3, 4, 5));
-    progressReport.setSubmissionDate(Timestamp.from(Instant.now()));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
     progressReport.setParentId(parentDar.getId());
     progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
     mockApprovedDatasets(progressReport.getDatasetIds());
@@ -857,7 +855,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     progressReport.setDatasetIds(List.of(1, 2));
     mockApprovedDatasets(progressReport.getDatasetIds());
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     assertDoesNotThrow(() -> service.validateProgressReport(user, progressReport, parentDar));
@@ -884,7 +882,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     collaborator2User.setInstitutionId(user.getInstitutionId());
     collaborator2User.setLibraryCard(new LibraryCard());
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     when(userDAO.findUserByEmail(collaborator1.email())).thenReturn(collaborator1User);
@@ -905,7 +903,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     Collaborator collaborator2 = createCollaborator("eve@yetanotherdomain.org");
     progressReportData.setLabCollaborators(Collections.singletonList(collaborator2));
     DataAccessRequest parentDar = generateDataAccessRequest();
-    parentDar.setSubmissionDate(Timestamp.from(Instant.now()));
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
     parentDar.setDatasetIds(List.of(1, 2, 3));
     parentDar.setUserId(user.getUserId());
     when(userDAO.findUserByEmail(collaborator1.email())).thenReturn(user);
@@ -1035,7 +1033,7 @@ library card) eve@yetanotherdomain.org\
 
   @Test
   void validateDarNullDar() {
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, null));
   }
 
@@ -1043,7 +1041,7 @@ library card) eve@yetanotherdomain.org\
   void validateDarNullReferenceId() {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setReferenceId(null);
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
@@ -1051,14 +1049,14 @@ library card) eve@yetanotherdomain.org\
   void validateDarNullData() {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setData(null);
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     assertThrows(IllegalArgumentException.class, () -> service.validateDar(user, dar));
   }
 
   @Test
   void validateDarNoLibraryCards() {
     DataAccessRequest dar = generateDataAccessRequest();
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     assertThrows(NIHComplianceRuleException.class, () -> service.validateDar(user, dar));
   }
 
@@ -1099,7 +1097,7 @@ library card) eve@yetanotherdomain.org\
     User requestingUser = createRequestingUser();
     Collaborator validCollaborator = createCollaborator();
     User collaboratorUser =
-        new User(2, validCollaborator.email(), "Collaborator", new Date(), roles);
+        new User(2, validCollaborator.email(), "Collaborator", FIXED_DATE, roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
     LibraryCard libraryCard = new LibraryCard();
     collaboratorUser.setLibraryCard(libraryCard);
@@ -1116,7 +1114,7 @@ library card) eve@yetanotherdomain.org\
     User requestingUser = createRequestingUser();
     Collaborator validCollaborator = createCollaborator();
     User collaboratorUser =
-        new User(2, validCollaborator.email(), "Collaborator", new Date(), roles);
+        new User(2, validCollaborator.email(), "Collaborator", FIXED_DATE, roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
     LibraryCard libraryCard = new LibraryCard();
     collaboratorUser.setLibraryCard(libraryCard);
@@ -1164,7 +1162,7 @@ library card) eve@yetanotherdomain.org\
     User requestingUser = createRequestingUser();
     Collaborator invalidCollaborator = createCollaborator();
     User collaboratorUser =
-        new User(2, invalidCollaborator.email(), "Collaborator", new Date(), roles);
+        new User(2, invalidCollaborator.email(), "Collaborator", FIXED_DATE, roles);
     collaboratorUser.setInstitutionId(requestingUser.getInstitutionId());
     DataAccessRequest dar = createDataAccessRequest(List.of(invalidCollaborator));
     when(userDAO.findUserByEmail(invalidCollaborator.email())).thenReturn(collaboratorUser);
@@ -1190,7 +1188,7 @@ institution or library cards issued: Internal Collaborator member:  \
   void testUpdateByReferenceIdVersion2() throws Exception {
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setCollectionId(randomInt(0, 100));
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     dar.addDatasetIds(List.of(1, 2, 3));
     when(dataAccessRequestServiceDAO.updateByReferenceId(any(), any())).thenReturn(dar);
     DataAccessRequest newDar = service.updateByReferenceId(user, dar);
@@ -1200,7 +1198,7 @@ institution or library cards issued: Internal Collaborator member:  \
   @Test
   void testUpdateByReferenceIdVersion2_WithCollection() throws Exception {
     DataAccessRequest dar = generateDataAccessRequest();
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     dar.addDatasetIds(List.of(1, 2, 3));
     when(dataAccessRequestServiceDAO.updateByReferenceId(user, dar)).thenReturn(dar);
     DataAccessRequest newDar = service.updateByReferenceId(user, dar);
@@ -1467,7 +1465,7 @@ institution or library cards issued: Internal Collaborator member:  \
     String referenceId = UUID.randomUUID().toString();
     DataAccessRequest dataAccessRequest = new DataAccessRequest();
     dataAccessRequest.setReferenceId(referenceId);
-    dataAccessRequest.setSubmissionDate(Timestamp.from(Instant.now()));
+    dataAccessRequest.setSubmissionDate(FIXED_TIMESTAMP);
 
     assertThrows(
         BadRequestException.class, () -> service.deleteDataAccessRequest(dataAccessRequest));
@@ -1539,7 +1537,7 @@ institution or library cards issued: Internal Collaborator member:  \
   @Test
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsException() {
     String badEmailAddress = "j@example.com";
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     Institution usersInstitution = new Institution();
     usersInstitution.setId(1);
     user.setInstitution(usersInstitution);
@@ -1567,7 +1565,7 @@ institution or library cards issued: Internal Collaborator member:  \
   @Test
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsDoesNotThrowException() {
     String goodEmailAddress = "j@example.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1584,7 +1582,7 @@ institution or library cards issued: Internal Collaborator member:  \
   @Test
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsForBadPI() {
     String badEmailAddress = "bad@evil.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1602,7 +1600,7 @@ institution or library cards issued: Internal Collaborator member:  \
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsForBadSO() {
     String goodEmailAddress = "j@example.com";
     String badEmailAddress = "bad@evil.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1632,7 +1630,7 @@ institution or library cards issued: Internal Collaborator member:  \
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsForBadIT() {
     String goodEmailAddress = "j@example.com";
     String badEmailAddress = "bad@evil.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1654,7 +1652,7 @@ institution or library cards issued: Internal Collaborator member:  \
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsForBadCollaborator() {
     String goodEmailAddress = "j@example.com";
     String badEmailAddress = "bad@evil.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1738,7 +1736,7 @@ institution or library cards issued: Internal Collaborator member:  \
   void testValidatePersonnelInstitutionAndLibraryCardRequirementsThrowsForBadLabStaffMember() {
     String goodEmailAddress = "j@example.com";
     String badEmailAddress = "bad@evil.com";
-    User user = new User(1, "j@example.com", "Display Name", new Date());
+    User user = new User(1, "j@example.com", "Display Name", FIXED_DATE);
     Institution goodInstitution = new Institution();
     goodInstitution.setId(1);
     user.setInstitution(goodInstitution);
@@ -1756,7 +1754,7 @@ institution or library cards issued: Internal Collaborator member:  \
   @Test
   void testValidatePersonnelInstitution_AndLibraryCardRequirements_NoCollaborators() {
     String badEmailAddress = "j@example.com";
-    User user = new User(1, "email@test.org", "Display Name", new Date());
+    User user = new User(1, "email@test.org", "Display Name", FIXED_DATE);
     Institution usersInstitution = new Institution();
     usersInstitution.setId(1);
     user.setInstitution(usersInstitution);
@@ -1780,7 +1778,7 @@ institution or library cards issued: Internal Collaborator member:  \
   }
 
   private User createUserWithPrerequisites() {
-    User user = new User(1, USER_EMAIL, USER_NAME, new Date());
+    User user = new User(1, USER_EMAIL, USER_NAME, FIXED_DATE);
     user.setInstitutionId(1);
     Institution institution = new Institution();
     institution.setId(1);
@@ -1857,13 +1855,9 @@ institution or library cards issued: Internal Collaborator member:  \
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {
-      "RP",
-      "TranslateDUL",
-      "DataSet",
-      "Unknown"
-  })
-  void testSendReminderMessage_NonDataAccessElectionType(String electionType) throws TemplateException, IOException {
+  @ValueSource(strings = {"RP", "TranslateDUL", "DataSet", "Unknown"})
+  void testSendReminderMessage_NonDataAccessElectionType(String electionType)
+      throws TemplateException, IOException {
     Election election = new Election();
     election.setElectionId(randomInt(0, 100));
     election.setReferenceId(UUID.randomUUID().toString());
@@ -2019,9 +2013,9 @@ institution or library cards issued: Internal Collaborator member:  \
     User user = new User();
     user.setUserId(123);
     DataAccessRequest dar = new DataAccessRequest();
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setSubmissionDate(FIXED_TIMESTAMP);
     dar.setParentId(1);
-    dar.setApprovingSigningOfficialApprovedDate(Timestamp.from(Instant.now()));
+    dar.setApprovingSigningOfficialApprovedDate(FIXED_TIMESTAMP);
     dar.setApprovingSigningOfficialUserId(1);
     DataAccessRequestData data = new DataAccessRequestData();
     data.setCloseoutSupplement(new CloseoutSupplement(List.of(""), "", 1));
@@ -2040,7 +2034,7 @@ institution or library cards issued: Internal Collaborator member:  \
     User user = new User();
     user.setUserId(123);
     DataAccessRequest dar = new DataAccessRequest();
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setSubmissionDate(FIXED_TIMESTAMP);
     dar.setParentId(1);
 
     DataAccessRequestData data = new DataAccessRequestData();
@@ -2065,7 +2059,7 @@ institution or library cards issued: Internal Collaborator member:  \
     darSubmitter.setInstitutionId(2);
     DataAccessRequest dar = new DataAccessRequest();
     dar.setUserId(darSubmitter.getUserId());
-    dar.setSubmissionDate(Timestamp.from(Instant.now()));
+    dar.setSubmissionDate(FIXED_TIMESTAMP);
     dar.setParentId(1);
 
     DataAccessRequestData data = new DataAccessRequestData();
@@ -2095,7 +2089,7 @@ institution or library cards issued: Internal Collaborator member:  \
     CloseoutWithUserAndSigningOfficialApproval closeout =
         new CloseoutWithUserAndSigningOfficialApproval();
     Dac dac = new Dac();
-    User chair = new User(1, "chair@duos.org", "A Chair", new Date());
+    User chair = new User(1, "chair@duos.org", "A Chair", FIXED_DATE);
     dac.setChairpersons(List.of(chair));
     when(userService.findUserById(closeout.submitter.getUserId())).thenReturn(closeout.submitter);
     when(dataAccessRequestDAO.findByReferenceId(closeout.dar.referenceId)).thenReturn(closeout.dar);
@@ -2125,7 +2119,7 @@ institution or library cards issued: Internal Collaborator member:  \
       submitter.setUserId(124);
       submitter.setInstitutionId(1);
       dar.setUserId(submitter.getUserId());
-      dar.setSubmissionDate(Timestamp.from(Instant.now()));
+      dar.setSubmissionDate(FIXED_TIMESTAMP);
       dar.setParentId(1);
       dar.setDatasetIds(List.of(1));
       dar.setDarCode("DAR-0001");

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -1477,11 +1476,7 @@ institution or library cards issued: Internal Collaborator member:  \
     data.setPiEmail(PI_EMAIL);
     data.setItDirectorEmail(IT_EMAIL);
     data.setSigningOfficialEmail(SO_EMAIL);
-    try {
-      service.validateNoKeyPersonnelDuplicates(data);
-    } catch (IllegalArgumentException e) {
-      fail("Should not have thrown exception");
-    }
+    assertDoesNotThrow(() -> service.validateNoKeyPersonnelDuplicates(data));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import freemarker.template.TemplateException;
+import jakarta.validation.Valid;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotFoundException;
@@ -84,6 +86,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1845,12 +1849,37 @@ institution or library cards issued: Internal Collaborator member:  \
     vote.setVoteId(randomInt(0, 100));
 
     String darCode = "DAR-12345";
-    String electionType = "DataAccess";
     String url = "http://localhost/dar_collection/1";
 
     initService();
-    service.sendReminderMessage(user, vote, darCode, electionType, url);
+    service.sendReminderMessage(user, vote, darCode, url);
     verify(emailService).sendMessage(any(ReminderMessage.class), eq(user.getUserId()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "RP",
+      "TranslateDUL",
+      "DataSet",
+      "Unknown"
+  })
+  void testSendReminderMessage_NonDataAccessElectionType(String electionType) throws TemplateException, IOException {
+    Election election = new Election();
+    election.setElectionId(randomInt(0, 100));
+    election.setReferenceId(UUID.randomUUID().toString());
+    election.setElectionType(electionType);
+    when(electionDAO.findElectionWithFinalVoteById(any())).thenReturn(election);
+
+    Vote vote = new Vote();
+    vote.setVoteId(randomInt(0, 100));
+    vote.setElectionId(election.getElectionId());
+    when(voteDAO.findVoteById(any())).thenReturn(vote);
+
+    initService();
+    assertThrows(
+        IllegalArgumentException.class, () -> service.sendReminderMessage(vote.getVoteId()));
+    verify(emailService, never()).sendMessage(any(ReminderMessage.class), any());
+    verify(voteDAO, never()).updateVoteReminderFlag(any(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3760

### Summary
This PR continues the RP election cleanup work. Specifically, this PR addresses the following email related features:
- `NewCaseMessage` was only used to send DAR election messages so this is now codified directly in the message itself
- Similarly, `ReminderMessage` was also only used to send DAR vote reminders
  - Relatedly, we do not send `RP` or `DUL` reminders so those are removed.
- `DataAccessRequestService.sendReminderMessage` now enforces that the election must be a `DataAccess` election to proceed.

See also previous PRs:
- https://github.com/DataBiosphere/consent/pull/2969
- https://github.com/DataBiosphere/consent/pull/2970

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
