### PR TITLE
[DT-3211] Add Rate Limit Response to all affected APIs

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -117,6 +117,12 @@ paths:
           description: No DAC or User found with the provided ID
         409:
           description: User is already a member of the DAC
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error
     delete:
@@ -142,6 +148,12 @@ paths:
           description: Dac member successfully removed
         404:
           description: No DAC or User found with the provided ID
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error
   /api/dac/{dacId}/chair/{userId}:
@@ -175,6 +187,12 @@ paths:
           description: No DAC or User found with the provided ID
         409:
           description: User is already a member of the DAC
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error
     delete:
@@ -202,6 +220,12 @@ paths:
           description: Dacs require at least one chair.
         404:
           description: No DAC or User found with the provided ID
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error
   /api/dac/{dacId}/datasets:
@@ -231,6 +255,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/User'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error
   /api/dar/v2:
@@ -265,6 +295,12 @@ paths:
       responses:
         201:
           description: Returns the created draft Data Access Request.
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error.
     get:
@@ -282,6 +318,12 @@ paths:
                 type: array
                 items:
                   $ref: './schemas/DataAccessRequest.yaml'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error.
 
@@ -314,6 +356,12 @@ paths:
           description: Returns the updated draft Data Access Request.
         403:
           description: Updates are restricted to the create user.
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error.
     get:
@@ -336,6 +384,12 @@ paths:
             application/json:
               schema:
                 $ref: './schemas/DataAccessRequest.yaml'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal Server Error.
 
@@ -360,6 +414,12 @@ paths:
           content:
             application/octet-stream:
               schema: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
@@ -394,6 +454,12 @@ paths:
             application/json:
               schema:
                 $ref: './schemas/DataAccessRequest.yaml'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/dar/v2/{referenceId}/collaborationDocument:
     get:
       summary: Retrieve DAR Collaboration Document
@@ -414,6 +480,12 @@ paths:
           content:
             application/octet-stream:
               schema: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
@@ -449,6 +521,12 @@ paths:
               schema:
                 $ref: './schemas/DataAccessRequest.yaml'
 
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/dar/v2/progress_report/{parentReferenceId}:
     $ref: './paths/progressReport.yaml'
   /api/dar/{referenceId}/approveCloseout:
@@ -480,6 +558,12 @@ paths:
                 type: integer
         404:
           description: Dataset not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/dataset/registration/{datasetIdentifier}:
     $ref: './paths/datasetRegistrationByDatasetIdentifier.yaml'
   /api/dataset/studyNames:
@@ -555,6 +639,12 @@ paths:
       responses:
         200:
           description: Email successfully sent
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
           content:
@@ -594,6 +684,12 @@ paths:
                   $ref: '#/components/schemas/LibraryCard'
         401:
           description: User not authorized
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
     post:
@@ -623,6 +719,12 @@ paths:
           description: User not authorized
         409:
           description: Library Card payload conflicts with an existing record
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
   /api/libraryCards/{id}:
@@ -651,6 +753,12 @@ paths:
           description: User not authorized
         404:
           description: Library Card not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
     delete:
@@ -674,6 +782,12 @@ paths:
           description: User not authorized
         404:
           description: Library Card not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
   /api/libraryCards/institution/{id}:
@@ -702,6 +816,12 @@ paths:
           description: User not authorized
         404:
           description: Institution not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Internal server error
   /api/libraryCards/history/{userId}:
@@ -730,6 +850,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/MatchResult'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
   /api/match/purpose/batch/:
@@ -756,6 +882,12 @@ paths:
                 $ref: '#/components/schemas/User'
         404:
           description: User not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
   /api/user/me/dac/datasets:
@@ -786,6 +918,12 @@ paths:
                   $ref: '#/components/schemas/SimplifiedUser'
         404:
           description: User not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
   /api/user/{userId}:
@@ -818,6 +956,12 @@ paths:
           description: Unsupported or Invalid role name
         404:
           description: The user does not have the given role, or role is SO and the user does not have an Institution
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
   /api/user/{userId}/{roleId}:
@@ -847,6 +991,12 @@ paths:
           description: Unauthorized, log in and try the operation again.
         404:
           description: No acknowledgement found for the given key.
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Error processing the request.
     delete:
@@ -873,6 +1023,12 @@ paths:
           description: Unauthorized, log in and try the operation again.
         404:
           description: No acknowledgement found for the given key.
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Error processing the request.
   /api/user/acknowledgements:
@@ -905,6 +1061,12 @@ paths:
           description: |
             Unauthorized, log in and try the operation again.
             Closeout Acknowledgements can only be submitted by Chairpersons
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Error processing the request.
     get:
@@ -922,6 +1084,12 @@ paths:
                 $ref: '#/components/schemas/AcknowledgementMap'
         401:
           description: Unauthorized, log in and try the operation again.
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Error processing the request.
   /api/user/create:

--- a/src/main/resources/assets/paths/adminFeatureById.yaml
+++ b/src/main/resources/assets/paths/adminFeatureById.yaml
@@ -65,6 +65,12 @@ post:
         application/json:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
       content:
@@ -98,6 +104,12 @@ delete:
             $ref: '../schemas/ErrorResponse.yaml'
     404:
       description: Feature flag not found
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/paths/approveCloseoutBySigningOfficial.yaml
+++ b/src/main/resources/assets/paths/approveCloseoutBySigningOfficial.yaml
@@ -18,3 +18,9 @@ put:
       description: Error, consult response for details
     401:
       description: Unauthorized
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/approveCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/approveCollectionByCollectionId.yaml
@@ -27,5 +27,11 @@ post:
       description: Not Found
     409:
       description: Conflict.  Check error details
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/approveDataset.yaml
+++ b/src/main/resources/assets/paths/approveDataset.yaml
@@ -36,5 +36,11 @@ put:
       description: Bad Request (missing or invalid request body)
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500: 
       description: Internal Server Error

--- a/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/cancelCollectionByCollectionId.yaml
@@ -32,5 +32,11 @@ put:
       description: Bad Request (result of elections present on DARs or the user not having the provided role name)
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/cleanupEmptyCertificationAndAlternativeSharingFiles.yaml
+++ b/src/main/resources/assets/paths/cleanupEmptyCertificationAndAlternativeSharingFiles.yaml
@@ -11,4 +11,10 @@ put:
         application/json:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
   operationId: apiDatasetCleanupEmptyCertificationAndAlternativeSharingFilesPut

--- a/src/main/resources/assets/paths/collection.yaml
+++ b/src/main/resources/assets/paths/collection.yaml
@@ -21,3 +21,9 @@ get:
     404:
       description: Not Found
 
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/collectionByReferenceId.yaml
+++ b/src/main/resources/assets/paths/collectionByReferenceId.yaml
@@ -20,3 +20,9 @@ get:
             $ref: '../schemas/DarCollection.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/collectionWithElectionHistoryByCollectionId.yaml
+++ b/src/main/resources/assets/paths/collectionWithElectionHistoryByCollectionId.yaml
@@ -20,5 +20,11 @@ get:
             $ref: '../schemas/DarCollection.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/collectionsByRoleNameSummary.yaml
+++ b/src/main/resources/assets/paths/collectionsByRoleNameSummary.yaml
@@ -30,6 +30,12 @@ get:
       description: Bad Request
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 

--- a/src/main/resources/assets/paths/collectionsForRoleNameByIdSummary.yaml
+++ b/src/main/resources/assets/paths/collectionsForRoleNameByIdSummary.yaml
@@ -37,6 +37,12 @@ get:
       description: Bad Request
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 

--- a/src/main/resources/assets/paths/createCollectionElectionsByCollectionId.yaml
+++ b/src/main/resources/assets/paths/createCollectionElectionsByCollectionId.yaml
@@ -27,5 +27,11 @@ post:
       description: Not Found
     409:
       description: Conflict.  Check error details
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daa.yaml
+++ b/src/main/resources/assets/paths/daa.yaml
@@ -11,5 +11,11 @@ get:
         application/json:
           schema:
             $ref: '../schemas/DataAccessAgreement.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaAssignAllEligibleUsersByDaaId.yaml
+++ b/src/main/resources/assets/paths/daaAssignAllEligibleUsersByDaaId.yaml
@@ -33,6 +33,12 @@ post:
                   type: string
     404:
       description: DAA Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 

--- a/src/main/resources/assets/paths/daaBulkByDaaId.yaml
+++ b/src/main/resources/assets/paths/daaBulkByDaaId.yaml
@@ -38,6 +38,12 @@ post:
       description: User not authorized to add users to DAA
     404:
       description: Daa Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -80,5 +86,11 @@ delete:
       description: User not authorized to remove users from DAA
     404:
       description: Daa Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaBulkByUserId.yaml
+++ b/src/main/resources/assets/paths/daaBulkByUserId.yaml
@@ -38,6 +38,12 @@ post:
       description: User not authorized to add DAAs to a user
     404:
       description: User Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -80,5 +86,11 @@ delete:
       description: User not authorized to remove DAAs from a user
     404:
       description: User Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaByDaaId.yaml
+++ b/src/main/resources/assets/paths/daaByDaaId.yaml
@@ -20,5 +20,11 @@ get:
             $ref: '../schemas/DataAccessAgreement.yaml'
     404:
       description: No DAA found with the given ID
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaById.yaml
+++ b/src/main/resources/assets/paths/daaById.yaml
@@ -32,5 +32,11 @@ post:
       description: User not authorized to create DAA for a DAC.
     404:
       description: Dac Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaDatasets.yaml
+++ b/src/main/resources/assets/paths/daaDatasets.yaml
@@ -32,5 +32,11 @@ post:
       description: Bad Request (malformed list of dataset ids)
     401:
       description: Unauthenticated
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error

--- a/src/main/resources/assets/paths/daaFileByDaaId.yaml
+++ b/src/main/resources/assets/paths/daaFileByDaaId.yaml
@@ -23,6 +23,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
       content:

--- a/src/main/resources/assets/paths/daaForDacId.yaml
+++ b/src/main/resources/assets/paths/daaForDacId.yaml
@@ -24,6 +24,12 @@ put:
       description: User not authorized to create a relationship between a DAA and a DAC.
     404:
       description: Data Access Agreement or Data Access Committee Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -54,5 +60,11 @@ delete:
       description: User not authorized to create a relationship between a DAA and a DAC.
     404:
       description: Data Access Agreement or Data Access Committee Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaForUserId.yaml
+++ b/src/main/resources/assets/paths/daaForUserId.yaml
@@ -24,6 +24,12 @@ delete:
       description: User is forbidden.
     404:
       description: DAA Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 put:
@@ -58,5 +64,11 @@ put:
       description: User not authorized to create a relationship between a DAA and a User.
     404:
       description: User, Data Access Agreement, or Library Card Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/daaUpdateByDacId.yaml
+++ b/src/main/resources/assets/paths/daaUpdateByDacId.yaml
@@ -29,5 +29,11 @@ post:
       description: Successfully sent emails to Signing Officials and Researchers about the newly uploaded DAA
     404:
       description: DAC, DAA, or User Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dac.yaml
+++ b/src/main/resources/assets/paths/dac.yaml
@@ -22,6 +22,12 @@ post:
       description: Bad Request. DAC Name and Description are required.
     403:
       description: User not authorized to request all dacs.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 put:
@@ -48,6 +54,12 @@ put:
             $ref: '../schemas/Dac.yaml'
     400:
       description: Bad Request. DAC ID, Name, and Description are required.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 get:
@@ -71,5 +83,11 @@ get:
             type: array
             items:
               $ref: '../schemas/Dac.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dacById.yaml
+++ b/src/main/resources/assets/paths/dacById.yaml
@@ -20,6 +20,12 @@ get:
             $ref: '../schemas/Dac.yaml'
     404:
       description: No DAC found with the given ID
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -44,5 +50,11 @@ delete:
             $ref: '../schemas/Dac.yaml'
     404:
       description: No DAC found with the given ID
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dacDatasetExternalizeById.yaml
+++ b/src/main/resources/assets/paths/dacDatasetExternalizeById.yaml
@@ -45,6 +45,12 @@ post:
         application/json:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error
       content:

--- a/src/main/resources/assets/paths/dacRuleAuditsById.yaml
+++ b/src/main/resources/assets/paths/dacRuleAuditsById.yaml
@@ -34,5 +34,11 @@ get:
       description: The user is not authorized to retrieve these settings
     401:
       description: No DAC found with the given ID
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dacRuleToggle.yaml
+++ b/src/main/resources/assets/paths/dacRuleToggle.yaml
@@ -31,5 +31,11 @@ put:
       description: Rules are conflicting.  See exception message for how to deconflict.
     422:
       description: No Rule exists with this ID number.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dacRules.yaml
+++ b/src/main/resources/assets/paths/dacRules.yaml
@@ -13,3 +13,9 @@ get:
             type: array
             items:
               $ref: '../schemas/DacAutomationRule.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/dacRulesById.yaml
+++ b/src/main/resources/assets/paths/dacRulesById.yaml
@@ -24,5 +24,11 @@ get:
       description: The user is not authorized to retrieve these settings
     401:
       description: No DAC found with the given ID
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/dailyMessages.yaml
+++ b/src/main/resources/assets/paths/dailyMessages.yaml
@@ -11,5 +11,11 @@ get:
       description: Not authenticated.
     403:
       description: Not authorized.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/darSummariesByDatasetId.yaml
+++ b/src/main/resources/assets/paths/darSummariesByDatasetId.yaml
@@ -21,5 +21,11 @@ get:
               $ref: '../schemas/DarMetric.yaml'
     404:
       description: Dataset with specified ID does not exist
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/darV2.yaml
+++ b/src/main/resources/assets/paths/darV2.yaml
@@ -23,6 +23,12 @@ post:
             type: array
             items:
               $ref: '../schemas/DataAccessRequest.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error.
 get:
@@ -42,5 +48,11 @@ get:
               $ref: '../schemas/DataAccessRequest.yaml'
     403:
       description: The user is not authorized to see all DARs
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server Error

--- a/src/main/resources/assets/paths/darV2ByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2ByReferenceId.yaml
@@ -22,6 +22,12 @@ get:
       description: The provided Reference Id is not a valid DAR identifier
     404:
       description: No DAR can be found with the provided identifier
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server Error
 put:
@@ -53,6 +59,12 @@ put:
             $ref: '../schemas/DataAccessRequest.yaml'
     403:
       description: Updates are restricted to the create user.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error.
 delete:
@@ -84,5 +96,11 @@ delete:
       description: Only drafts can be deleted.
     406:
       description: There are existing resources that reference this Data Access Request
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error.

--- a/src/main/resources/assets/paths/darV2DAAsByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2DAAsByReferenceId.yaml
@@ -25,5 +25,11 @@ get:
       description: The provided Reference Id is not a valid DAR identifier
     404:
       description: No DAR can be found with the provided identifier
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server Error

--- a/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
+++ b/src/main/resources/assets/paths/darV2DatasetDaaSnapshotsByReferenceId.yaml
@@ -23,6 +23,12 @@ get:
               $ref: '../schemas/DatasetDaaSnapshot.yaml'
     404:
       description: No DAR or Progress Report can be found with the provided identifier, or no dataset to DAA snapshot map exists for it
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server Error
 

--- a/src/main/resources/assets/paths/datasetAuthorizedReaders.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedReaders.yaml
@@ -21,3 +21,9 @@ get:
             type: array
             items:
               $ref: '../schemas/DatasetAuthorizedReader.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetAuthorizedReadersAddDelete.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedReadersAddDelete.yaml
@@ -26,6 +26,12 @@ put:
             $ref: '../schemas/DatasetAuthorizedReader.yaml'
     409:
       description: The user is missing the RESEARCHER role required to check access.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 delete:
   summary: Remove authorized access reader
   operationId: apiDatasetIdAuthorizedAccessReadersUserIdDelete
@@ -48,3 +54,9 @@ delete:
   responses:
     200:
       description: The removal of the user was successful
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetAuthorizedUsers.yaml
+++ b/src/main/resources/assets/paths/datasetAuthorizedUsers.yaml
@@ -22,5 +22,11 @@ get:
       description: Invalid dataset identifier.
     404:
       description: Could not find dataset with given identifier.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/datasetBatch.yaml
+++ b/src/main/resources/assets/paths/datasetBatch.yaml
@@ -27,5 +27,11 @@ get:
               $ref: '../schemas/Dataset.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/datasetById.yaml
+++ b/src/main/resources/assets/paths/datasetById.yaml
@@ -50,6 +50,12 @@ patch:
         existing dataset names.
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.
 delete:
@@ -72,5 +78,11 @@ delete:
       description: Dataset is in use and cannot be deleted
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -37,5 +37,11 @@ put:
       description: Bad Request (invalid input)
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error

--- a/src/main/resources/assets/paths/datasetByIdV2.yaml
+++ b/src/main/resources/assets/paths/datasetByIdV2.yaml
@@ -20,5 +20,11 @@ get:
             $ref: '../schemas/Dataset.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/datasetIndex.yaml
+++ b/src/main/resources/assets/paths/datasetIndex.yaml
@@ -10,3 +10,9 @@ post:
       description: All datasets have been indexed
     404:
       description: No datasets found to index
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetIndexById.yaml
+++ b/src/main/resources/assets/paths/datasetIndexById.yaml
@@ -17,6 +17,12 @@ post:
       description: The dataset has been indexed
     404:
       description: Dataset not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 delete:
   summary: Delete dataset index by id
   operationId: apiDatasetIndexDatasetIdDelete
@@ -34,3 +40,9 @@ delete:
   responses:
     200:
       description: The dataset index has been deleted
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetNihInstitutionalCertification.yaml
+++ b/src/main/resources/assets/paths/datasetNihInstitutionalCertification.yaml
@@ -21,5 +21,11 @@ get:
       description: User not authorized to get file
     404:
       description: The dataset and/or the file cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: An unrecoverable error occurred when attempting to return this attachment.

--- a/src/main/resources/assets/paths/datasetRegistrationByDatasetIdentifier.yaml
+++ b/src/main/resources/assets/paths/datasetRegistrationByDatasetIdentifier.yaml
@@ -21,5 +21,11 @@ get:
             $ref: '../schemas/DatasetRegistrationSchemaV1.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -80,3 +80,9 @@ post:
                     publicVisibility: true
                     dataTypes:
                       - genome
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -96,3 +96,9 @@ post:
                             dacId: 2
                             name: Example DAC
                             dacEmail: dac_email@test.org
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/datasetV3.yaml
+++ b/src/main/resources/assets/paths/datasetV3.yaml
@@ -14,6 +14,12 @@ get:
             type: array
             items:
               $ref: '../schemas/DatasetStudySummary.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 post:
   summary: Creates a set of Datasets from a valid dataset registration JsonSchema object
   operationId: apiDatasetV3Post
@@ -54,5 +60,11 @@ post:
       description: Bad Request (invalid input)
     409:
       description: Dataset Name given is already in use by another dataset
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error (something went wrong processing a valid input)

--- a/src/main/resources/assets/paths/datasetV3ById.yaml
+++ b/src/main/resources/assets/paths/datasetV3ById.yaml
@@ -71,5 +71,11 @@ put:
       description: Bad Request (invalid input)
     404:
       description: Dataset Id not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error (something went wrong processing a valid input)

--- a/src/main/resources/assets/paths/datasetsByDacId.yaml
+++ b/src/main/resources/assets/paths/datasetsByDacId.yaml
@@ -26,5 +26,11 @@
                   $ref: '../schemas/Dataset.yaml'
         404:
           description: No DAC found with the provided ID
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/ErrorResponse.yaml'
         500:
           description: Internal Server Error

--- a/src/main/resources/assets/paths/documentById.yaml
+++ b/src/main/resources/assets/paths/documentById.yaml
@@ -38,6 +38,12 @@ get:
     404:
       description: Not Found
 
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 put:
   summary: Update document category by entity and file id
   operationId: apiDocumentEntityEntityIdIdPut
@@ -86,6 +92,12 @@ put:
     404:
       description: Not Found
 
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 delete:
   summary: Soft delete document metadata by entity and file id
   operationId: apiDocumentEntityEntityIdIdDelete
@@ -126,3 +138,9 @@ delete:
     404:
       description: Not Found
 
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/documentFileById.yaml
+++ b/src/main/resources/assets/paths/documentFileById.yaml
@@ -45,6 +45,12 @@ get:
       description: Forbidden
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     502:
       description: Bad Gateway
 

--- a/src/main/resources/assets/paths/documentsByEntityId.yaml
+++ b/src/main/resources/assets/paths/documentsByEntityId.yaml
@@ -33,6 +33,12 @@ get:
       description: Forbidden
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 post:
   summary: Upload a document for an entity
   operationId: apiDocumentEntityEntityIdPost
@@ -84,5 +90,11 @@ post:
       description: Forbidden
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error

--- a/src/main/resources/assets/paths/draftAttachments.yaml
+++ b/src/main/resources/assets/paths/draftAttachments.yaml
@@ -28,6 +28,12 @@ get:
       description: User not authorized to get file attachment
     404:
       description: The draft and/or the attachment cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
        description: An unrecoverable error occurred when attempting to return this attachment.
 delete:
@@ -57,5 +63,11 @@ delete:
       description: User not authorized to delete file attachment
     404:
       description: The draft and/or the attachment cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: An unrecoverable error occurred when deleting this attachment.

--- a/src/main/resources/assets/paths/draftAttachmentsIndex.yaml
+++ b/src/main/resources/assets/paths/draftAttachmentsIndex.yaml
@@ -25,6 +25,12 @@ get:
       description: User not authorized to get list of file attachments
     404:
       description: The draft cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 post:
   summary: Upload attachments to the draft.
   operationId: apiDraftV1DraftUUIDAttachmentsPost
@@ -66,3 +72,9 @@ post:
       description: User not authorized to upload file attachments
     404:
       description: The draft cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/draftDocumentIndex.yaml
+++ b/src/main/resources/assets/paths/draftDocumentIndex.yaml
@@ -23,6 +23,12 @@ get:
       description: User not authorized to get draft
     404:
       description: The draft cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 put:
   summary: Updates a draft
   operationId: apiDraftV1DraftUUIDPut
@@ -56,6 +62,12 @@ put:
       404:
         description: The draft cannot be found.
 
+      429:
+        description: Too Many Requests - rate limit exceeded
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/ErrorResponse.yaml'
 delete:
   summary: Deletes a draft
   operationId: apiDraftV1DraftUUIDDelete
@@ -77,6 +89,12 @@ delete:
       description: User not authorized to delete draft
     404:
       description: The draft cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
 patch:
   summary: Renames a draft
   operationId: apiDraftV1DraftUUIDPatch
@@ -105,3 +123,9 @@ patch:
       description: User not authorized to rename draft
     404:
       description: The draft cannot be found.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/draftIndex.yaml
+++ b/src/main/resources/assets/paths/draftIndex.yaml
@@ -15,6 +15,12 @@ get:
               $ref: '../schemas/DraftSummary.yaml'
     401:
       description: User not authorized to get draft summaries.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error.  Something went wrong with the valid input provided.
 post:
@@ -41,5 +47,11 @@ post:
       description: Bad Request (invalid input)
     401:
       description: User not authorized to create draft
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error (something went wrong processing valid input)

--- a/src/main/resources/assets/paths/findAllDatasetNames.yaml
+++ b/src/main/resources/assets/paths/findAllDatasetNames.yaml
@@ -13,5 +13,11 @@ get:
             type: array
             items:
               type: string
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/findAllStudyNames.yaml
+++ b/src/main/resources/assets/paths/findAllStudyNames.yaml
@@ -14,5 +14,11 @@ get:
             type: array
             items:
               type: string
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/getApprovedDatasets.yaml
+++ b/src/main/resources/assets/paths/getApprovedDatasets.yaml
@@ -15,5 +15,11 @@ get:
               $ref: '../schemas/ApprovedDataset.yaml'
     404:
       description: User not found or no datasets found for user
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacs.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacs.yaml
@@ -16,5 +16,11 @@ get:
               $ref: '../schemas/Dataset.yaml'
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
+++ b/src/main/resources/assets/paths/getDatasetsFromUserDacsV2.yaml
@@ -18,5 +18,11 @@ get:
               $ref: '../schemas/Dataset.yaml'
     404:
       description: User not found or no datasets found for user
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml
+++ b/src/main/resources/assets/paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml
@@ -21,6 +21,12 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/MatchResult.yaml'
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/ErrorResponse.yaml'
         500:
           description: Server error.
         404:

--- a/src/main/resources/assets/paths/institutionById.yaml
+++ b/src/main/resources/assets/paths/institutionById.yaml
@@ -21,6 +21,12 @@ get:
             $ref: '../schemas/Institution.yaml'
     404:
       description: Institution not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 patch:
@@ -78,6 +84,12 @@ patch:
           description: Bad Request
         404:
           description: Institution not found
+        429:
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/ErrorResponse.yaml'
         500:
           description: Internal Server Error
 put:
@@ -107,6 +119,12 @@ put:
       description: Bad Request
     404:
       description: Institution not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -127,5 +145,11 @@ delete:
       description: Deletes target institution (no return entity)
     404:
       description: Institution not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/institutions.yaml
+++ b/src/main/resources/assets/paths/institutions.yaml
@@ -9,6 +9,12 @@ get:
       description: Returns all institutions, along with their create user, update user, and signing official users if there are any.
         If no results are found, an empty array is returned.
         Admin will see all details while non-Admins will only see a subset.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 post:
@@ -31,5 +37,11 @@ post:
       description: Bad Request
     409:
       description: Conflict Error
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/institutionsDomains.yaml
+++ b/src/main/resources/assets/paths/institutionsDomains.yaml
@@ -30,5 +30,11 @@ post:
       description: Bad Request
     409:
       description: Conflict Error
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
+++ b/src/main/resources/assets/paths/libraryCardHistoryByUserId.yaml
@@ -28,6 +28,12 @@ get:
       description: Forbidden - The requester does not have permission to access this resource.
     404:
       description: Not Found - User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error - An error occurred while processing the request.
 

--- a/src/main/resources/assets/paths/mailByRange.yaml
+++ b/src/main/resources/assets/paths/mailByRange.yaml
@@ -46,5 +46,11 @@ get:
       description: Bad Request - Check to make sure dates are provided in the MM/dd/yyyy format and that limit and offset are not negative.
     401:
       description: Unauthorized.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/mailByType.yaml
+++ b/src/main/resources/assets/paths/mailByType.yaml
@@ -74,5 +74,11 @@ get:
       description: Bad Request.  Make sure limit and offset are not negative numbers.
     401:
       description: Unauthorized.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/mailByUserId.yaml
+++ b/src/main/resources/assets/paths/mailByUserId.yaml
@@ -38,5 +38,11 @@ get:
       description: Bad Request.  Make sure limit and offset are not negative numbers.
     401:
       description: Unauthorized.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/nih.yaml
+++ b/src/main/resources/assets/paths/nih.yaml
@@ -8,3 +8,9 @@ delete:
   responses:
     200:
       description: Returns an empty response if the operation was successful
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/nihSync.yaml
+++ b/src/main/resources/assets/paths/nihSync.yaml
@@ -12,5 +12,11 @@ get:
         application/json:
           schema:
             $ref: '../schemas/User.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/ontology.yaml
+++ b/src/main/resources/assets/paths/ontology.yaml
@@ -21,6 +21,12 @@ post:
   responses:
     200:
       description: Ontology Index Results
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 
@@ -41,5 +47,11 @@ delete:
   responses:
     200:
       description: Ontology Deletion Results
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/ontologyReconcile.yaml
+++ b/src/main/resources/assets/paths/ontologyReconcile.yaml
@@ -16,5 +16,11 @@ get:
             type: array
             items:
               $ref: '../schemas/OntologyReconciliationResult.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/passportUserInfo.yaml
+++ b/src/main/resources/assets/paths/passportUserInfo.yaml
@@ -19,5 +19,11 @@ get:
       description: Bad Request
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/progressReport.yaml
+++ b/src/main/resources/assets/paths/progressReport.yaml
@@ -57,6 +57,12 @@ post:
         application/json:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error
       content:

--- a/src/main/resources/assets/paths/resubmitCollectionByCollectionId.yaml
+++ b/src/main/resources/assets/paths/resubmitCollectionByCollectionId.yaml
@@ -22,5 +22,11 @@ put:
       description: Bad Request (dar collection is not canceled)
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/samRegisterSelf.yaml
+++ b/src/main/resources/assets/paths/samRegisterSelf.yaml
@@ -13,5 +13,11 @@ post:
             $ref: '../schemas/SamUserInfo.yaml'
     409:
       description: Conflict, user exists
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/samRegisterSelfDiagnostics.yaml
+++ b/src/main/resources/assets/paths/samRegisterSelfDiagnostics.yaml
@@ -13,5 +13,11 @@ get:
             $ref: '../schemas/SamSelfDiagnostics.yaml'
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/samRegisterSelfInfo.yaml
+++ b/src/main/resources/assets/paths/samRegisterSelfInfo.yaml
@@ -13,5 +13,11 @@ get:
             $ref: '../schemas/SamUserInfo.yaml'
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/samRegisterSelfTos.yaml
+++ b/src/main/resources/assets/paths/samRegisterSelfTos.yaml
@@ -11,6 +11,12 @@ post:
         application/json:
           schema:
             $ref: '../schemas/SamTosResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error
 delete:
@@ -26,5 +32,11 @@ delete:
         application/json:
           schema:
             $ref: '../schemas/SamTosResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/samResourceTypes.yaml
+++ b/src/main/resources/assets/paths/samResourceTypes.yaml
@@ -11,5 +11,11 @@ get:
         application/json:
           schema:
             type: object
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/studyById.yaml
+++ b/src/main/resources/assets/paths/studyById.yaml
@@ -20,6 +20,12 @@ get:
             $ref: '../schemas/Study.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error
 put:
@@ -83,6 +89,12 @@ put:
       description: Forbidden
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error
 delete:
@@ -108,6 +120,12 @@ delete:
       description: Study is in use and cannot be deleted
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error
 patch:
@@ -153,5 +171,11 @@ patch:
       description: Not Modified
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/studyByIdCustodians.yaml
+++ b/src/main/resources/assets/paths/studyByIdCustodians.yaml
@@ -35,5 +35,11 @@ put:
       description: User is not authorized
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
+++ b/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
@@ -29,5 +29,11 @@ put:
       description: Bad Request
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/studyRegistrationByStudyId.yaml
+++ b/src/main/resources/assets/paths/studyRegistrationByStudyId.yaml
@@ -20,5 +20,11 @@ get:
             $ref: '../schemas/DatasetRegistrationSchemaV1.yaml'
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error

--- a/src/main/resources/assets/paths/tdrDataset.yaml
+++ b/src/main/resources/assets/paths/tdrDataset.yaml
@@ -22,5 +22,11 @@ get:
       description: Invalid dataset identifier.
     404:
       description: Could not find dataset with given identifier.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/tdrDatasetApprovedUsers.yaml
+++ b/src/main/resources/assets/paths/tdrDatasetApprovedUsers.yaml
@@ -22,5 +22,11 @@ get:
       description: Invalid dataset identifier.
     404:
       description: Could not find dataset with given identifier.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/user.yaml
+++ b/src/main/resources/assets/paths/user.yaml
@@ -15,6 +15,12 @@ post:
       description: Unable to validate the user's google identity.
     409:
       description: User should be unique
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.
 put:
@@ -61,5 +67,11 @@ put:
       description: Bad request if invalid input is provided
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/userByIdv2.yaml
+++ b/src/main/resources/assets/paths/userByIdv2.yaml
@@ -20,6 +20,12 @@ get:
             $ref: '../schemas/User.yaml'
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.
 put:
@@ -72,5 +78,11 @@ put:
             $ref: '../schemas/User.yaml'
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/userCreate.yaml
+++ b/src/main/resources/assets/paths/userCreate.yaml
@@ -44,3 +44,9 @@ post:
     403:
         description: |
           Forbidden. The user does not have permission to create a user with the specified roles
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/userInstitutionByInstitutionId.yaml
+++ b/src/main/resources/assets/paths/userInstitutionByInstitutionId.yaml
@@ -25,5 +25,11 @@ get:
       description: Bad Request
     404:
       description: Not Found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Server Error

--- a/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
+++ b/src/main/resources/assets/paths/userInstitutionSigningOfficials.yaml
@@ -41,5 +41,11 @@ get:
         other than their own.
     404:
       description: Authenticated user not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal server error

--- a/src/main/resources/assets/paths/userRedact.yaml
+++ b/src/main/resources/assets/paths/userRedact.yaml
@@ -25,6 +25,12 @@ post:
       description: Administrator required to redact a user.
     404:
       description: No user found with the supplied email address.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Error processing the request.
 

--- a/src/main/resources/assets/paths/userRole.yaml
+++ b/src/main/resources/assets/paths/userRole.yaml
@@ -48,6 +48,12 @@ put:
       description: Bad Request
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.
 delete:
@@ -101,5 +107,11 @@ delete:
         Signing Official role from themselves.
     404:
       description: User not found
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Server error.

--- a/src/main/resources/assets/paths/votes.yaml
+++ b/src/main/resources/assets/paths/votes.yaml
@@ -50,5 +50,11 @@ put:
       description: Not Found
     409:
       description: Conflict Error
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error

--- a/src/main/resources/assets/paths/votesRationale.yaml
+++ b/src/main/resources/assets/paths/votesRationale.yaml
@@ -37,5 +37,11 @@ put:
       description: Not Found
     409:
       description: Conflict Error
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     500:
       description: Internal Error


### PR DESCRIPTION
### Addresses
Completes https://broadworkbench.atlassian.net/browse/DT-3211

### Summary
This PR adds
```
        429:
          description: Too Many Requests - rate limit exceeded
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ErrorResponse'
```
to all endpoints under `/api`. 

### Of Note
There are a number of unauthenticated paths that are NOT subject to rate limiting that we may wish to reevaluate:
* `/feature`
* `/ontology/search`
* `/ontology/autocomplete`
* `/tos/text`
* `/tos/text/duos`

These endpoints should never be subject to rate limiting:
- `/liveness`
- `/status`
- `/version`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
