### PR TITLE
[DT-3325] Bulk DAA endpoint hardening.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -193,7 +193,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       SELECT :daaId, :lcId, :lcUserId, :userId, 'ADD', NOW()
       WHERE EXISTS (SELECT 1 FROM lc_daa_insert)
       """)
-  void createLibraryCardDaaRelation(
+  int createLibraryCardDaaRelation(
       @Bind("lcUserId") Integer lcUserId,
       @Bind("userId") Integer userId,
       @Bind("lcId") Integer lcId,
@@ -211,7 +211,7 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       SELECT :daaId, :lcId, :lcUserId, :userId, 'REMOVE', NOW()
       WHERE EXISTS (SELECT 1 FROM lc_daa_delete)
       """)
-  void deleteLibraryCardDaaRelation(
+  int deleteLibraryCardDaaRelation(
       @Bind("lcUserId") Integer lcUserId,
       @Bind("userId") Integer userId,
       @Bind("lcId") Integer lcId,

--- a/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/LibraryCardDAO.java
@@ -131,6 +131,15 @@ public interface LibraryCardDAO extends Transactional<LibraryCardDAO> {
       """)
   LibraryCard findLibraryCardByUserId(@Bind("userId") Integer userId);
 
+  /**
+   * Lightweight lookup of just a user's library-card id (or null). Unlike {@link
+   * #findLibraryCardByUserId} this touches only {@code library_card} (served by the unique index on
+   * {@code user_id}) and joins nothing, so it is cheap to call per-user inside a bulk loop where
+   * the full card with its DAA/audit associations is not needed.
+   */
+  @SqlQuery("SELECT id FROM library_card WHERE user_id = :userId")
+  Integer findLibraryCardIdByUserId(@Bind("userId") Integer userId);
+
   @RegisterBeanMapper(value = LibraryCard.class)
   @UseRowReducer(LibraryCardReducer.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
@@ -1,0 +1,75 @@
+package org.broadinstitute.consent.http.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Result of an atomic bulk pre-authorization operation between researchers and a DAA (the SO-driven
+ * "Approve All" / "Remove All" actions).
+ *
+ * <p>Because the underlying operation runs in a single database transaction it is all-or-nothing
+ * with respect to failure: a mid-batch error rolls the whole batch back and surfaces as an
+ * exception rather than a partial result, so {@code errors} is always empty on a returned summary.
+ * {@code applied} counts only the relationships that actually changed; requested items that were
+ * already in the desired state (re-adding an existing pre-authorization, or removing one that was
+ * never present) are no-ops counted under {@code skipped}, so {@code applied + skipped ==
+ * requested} and {@code applied} may be less than {@code requested}.
+ */
+public class DaaBulkRelationResult {
+
+  @JsonProperty private Integer requested;
+
+  @JsonProperty private Integer applied;
+
+  @JsonProperty private Integer skipped;
+
+  @JsonProperty private List<String> errors;
+
+  public DaaBulkRelationResult() {}
+
+  public DaaBulkRelationResult(
+      Integer requested, Integer applied, Integer skipped, List<String> errors) {
+    this.requested = requested;
+    this.applied = applied;
+    this.skipped = skipped;
+    this.errors = errors == null ? new ArrayList<>() : errors;
+  }
+
+  /** Convenience factory for the atomic happy path where every requested item was applied. */
+  public static DaaBulkRelationResult allApplied(int requested) {
+    return new DaaBulkRelationResult(requested, requested, 0, List.of());
+  }
+
+  public Integer getRequested() {
+    return requested;
+  }
+
+  public void setRequested(Integer requested) {
+    this.requested = requested;
+  }
+
+  public Integer getApplied() {
+    return applied;
+  }
+
+  public void setApplied(Integer applied) {
+    this.applied = applied;
+  }
+
+  public Integer getSkipped() {
+    return skipped;
+  }
+
+  public void setSkipped(Integer skipped) {
+    this.skipped = skipped;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+
+  public void setErrors(List<String> errors) {
+    this.errors = errors;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Result of an atomic bulk pre-authorization operation between researchers and a DAA (the SO-driven
@@ -10,11 +8,11 @@ import java.util.List;
  *
  * <p>Because the underlying operation runs in a single database transaction it is all-or-nothing
  * with respect to failure: a mid-batch error rolls the whole batch back and surfaces as an
- * exception rather than a partial result, so {@code errors} is always empty on a returned summary.
- * {@code applied} counts only the relationships that actually changed; requested items that were
- * already in the desired state (re-adding an existing pre-authorization, or removing one that was
- * never present) are no-ops counted under {@code skipped}, so {@code applied + skipped ==
- * requested} and {@code applied} may be less than {@code requested}.
+ * exception rather than a partial result. {@code applied} counts only the relationships that
+ * actually changed; requested items that were already in the desired state (re-adding an existing
+ * pre-authorization, or removing one that was never present) are no-ops counted under {@code
+ * skipped}, so {@code applied + skipped == requested} and {@code applied} may be less than {@code
+ * requested}.
  */
 public class DaaBulkRelationResult {
 
@@ -24,21 +22,17 @@ public class DaaBulkRelationResult {
 
   @JsonProperty private Integer skipped;
 
-  @JsonProperty private List<String> errors;
-
   public DaaBulkRelationResult() {}
 
-  public DaaBulkRelationResult(
-      Integer requested, Integer applied, Integer skipped, List<String> errors) {
+  public DaaBulkRelationResult(Integer requested, Integer applied, Integer skipped) {
     this.requested = requested;
     this.applied = applied;
     this.skipped = skipped;
-    setErrors(errors);
   }
 
   /** Convenience factory for the atomic happy path where every requested item was applied. */
   public static DaaBulkRelationResult allApplied(int requested) {
-    return new DaaBulkRelationResult(requested, requested, 0, List.of());
+    return new DaaBulkRelationResult(requested, requested, 0);
   }
 
   public Integer getRequested() {
@@ -63,17 +57,5 @@ public class DaaBulkRelationResult {
 
   public void setSkipped(Integer skipped) {
     this.skipped = skipped;
-  }
-
-  public List<String> getErrors() {
-    return errors;
-  }
-
-  /**
-   * Normalizes {@code null} to an empty list and defensively copies, preserving the class invariant
-   * that {@code errors} is always a non-null list callers can safely read.
-   */
-  public void setErrors(List<String> errors) {
-    this.errors = errors == null ? new ArrayList<>() : new ArrayList<>(errors);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DaaBulkRelationResult.java
@@ -33,7 +33,7 @@ public class DaaBulkRelationResult {
     this.requested = requested;
     this.applied = applied;
     this.skipped = skipped;
-    this.errors = errors == null ? new ArrayList<>() : errors;
+    setErrors(errors);
   }
 
   /** Convenience factory for the atomic happy path where every requested item was applied. */
@@ -69,7 +69,11 @@ public class DaaBulkRelationResult {
     return errors;
   }
 
+  /**
+   * Normalizes {@code null} to an empty list and defensively copies, preserving the class invariant
+   * that {@code errors} is always a non-null list callers can safely read.
+   */
   public void setErrors(List<String> errors) {
-    this.errors = errors;
+    this.errors = errors == null ? new ArrayList<>() : new ArrayList<>(errors);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DaaResource.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DaaBulkAssignmentResult;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DuosUser;
@@ -213,6 +214,7 @@ public class DaaResource extends Resource implements ConsentLogger {
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/bulk/{daaId}")
   public Response bulkAddUsersToDaa(
@@ -225,11 +227,8 @@ public class DaaResource extends Resource implements ConsentLogger {
           return Response.status(Status.FORBIDDEN).build();
         }
       }
-      daaService.findById(daaId);
-      for (User user : users) {
-        libraryCardService.addDaaToUserLibraryCard(user, authedUser, daaId);
-      }
-      return Response.ok().build();
+      DaaBulkRelationResult result = daaService.bulkAddUsersToDaa(daaId, users, authedUser);
+      return Response.ok(result).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -252,6 +251,7 @@ public class DaaResource extends Resource implements ConsentLogger {
 
   @DELETE
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/bulk/{daaId}")
   public Response bulkRemoveUsersFromDaa(
@@ -264,11 +264,8 @@ public class DaaResource extends Resource implements ConsentLogger {
           return Response.status(Status.FORBIDDEN).build();
         }
       }
-      daaService.findById(daaId);
-      for (User user : users) {
-        libraryCardService.removeDaaFromUserLibraryCard(user, authedUser, daaId);
-      }
-      return Response.ok().build();
+      DaaBulkRelationResult result = daaService.bulkRemoveUsersFromDaa(daaId, users, authedUser);
+      return Response.ok(result).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -276,6 +273,7 @@ public class DaaResource extends Resource implements ConsentLogger {
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/bulk/user/{userId}")
   public Response bulkAddDAAsToUser(
@@ -287,10 +285,9 @@ public class DaaResource extends Resource implements ConsentLogger {
         return Response.status(Status.FORBIDDEN).build();
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
-      for (DataAccessAgreement daa : daaList) {
-        libraryCardService.addDaaToUserLibraryCard(user, authedUser, daa.getDaaId());
-      }
-      return Response.ok().build();
+      List<Integer> daaIds = daaList.stream().map(DataAccessAgreement::getDaaId).toList();
+      DaaBulkRelationResult result = daaService.bulkAddDaasToUser(user, daaIds, authedUser);
+      return Response.ok(result).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -298,6 +295,7 @@ public class DaaResource extends Resource implements ConsentLogger {
 
   @DELETE
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed({SIGNINGOFFICIAL})
   @Path("/bulk/user/{userId}")
   public Response bulkRemoveDAAsFromUser(
@@ -309,10 +307,9 @@ public class DaaResource extends Resource implements ConsentLogger {
         return Response.status(Status.FORBIDDEN).build();
       }
       List<DataAccessAgreement> daaList = daaService.findDAAsInJsonArray(json, "daaList");
-      for (DataAccessAgreement daa : daaList) {
-        libraryCardService.removeDaaFromUserLibraryCard(user, authedUser, daa.getDaaId());
-      }
-      return Response.ok().build();
+      List<Integer> daaIds = daaList.stream().map(DataAccessAgreement::getDaaId).toList();
+      DaaBulkRelationResult result = daaService.bulkRemoveDaasFromUser(user, daaIds, authedUser);
+      return Response.ok(result).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -29,6 +29,7 @@ import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadResearcherMessage;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadSOMessage;
 import org.broadinstitute.consent.http.models.DaaBulkAssignmentResult;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -325,5 +326,75 @@ public class DaaService implements ConsentLogger {
 
     return new DaaBulkAssignmentResult(
         daaId, eligibleUsers.size(), assignedCount, skippedCount, errors);
+  }
+
+  // ── Atomic bulk pre-authorization (DT-3325) ─────────────────────────────────────
+  //
+  // Each method delegates the all-or-nothing database work to DaaServiceDAO, then sends any
+  // "new library card issued" notification AFTER the transaction commits. Email is kept out of
+  // the transaction on purpose: a sent email cannot be rolled back, and an email failure must
+  // not undo committed pre-authorizations.
+
+  /** Atomically pre-authorize every user in {@code users} for {@code daaId}. */
+  public DaaBulkRelationResult bulkAddUsersToDaa(
+      Integer daaId, List<User> users, User signingOfficial) {
+    findById(daaId);
+    // Reject before mutating anything, in every case the single-link add flow would. The signing
+    // official must have an institution regardless of whether any card is created, and each user
+    // who would have a library card auto-created must pass the same pre-creation validations.
+    libraryCardService.requireSigningOfficialInstitution(signingOfficial);
+    List<User> usersNeedingCard =
+        users.stream()
+            .filter(user -> libraryCardService.findLibraryCardByUserId(user.getUserId()) == null)
+            .toList();
+    usersNeedingCard.forEach(
+        user -> libraryCardService.validateNewLibraryCardCreation(user, signingOfficial));
+    DaaBulkRelationResult result = daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial);
+    usersNeedingCard.forEach(this::notifyNewLibraryCard);
+    return result;
+  }
+
+  /** Atomically remove pre-authorization for {@code daaId} from every user in {@code users}. */
+  public DaaBulkRelationResult bulkRemoveUsersFromDaa(
+      Integer daaId, List<User> users, User signingOfficial) {
+    findById(daaId);
+    return daaServiceDAO.bulkRemoveUsersFromDaa(daaId, users, signingOfficial);
+  }
+
+  /** Atomically pre-authorize {@code user} for every DAA in {@code daaIds}. */
+  public DaaBulkRelationResult bulkAddDaasToUser(
+      User user, List<Integer> daaIds, User signingOfficial) {
+    // Reject before mutating anything, matching the single-link add flow: the signing official must
+    // have an institution regardless of whether a card is created.
+    libraryCardService.requireSigningOfficialInstitution(signingOfficial);
+    boolean needsCard = libraryCardService.findLibraryCardByUserId(user.getUserId()) == null;
+    if (needsCard) {
+      // Match the single-link flow's card-creation guards for the user getting a new card.
+      libraryCardService.validateNewLibraryCardCreation(user, signingOfficial);
+    }
+    DaaBulkRelationResult result = daaServiceDAO.bulkAddDaasToUser(user, daaIds, signingOfficial);
+    if (needsCard) {
+      notifyNewLibraryCard(user);
+    }
+    return result;
+  }
+
+  /** Atomically remove pre-authorization for every DAA in {@code daaIds} from {@code user}. */
+  public DaaBulkRelationResult bulkRemoveDaasFromUser(
+      User user, List<Integer> daaIds, User signingOfficial) {
+    return daaServiceDAO.bulkRemoveDaasFromUser(user, daaIds, signingOfficial);
+  }
+
+  /**
+   * Best-effort "new library card issued" notification, mirroring the single-link path's behavior.
+   * Sent post-commit; a failure is logged and swallowed so it never rolls back an already-committed
+   * pre-authorization batch.
+   */
+  private void notifyNewLibraryCard(User user) {
+    try {
+      libraryCardService.sendNewLibraryCardIssuedMessage(user);
+    } catch (Exception e) {
+      logWarn("Failed to send library card issuance notification for user " + user.getUserId(), e);
+    }
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -366,10 +366,8 @@ public class DaaService implements ConsentLogger {
   /** Atomically pre-authorize {@code user} for every DAA in {@code daaIds}. */
   public DaaBulkRelationResult bulkAddDaasToUser(
       User user, List<Integer> daaIds, User signingOfficial) {
-    // Reject before mutating anything, matching the single-link add flow. Each referenced DAA must
-    // exist: findById throws NotFoundException (404), preserving the single-link flow's friendly
-    // error rather than letting a bad id surface as a raw FK violation / generic 500 mid-batch.
-    daaIds.stream().distinct().forEach(this::findById);
+    // Callers resolve daaIds via findDAAsInJsonArray, which already 404s on any missing DAA, so no
+    // per-id existence re-check is needed here.
     // The signing official must have an institution regardless of whether a card is created.
     libraryCardService.requireSigningOfficialInstitution(signingOfficial);
     if (libraryCardService.findLibraryCardIdByUserId(user.getUserId()) == null) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +37,7 @@ import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DaaServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DaaServiceDAO.BulkAddResult;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.jdbi.v3.core.Jdbi;
@@ -341,17 +343,17 @@ public class DaaService implements ConsentLogger {
     findById(daaId);
     // Reject before mutating anything, in every case the single-link add flow would. The signing
     // official must have an institution regardless of whether any card is created, and each user
-    // who would have a library card auto-created must pass the same pre-creation validations.
+    // who would have a library card auto-created must pass the same pre-creation validations. The
+    // id-only lookup avoids the DAA/audit joins of the full-card query.
     libraryCardService.requireSigningOfficialInstitution(signingOfficial);
-    List<User> usersNeedingCard =
-        users.stream()
-            .filter(user -> libraryCardService.findLibraryCardByUserId(user.getUserId()) == null)
-            .toList();
-    usersNeedingCard.forEach(
-        user -> libraryCardService.validateNewLibraryCardCreation(user, signingOfficial));
-    DaaBulkRelationResult result = daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial);
-    usersNeedingCard.forEach(this::notifyNewLibraryCard);
-    return result;
+    users.stream()
+        .filter(user -> libraryCardService.findLibraryCardIdByUserId(user.getUserId()) == null)
+        .forEach(user -> libraryCardService.validateNewLibraryCardCreation(user, signingOfficial));
+    BulkAddResult result = daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial);
+    // Notify only users whose card the transaction actually inserted, avoiding a mis-notification
+    // if a card was created for a user between the pre-transaction check and the commit.
+    notifyUsersWithNewCard(users, result.usersWithNewCard());
+    return result.summary();
   }
 
   /** Atomically remove pre-authorization for {@code daaId} from every user in {@code users}. */
@@ -367,22 +369,33 @@ public class DaaService implements ConsentLogger {
     // Reject before mutating anything, matching the single-link add flow: the signing official must
     // have an institution regardless of whether a card is created.
     libraryCardService.requireSigningOfficialInstitution(signingOfficial);
-    boolean needsCard = libraryCardService.findLibraryCardByUserId(user.getUserId()) == null;
-    if (needsCard) {
+    if (libraryCardService.findLibraryCardIdByUserId(user.getUserId()) == null) {
       // Match the single-link flow's card-creation guards for the user getting a new card.
       libraryCardService.validateNewLibraryCardCreation(user, signingOfficial);
     }
-    DaaBulkRelationResult result = daaServiceDAO.bulkAddDaasToUser(user, daaIds, signingOfficial);
-    if (needsCard) {
-      notifyNewLibraryCard(user);
-    }
-    return result;
+    BulkAddResult result = daaServiceDAO.bulkAddDaasToUser(user, daaIds, signingOfficial);
+    // Notify only if the transaction actually created the card (never on a pre-transaction guess).
+    notifyUsersWithNewCard(List.of(user), result.usersWithNewCard());
+    return result.summary();
   }
 
   /** Atomically remove pre-authorization for every DAA in {@code daaIds} from {@code user}. */
   public DaaBulkRelationResult bulkRemoveDaasFromUser(
       User user, List<Integer> daaIds, User signingOfficial) {
     return daaServiceDAO.bulkRemoveDaasFromUser(user, daaIds, signingOfficial);
+  }
+
+  /**
+   * Best-effort "new library card issued" notification for exactly the users whose card was created
+   * by the committed batch, as reported by the transaction in {@code userIdsWithNewCard}. Driving
+   * this off the actual insertions (rather than a pre-transaction estimate) avoids notifying a user
+   * whose card was created by another actor between the pre-check and the commit.
+   */
+  private void notifyUsersWithNewCard(List<User> candidates, List<Integer> userIdsWithNewCard) {
+    Set<Integer> newCardUserIds = new HashSet<>(userIdsWithNewCard);
+    candidates.stream()
+        .filter(user -> newCardUserIds.contains(user.getUserId()))
+        .forEach(this::notifyNewLibraryCard);
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DaaService.java
@@ -366,8 +366,11 @@ public class DaaService implements ConsentLogger {
   /** Atomically pre-authorize {@code user} for every DAA in {@code daaIds}. */
   public DaaBulkRelationResult bulkAddDaasToUser(
       User user, List<Integer> daaIds, User signingOfficial) {
-    // Reject before mutating anything, matching the single-link add flow: the signing official must
-    // have an institution regardless of whether a card is created.
+    // Reject before mutating anything, matching the single-link add flow. Each referenced DAA must
+    // exist: findById throws NotFoundException (404), preserving the single-link flow's friendly
+    // error rather than letting a bad id surface as a raw FK violation / generic 500 mid-batch.
+    daaIds.stream().distinct().forEach(this::findById);
+    // The signing official must have an institution regardless of whether a card is created.
     libraryCardService.requireSigningOfficialInstitution(signingOfficial);
     if (libraryCardService.findLibraryCardIdByUserId(user.getUserId()) == null) {
       // Match the single-link flow's card-creation guards for the user getting a new card.

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -120,15 +120,49 @@ public class LibraryCardService implements ConsentLogger {
   }
 
   public LibraryCard addDaaToUserLibraryCard(User user, User signingOfficial, Integer daaId) {
-    if (signingOfficial.getInstitutionId() == null) {
-      throw new BadRequestException("This signing official does not have an institution.");
-    }
+    requireSigningOfficialInstitution(signingOfficial);
     LibraryCard libraryCard = libraryCardDAO.findLibraryCardByUserId(user.getUserId());
     if (libraryCard == null) {
       libraryCard = createLibraryCardForSigningOfficial(user, signingOfficial);
     }
     addDaaToLibraryCard(user.getUserId(), signingOfficial.getUserId(), libraryCard.getId(), daaId);
     return libraryCardDAO.findLibraryCardByUserId(user.getUserId());
+  }
+
+  /**
+   * The signing-official-level guard that {@link #addDaaToUserLibraryCard} applies to every
+   * pre-authorization regardless of whether a library card ends up being created. The atomic bulk
+   * pre-authorization add flows (see {@code DaaServiceDAO}) call this once, up front, so a bulk
+   * "Approve All" is rejected in the same case the single-link flow would be — even when every
+   * targeted user already has a card and no card creation is triggered.
+   */
+  public void requireSigningOfficialInstitution(User signingOfficial) {
+    if (signingOfficial.getInstitutionId() == null) {
+      throw new BadRequestException("This signing official does not have an institution.");
+    }
+  }
+
+  /**
+   * Runs — without inserting anything — exactly the validations that {@link #createLibraryCard}
+   * performs before persisting a new library card: no card may already exist for the user, the user
+   * must exist with a matching email, and the user's email must map to their institution.
+   *
+   * <p>The atomic bulk pre-authorization flows create library cards inside their own database
+   * transaction (see {@code DaaServiceDAO}) and therefore cannot route through {@link
+   * #createLibraryCard}; they call this for each user who would have a card auto-created so a bulk
+   * "Approve All" rejects that user in every case the per-researcher flow would. The
+   * signing-official guard is applied separately and unconditionally via {@link
+   * #requireSigningOfficialInstitution}.
+   */
+  public void validateNewLibraryCardCreation(User user, User signingOfficial) {
+    LibraryCard payload = new LibraryCard();
+    payload.setUserId(user.getUserId());
+    payload.setUserName(user.getDisplayName());
+    payload.setUserEmail(user.getEmail());
+    payload.setCreateUserId(signingOfficial.getUserId());
+    checkIfCardExists(payload);
+    processUserOnNewLC(payload);
+    checkForValidInstitution(user.getInstitutionId(), payload.getUserEmail());
   }
 
   public LibraryCard removeDaaFromUserLibraryCard(

--- a/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/LibraryCardService.java
@@ -81,6 +81,14 @@ public class LibraryCardService implements ConsentLogger {
     return libraryCardDAO.findLibraryCardByUserId(userId);
   }
 
+  /**
+   * Lightweight existence/id check for a user's library card, avoiding the DAA/audit joins of
+   * {@link #findLibraryCardByUserId}. Returns the card id, or null when the user has no card.
+   */
+  public Integer findLibraryCardIdByUserId(Integer userId) {
+    return libraryCardDAO.findLibraryCardIdByUserId(userId);
+  }
+
   public List<LibraryCard> findLibraryCardsByInstitutionId(Integer institutionId) {
     return libraryCardDAO.findLibraryCardsByInstitutionId(institutionId);
   }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -12,7 +12,6 @@ import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
 import org.broadinstitute.consent.http.db.LibraryCardDAO;
 import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.FileStorageObject;
-import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
@@ -83,20 +82,23 @@ public class DaaServiceDAO implements ConsentLogger {
    * Atomically pre-authorize every user in {@code users} for a single DAA. Any user lacking a
    * library card has one created inside the transaction.
    */
-  public DaaBulkRelationResult bulkAddUsersToDaa(
-      Integer daaId, List<User> users, User signingOfficial) {
-    return inBulkTransaction(
-        users.size(),
-        lcDAO -> {
-          int applied = 0;
-          for (User user : users) {
-            Integer lcId = findOrCreateLibraryCardId(lcDAO, user, signingOfficial);
-            applied +=
-                lcDAO.createLibraryCardDaaRelation(
-                    user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
-          }
-          return applied;
-        });
+  public BulkAddResult bulkAddUsersToDaa(Integer daaId, List<User> users, User signingOfficial) {
+    List<Integer> usersWithNewCard = new ArrayList<>();
+    DaaBulkRelationResult summary =
+        inBulkTransaction(
+            users.size(),
+            lcDAO -> {
+              int applied = 0;
+              for (User user : users) {
+                Integer lcId =
+                    findOrCreateLibraryCardId(lcDAO, user, signingOfficial, usersWithNewCard);
+                applied +=
+                    lcDAO.createLibraryCardDaaRelation(
+                        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+              }
+              return applied;
+            });
+    return new BulkAddResult(summary, usersWithNewCard);
   }
 
   /** Atomically remove pre-authorization for a single DAA from every user in {@code users}. */
@@ -107,11 +109,11 @@ public class DaaServiceDAO implements ConsentLogger {
         lcDAO -> {
           int applied = 0;
           for (User user : users) {
-            LibraryCard lc = lcDAO.findLibraryCardByUserId(user.getUserId());
-            if (lc != null) {
+            Integer lcId = lcDAO.findLibraryCardIdByUserId(user.getUserId());
+            if (lcId != null) {
               applied +=
                   lcDAO.deleteLibraryCardDaaRelation(
-                      user.getUserId(), signingOfficial.getUserId(), lc.getId(), daaId);
+                      user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
             }
           }
           return applied;
@@ -122,20 +124,23 @@ public class DaaServiceDAO implements ConsentLogger {
    * Atomically pre-authorize a single user for every DAA in {@code daaIds}. If the user lacks a
    * library card one is created inside the transaction.
    */
-  public DaaBulkRelationResult bulkAddDaasToUser(
-      User user, List<Integer> daaIds, User signingOfficial) {
-    return inBulkTransaction(
-        daaIds.size(),
-        lcDAO -> {
-          Integer lcId = findOrCreateLibraryCardId(lcDAO, user, signingOfficial);
-          int applied = 0;
-          for (Integer daaId : daaIds) {
-            applied +=
-                lcDAO.createLibraryCardDaaRelation(
-                    user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
-          }
-          return applied;
-        });
+  public BulkAddResult bulkAddDaasToUser(User user, List<Integer> daaIds, User signingOfficial) {
+    List<Integer> usersWithNewCard = new ArrayList<>();
+    DaaBulkRelationResult summary =
+        inBulkTransaction(
+            daaIds.size(),
+            lcDAO -> {
+              Integer lcId =
+                  findOrCreateLibraryCardId(lcDAO, user, signingOfficial, usersWithNewCard);
+              int applied = 0;
+              for (Integer daaId : daaIds) {
+                applied +=
+                    lcDAO.createLibraryCardDaaRelation(
+                        user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+              }
+              return applied;
+            });
+    return new BulkAddResult(summary, usersWithNewCard);
   }
 
   /** Atomically remove pre-authorization for every DAA in {@code daaIds} from a single user. */
@@ -144,15 +149,15 @@ public class DaaServiceDAO implements ConsentLogger {
     return inBulkTransaction(
         daaIds.size(),
         lcDAO -> {
-          LibraryCard lc = lcDAO.findLibraryCardByUserId(user.getUserId());
-          if (lc == null) {
+          Integer lcId = lcDAO.findLibraryCardIdByUserId(user.getUserId());
+          if (lcId == null) {
             return 0;
           }
           int applied = 0;
           for (Integer daaId : daaIds) {
             applied +=
                 lcDAO.deleteLibraryCardDaaRelation(
-                    user.getUserId(), signingOfficial.getUserId(), lc.getId(), daaId);
+                    user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
           }
           return applied;
         });
@@ -161,20 +166,34 @@ public class DaaServiceDAO implements ConsentLogger {
   /**
    * Returns the id of the user's existing library card, creating a bare card (via the supplied
    * transaction-scoped DAO) if none exists. Must be called from within a transaction so the card
-   * creation participates in the same all-or-nothing batch.
+   * creation participates in the same all-or-nothing batch. When a card is created the user's id is
+   * appended to {@code newCardUserIds} so the caller can notify exactly the users whose card was
+   * actually inserted by this batch (rather than a pre-transaction estimate). Uses the lightweight
+   * id-only lookup to avoid the DAA/audit joins of the full-card query on every iteration.
    */
-  private Integer findOrCreateLibraryCardId(LibraryCardDAO lcDAO, User user, User signingOfficial) {
-    LibraryCard existing = lcDAO.findLibraryCardByUserId(user.getUserId());
-    if (existing != null) {
-      return existing.getId();
+  private Integer findOrCreateLibraryCardId(
+      LibraryCardDAO lcDAO, User user, User signingOfficial, List<Integer> newCardUserIds) {
+    Integer existingId = lcDAO.findLibraryCardIdByUserId(user.getUserId());
+    if (existingId != null) {
+      return existingId;
     }
-    return lcDAO.insertLibraryCard(
-        user.getUserId(),
-        user.getDisplayName(),
-        user.getEmail(),
-        signingOfficial.getUserId(),
-        new Date());
+    Integer newId =
+        lcDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            signingOfficial.getUserId(),
+            new Date());
+    newCardUserIds.add(user.getUserId());
+    return newId;
   }
+
+  /**
+   * Result of a bulk <em>add</em> operation: the relation-count {@code summary} plus the ids of
+   * users whose library card was created as part of this (committed) batch, so the caller sends a
+   * "new card issued" notification to exactly those users and no others.
+   */
+  public record BulkAddResult(DaaBulkRelationResult summary, List<Integer> usersWithNewCard) {}
 
   /**
    * Runs {@code work} inside a single transaction against a transaction-scoped {@link

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -216,9 +216,9 @@ public class DaaServiceDAO implements ConsentLogger {
    * statement runs {@code WHERE EXISTS}, so it returns 1 only on a real change), so re-adding an
    * existing relation or removing one that was never there is reported under {@code skipped} rather
    * than inflating {@code applied}. Because the batch is atomic, any true failure throws and rolls
-   * back rather than surfacing here, so {@code errors} is always empty.
+   * back rather than surfacing here.
    */
   private DaaBulkRelationResult summarize(int requested, int applied) {
-    return new DaaBulkRelationResult(requested, applied, requested - applied, List.of());
+    return new DaaBulkRelationResult(requested, applied, requested - applied);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAO.java
@@ -4,10 +4,16 @@ import com.google.inject.Inject;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.function.ToIntFunction;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.FileStorageObjectDAO;
+import org.broadinstitute.consent.http.db.LibraryCardDAO;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.LibraryCard;
+import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.Jdbi;
 
@@ -62,5 +68,138 @@ public class DaaServiceDAO implements ConsentLogger {
           handle.commit();
         });
     return createdDaaIds.isEmpty() ? null : createdDaaIds.getFirst();
+  }
+
+  // ── Atomic bulk pre-authorization operations (DT-3325) ──────────────────────────
+  //
+  // Each of the four methods below performs the entire batch inside a single
+  // jdbi.useTransaction(...) so that a mid-batch failure rolls the whole batch back —
+  // the SO never ends up with a half-applied set of relationships. The lc_daa audit
+  // rows are written by the same SQL statement as the relation itself, so audit history
+  // is preserved atomically. Library-card auto-create happens inside the transaction;
+  // the "new card issued" email is deliberately left to the caller to send AFTER commit.
+
+  /**
+   * Atomically pre-authorize every user in {@code users} for a single DAA. Any user lacking a
+   * library card has one created inside the transaction.
+   */
+  public DaaBulkRelationResult bulkAddUsersToDaa(
+      Integer daaId, List<User> users, User signingOfficial) {
+    return inBulkTransaction(
+        users.size(),
+        lcDAO -> {
+          int applied = 0;
+          for (User user : users) {
+            Integer lcId = findOrCreateLibraryCardId(lcDAO, user, signingOfficial);
+            applied +=
+                lcDAO.createLibraryCardDaaRelation(
+                    user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+          }
+          return applied;
+        });
+  }
+
+  /** Atomically remove pre-authorization for a single DAA from every user in {@code users}. */
+  public DaaBulkRelationResult bulkRemoveUsersFromDaa(
+      Integer daaId, List<User> users, User signingOfficial) {
+    return inBulkTransaction(
+        users.size(),
+        lcDAO -> {
+          int applied = 0;
+          for (User user : users) {
+            LibraryCard lc = lcDAO.findLibraryCardByUserId(user.getUserId());
+            if (lc != null) {
+              applied +=
+                  lcDAO.deleteLibraryCardDaaRelation(
+                      user.getUserId(), signingOfficial.getUserId(), lc.getId(), daaId);
+            }
+          }
+          return applied;
+        });
+  }
+
+  /**
+   * Atomically pre-authorize a single user for every DAA in {@code daaIds}. If the user lacks a
+   * library card one is created inside the transaction.
+   */
+  public DaaBulkRelationResult bulkAddDaasToUser(
+      User user, List<Integer> daaIds, User signingOfficial) {
+    return inBulkTransaction(
+        daaIds.size(),
+        lcDAO -> {
+          Integer lcId = findOrCreateLibraryCardId(lcDAO, user, signingOfficial);
+          int applied = 0;
+          for (Integer daaId : daaIds) {
+            applied +=
+                lcDAO.createLibraryCardDaaRelation(
+                    user.getUserId(), signingOfficial.getUserId(), lcId, daaId);
+          }
+          return applied;
+        });
+  }
+
+  /** Atomically remove pre-authorization for every DAA in {@code daaIds} from a single user. */
+  public DaaBulkRelationResult bulkRemoveDaasFromUser(
+      User user, List<Integer> daaIds, User signingOfficial) {
+    return inBulkTransaction(
+        daaIds.size(),
+        lcDAO -> {
+          LibraryCard lc = lcDAO.findLibraryCardByUserId(user.getUserId());
+          if (lc == null) {
+            return 0;
+          }
+          int applied = 0;
+          for (Integer daaId : daaIds) {
+            applied +=
+                lcDAO.deleteLibraryCardDaaRelation(
+                    user.getUserId(), signingOfficial.getUserId(), lc.getId(), daaId);
+          }
+          return applied;
+        });
+  }
+
+  /**
+   * Returns the id of the user's existing library card, creating a bare card (via the supplied
+   * transaction-scoped DAO) if none exists. Must be called from within a transaction so the card
+   * creation participates in the same all-or-nothing batch.
+   */
+  private Integer findOrCreateLibraryCardId(LibraryCardDAO lcDAO, User user, User signingOfficial) {
+    LibraryCard existing = lcDAO.findLibraryCardByUserId(user.getUserId());
+    if (existing != null) {
+      return existing.getId();
+    }
+    return lcDAO.insertLibraryCard(
+        user.getUserId(),
+        user.getDisplayName(),
+        user.getEmail(),
+        signingOfficial.getUserId(),
+        new Date());
+  }
+
+  /**
+   * Runs {@code work} inside a single transaction against a transaction-scoped {@link
+   * LibraryCardDAO} and wraps the count it returns (the number of relationships actually changed)
+   * in a {@link DaaBulkRelationResult}. Centralizing the transaction boundary keeps each bulk
+   * method to just its per-item loop, and guarantees the all-or-nothing rollback semantics are
+   * applied identically across all four operations.
+   */
+  private DaaBulkRelationResult inBulkTransaction(
+      int requested, ToIntFunction<LibraryCardDAO> work) {
+    int[] applied = {0};
+    jdbi.useTransaction(
+        handle -> applied[0] = work.applyAsInt(handle.attach(LibraryCardDAO.class)));
+    return summarize(requested, applied[0]);
+  }
+
+  /**
+   * Builds a result from the requested count and the number of relationships actually changed.
+   * {@code applied} counts only rows that were genuinely inserted/deleted (the audit-writing
+   * statement runs {@code WHERE EXISTS}, so it returns 1 only on a real change), so re-adding an
+   * existing relation or removing one that was never there is reported under {@code skipped} rather
+   * than inflating {@code applied}. Because the batch is atomic, any true failure throws and rolls
+   * back rather than surfacing here, so {@code errors} is always empty.
+   */
+  private DaaBulkRelationResult summarize(int requested, int applied) {
+    return new DaaBulkRelationResult(requested, applied, requested - applied, List.of());
   }
 }

--- a/src/main/resources/assets/paths/daaBulkByDaaId.yaml
+++ b/src/main/resources/assets/paths/daaBulkByDaaId.yaml
@@ -34,6 +34,10 @@ post:
   responses:
     200:
       description: Successfully added users to a DAA
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DaaBulkRelationResult.yaml'
     403:
       description: User not authorized to add users to DAA
     404:
@@ -82,6 +86,10 @@ delete:
   responses:
     200:
       description: Successfully removed users from a DAA
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DaaBulkRelationResult.yaml'
     403:
       description: User not authorized to remove users from DAA
     404:

--- a/src/main/resources/assets/paths/daaBulkByUserId.yaml
+++ b/src/main/resources/assets/paths/daaBulkByUserId.yaml
@@ -34,6 +34,10 @@ post:
   responses:
     200:
       description: Successfully added DAAs to a user
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DaaBulkRelationResult.yaml'
     403:
       description: User not authorized to add DAAs to a user
     404:
@@ -82,6 +86,10 @@ delete:
   responses:
     200:
       description: Successfully removed DAAs from a user
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/DaaBulkRelationResult.yaml'
     403:
       description: User not authorized to remove DAAs from a user
     404:

--- a/src/main/resources/assets/schemas/DaaBulkRelationResult.yaml
+++ b/src/main/resources/assets/schemas/DaaBulkRelationResult.yaml
@@ -1,0 +1,23 @@
+type: object
+title: DaaBulkRelationResult
+description: >-
+  Summary of an atomic bulk pre-authorization operation. The operation is all-or-nothing with
+  respect to failure, so on a returned summary `errors` is always empty and a real failure surfaces
+  as a 4xx/5xx instead. `applied` counts only relationships that actually changed; requested items
+  already in the target state (re-adding an existing pre-authorization, or removing one that was
+  never present) are counted under `skipped`, so `applied + skipped == requested`.
+properties:
+  requested:
+    type: integer
+    description: Number of relationships requested in the batch.
+  applied:
+    type: integer
+    description: Number of relationships that actually changed.
+  skipped:
+    type: integer
+    description: Number of requested relationships that were already in the target state (no-ops).
+  errors:
+    type: array
+    description: Always empty on a returned summary (failures roll back and surface as an error status).
+    items:
+      type: string

--- a/src/main/resources/assets/schemas/DaaBulkRelationResult.yaml
+++ b/src/main/resources/assets/schemas/DaaBulkRelationResult.yaml
@@ -2,10 +2,10 @@ type: object
 title: DaaBulkRelationResult
 description: >-
   Summary of an atomic bulk pre-authorization operation. The operation is all-or-nothing with
-  respect to failure, so on a returned summary `errors` is always empty and a real failure surfaces
-  as a 4xx/5xx instead. `applied` counts only relationships that actually changed; requested items
-  already in the target state (re-adding an existing pre-authorization, or removing one that was
-  never present) are counted under `skipped`, so `applied + skipped == requested`.
+  respect to failure, so a real failure surfaces as a 4xx/5xx instead of a partial summary.
+  `applied` counts only relationships that actually changed; requested items already in the target
+  state (re-adding an existing pre-authorization, or removing one that was never present) are counted
+  under `skipped`, so `applied + skipped == requested`.
 properties:
   requested:
     type: integer
@@ -16,8 +16,3 @@ properties:
   skipped:
     type: integer
     description: Number of requested relationships that were already in the target state (no-ops).
-  errors:
-    type: array
-    description: Always empty on a returned summary (failures roll back and surface as an error status).
-    items:
-      type: string

--- a/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DaaResourceTest.java
@@ -27,6 +27,7 @@ import org.apache.http.HttpStatus;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DaaBulkAssignmentResult;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.DuosUser;
@@ -620,13 +621,14 @@ class DaaResourceTest extends AbstractTestHelper {
             researcherWithInstitution(3, institutionId));
 
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
-    when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.addDaaToUserLibraryCard(any(), any(), any())).thenReturn(null);
+    when(daaService.bulkAddUsersToDaa(any(), any(), any()))
+        .thenReturn(DaaBulkRelationResult.allApplied(3));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
     try (Response response = resource.bulkAddUsersToDaa(duosUser, daaId, "{users:[1,2,3]}")) {
       assertEquals(HttpStatus.SC_OK, response.getStatus());
+      assertEquals(3, ((DaaBulkRelationResult) response.getEntity()).getApplied());
     }
   }
 
@@ -697,7 +699,7 @@ class DaaResourceTest extends AbstractTestHelper {
             researcherWithInstitution(3, institutionId));
 
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
-    when(daaService.findById(daaId)).thenThrow(new NotFoundException());
+    when(daaService.bulkAddUsersToDaa(any(), any(), any())).thenThrow(new NotFoundException());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -761,13 +763,14 @@ class DaaResourceTest extends AbstractTestHelper {
             researcherWithInstitution(3, institutionId));
 
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
-    when(daaService.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any(), any())).thenReturn(null);
+    when(daaService.bulkRemoveUsersFromDaa(any(), any(), any()))
+        .thenReturn(DaaBulkRelationResult.allApplied(3));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
     try (Response response = resource.bulkRemoveUsersFromDaa(duosUser, daaId, "{users:[1,2,3]}")) {
       assertEquals(HttpStatus.SC_OK, response.getStatus());
+      assertEquals(3, ((DaaBulkRelationResult) response.getEntity()).getApplied());
     }
   }
 
@@ -813,7 +816,7 @@ class DaaResourceTest extends AbstractTestHelper {
             researcherWithInstitution(3, institutionId));
 
     when(userService.findUsersInJsonArray(any(), any())).thenReturn(users);
-    when(daaService.findById(daaId)).thenThrow(new NotFoundException());
+    when(daaService.bulkRemoveUsersFromDaa(any(), any(), any())).thenThrow(new NotFoundException());
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
@@ -843,12 +846,14 @@ class DaaResourceTest extends AbstractTestHelper {
 
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.addDaaToUserLibraryCard(any(), any(), any())).thenReturn(null);
+    when(daaService.bulkAddDaasToUser(any(), any(), any()))
+        .thenReturn(DaaBulkRelationResult.allApplied(3));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
     try (Response response = resource.bulkAddDAAsToUser(duosUser, userId, "{daaList:[1,2,3]}")) {
       assertEquals(HttpStatus.SC_OK, response.getStatus());
+      assertEquals(3, ((DaaBulkRelationResult) response.getEntity()).getApplied());
     }
   }
 
@@ -906,13 +911,15 @@ class DaaResourceTest extends AbstractTestHelper {
 
     when(userService.findUserById(userId)).thenReturn(researcher);
     when(daaService.findDAAsInJsonArray(any(), any())).thenReturn(agreements);
-    when(libraryCardService.removeDaaFromUserLibraryCard(any(), any(), any())).thenReturn(null);
+    when(daaService.bulkRemoveDaasFromUser(any(), any(), any()))
+        .thenReturn(DaaBulkRelationResult.allApplied(3));
 
     resource = new DaaResource(daaService, dacService, userService, libraryCardService);
 
     try (Response response =
         resource.bulkRemoveDAAsFromUser(duosUser, userId, "{daaList:[1,2,3]}")) {
       assertEquals(HttpStatus.SC_OK, response.getStatus());
+      assertEquals(3, ((DaaBulkRelationResult) response.getEntity()).getApplied());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.service.UserService.SimplifiedUser;
 import org.broadinstitute.consent.http.service.dao.DaaServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DaaServiceDAO.BulkAddResult;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeEach;
@@ -671,8 +672,13 @@ class DaaServiceTest extends AbstractTestHelper {
     return user;
   }
 
+  /** Builds the DAO add-result: {@code applied} count plus the ids of users given a new card. */
+  private BulkAddResult bulkAdd(int applied, Integer... usersWithNewCard) {
+    return new BulkAddResult(DaaBulkRelationResult.allApplied(applied), List.of(usersWithNewCard));
+  }
+
   @Test
-  void testBulkAddUsersToDaaSendsEmailOnlyForUsersWithoutCard() throws Exception {
+  void testBulkAddUsersToDaaSendsEmailOnlyForUsersWithNewlyCreatedCard() throws Exception {
     Integer daaId = randomInt(10, 100);
     User signingOfficial = userWithId(500);
     User withCard = userWithId(1);
@@ -680,11 +686,11 @@ class DaaServiceTest extends AbstractTestHelper {
     List<User> users = List.of(withCard, withoutCard);
 
     when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.findLibraryCardByUserId(withCard.getUserId()))
-        .thenReturn(new LibraryCard());
-    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
+    when(libraryCardService.findLibraryCardIdByUserId(withCard.getUserId())).thenReturn(10);
+    when(libraryCardService.findLibraryCardIdByUserId(withoutCard.getUserId())).thenReturn(null);
+    // The transaction reports it actually created a card only for withoutCard.
     when(daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial))
-        .thenReturn(DaaBulkRelationResult.allApplied(2));
+        .thenReturn(bulkAdd(2, withoutCard.getUserId()));
 
     initService();
     DaaBulkRelationResult result = service.bulkAddUsersToDaa(daaId, users, signingOfficial);
@@ -732,9 +738,9 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId())).thenReturn(null);
+    when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
-        .thenReturn(DaaBulkRelationResult.allApplied(2));
+        .thenReturn(bulkAdd(2, researcher.getUserId()));
 
     initService();
     DaaBulkRelationResult result = service.bulkAddDaasToUser(researcher, daaIds, signingOfficial);
@@ -749,10 +755,9 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId()))
-        .thenReturn(new LibraryCard());
+    when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(10);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
-        .thenReturn(DaaBulkRelationResult.allApplied(2));
+        .thenReturn(bulkAdd(2));
 
     initService();
     service.bulkAddDaasToUser(researcher, daaIds, signingOfficial);
@@ -787,11 +792,9 @@ class DaaServiceTest extends AbstractTestHelper {
     List<User> users = List.of(withCard, withoutCard);
 
     when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.findLibraryCardByUserId(withCard.getUserId()))
-        .thenReturn(new LibraryCard());
-    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
-    when(daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial))
-        .thenReturn(DaaBulkRelationResult.allApplied(2));
+    when(libraryCardService.findLibraryCardIdByUserId(withCard.getUserId())).thenReturn(10);
+    when(libraryCardService.findLibraryCardIdByUserId(withoutCard.getUserId())).thenReturn(null);
+    when(daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial)).thenReturn(bulkAdd(2));
 
     initService();
     service.bulkAddUsersToDaa(daaId, users, signingOfficial);
@@ -810,7 +813,7 @@ class DaaServiceTest extends AbstractTestHelper {
     List<User> users = List.of(withoutCard);
 
     when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
-    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
+    when(libraryCardService.findLibraryCardIdByUserId(withoutCard.getUserId())).thenReturn(null);
     doThrow(new BadRequestException("invalid"))
         .when(libraryCardService)
         .validateNewLibraryCardCreation(withoutCard, signingOfficial);
@@ -828,7 +831,7 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId())).thenReturn(null);
+    when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     doThrow(new BadRequestException("invalid"))
         .when(libraryCardService)
         .validateNewLibraryCardCreation(researcher, signingOfficial);
@@ -859,7 +862,7 @@ class DaaServiceTest extends AbstractTestHelper {
     // The SO guard runs first and unconditionally: no per-user card lookup, validation, or mutation
     // happens — so a bulk add is rejected even when every targeted user already has a card.
     verify(daaServiceDAO, never()).bulkAddUsersToDaa(any(), any(), any());
-    verify(libraryCardService, never()).findLibraryCardByUserId(any());
+    verify(libraryCardService, never()).findLibraryCardIdByUserId(any());
     verify(libraryCardService, never()).validateNewLibraryCardCreation(any(), any());
     verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
   }
@@ -880,7 +883,7 @@ class DaaServiceTest extends AbstractTestHelper {
         BadRequestException.class,
         () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
     verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
-    verify(libraryCardService, never()).findLibraryCardByUserId(any());
+    verify(libraryCardService, never()).findLibraryCardIdByUserId(any());
     verify(libraryCardService, never()).validateNewLibraryCardCreation(any(), any());
     verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -738,7 +738,6 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
         .thenReturn(bulkAdd(2, researcher.getUserId()));
@@ -756,7 +755,6 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(10);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
         .thenReturn(bulkAdd(2));
@@ -833,7 +831,6 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     doThrow(new BadRequestException("invalid"))
         .when(libraryCardService)
@@ -848,20 +845,15 @@ class DaaServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testBulkAddDaasToUserDaaNotFoundDoesNotMutate() throws Exception {
-    User signingOfficial = userWithId(500);
-    User researcher = userWithId(1);
-    List<Integer> daaIds = List.of(10, 11);
-    // The second DAA does not exist; validation must reject with a 404 before any mutation.
+  void testFindDAAsInJsonArrayDaaNotFound() {
+    // The second DAA does not exist; the id-resolution step rejects with a 404 before callers ever
+    // reach a bulk mutation. This is the single guard the bulk add/remove flows rely on.
+    String json = "{daaList:[10,11]}";
     when(daaDAO.findById(10)).thenReturn(new DataAccessAgreement());
     when(daaDAO.findById(11)).thenReturn(null);
 
     initService();
-    assertThrows(
-        NotFoundException.class,
-        () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
-    verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
-    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+    assertThrows(NotFoundException.class, () -> service.findDAAsInJsonArray(json, "daaList"));
   }
 
   @Test
@@ -894,7 +886,6 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
-    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     doThrow(new BadRequestException("This signing official does not have an institution."))
         .when(libraryCardService)
         .requireSigningOfficialInstitution(signingOfficial);

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -738,6 +738,7 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
+    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
         .thenReturn(bulkAdd(2, researcher.getUserId()));
@@ -755,6 +756,7 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
+    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(10);
     when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
         .thenReturn(bulkAdd(2));
@@ -831,6 +833,7 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
+    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     when(libraryCardService.findLibraryCardIdByUserId(researcher.getUserId())).thenReturn(null);
     doThrow(new BadRequestException("invalid"))
         .when(libraryCardService)
@@ -839,6 +842,23 @@ class DaaServiceTest extends AbstractTestHelper {
     initService();
     assertThrows(
         BadRequestException.class,
+        () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
+    verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddDaasToUserDaaNotFoundDoesNotMutate() throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+    // The second DAA does not exist; validation must reject with a 404 before any mutation.
+    when(daaDAO.findById(10)).thenReturn(new DataAccessAgreement());
+    when(daaDAO.findById(11)).thenReturn(null);
+
+    initService();
+    assertThrows(
+        NotFoundException.class,
         () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
     verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
     verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
@@ -874,6 +894,7 @@ class DaaServiceTest extends AbstractTestHelper {
     User researcher = userWithId(1);
     List<Integer> daaIds = List.of(10, 11);
 
+    when(daaDAO.findById(any())).thenReturn(new DataAccessAgreement());
     doThrow(new BadRequestException("This signing official does not have an institution."))
         .when(libraryCardService)
         .requireSigningOfficialInstitution(signingOfficial);

--- a/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DaaServiceTest.java
@@ -35,6 +35,7 @@ import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadResearcherMessage;
 import org.broadinstitute.consent.http.mail.message.NewDAAUploadSOMessage;
 import org.broadinstitute.consent.http.models.DaaBulkAssignmentResult;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
@@ -660,5 +661,227 @@ class DaaServiceTest extends AbstractTestHelper {
     verify(daaDAO).createDacDaaRelation(dacId, 801, user.getUserId());
     verify(daaDAO, never()).findByDacId(dacId);
     verify(daaDAO, never()).findDaaIdsByDacId(dacId);
+  }
+
+  // ── Atomic bulk pre-authorization (DT-3325) ─────────────────────────────────────
+
+  private User userWithId(int userId) {
+    User user = new User();
+    user.setUserId(userId);
+    return user;
+  }
+
+  @Test
+  void testBulkAddUsersToDaaSendsEmailOnlyForUsersWithoutCard() throws Exception {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    User withCard = userWithId(1);
+    User withoutCard = userWithId(2);
+    List<User> users = List.of(withCard, withoutCard);
+
+    when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
+    when(libraryCardService.findLibraryCardByUserId(withCard.getUserId()))
+        .thenReturn(new LibraryCard());
+    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
+    when(daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    DaaBulkRelationResult result = service.bulkAddUsersToDaa(daaId, users, signingOfficial);
+
+    assertEquals(2, result.getApplied());
+    verify(daaServiceDAO).bulkAddUsersToDaa(daaId, users, signingOfficial);
+    verify(libraryCardService, times(1)).sendNewLibraryCardIssuedMessage(withoutCard);
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(withCard);
+  }
+
+  @Test
+  void testBulkAddUsersToDaaDaaNotFoundDoesNotMutate() {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    List<User> users = List.of(userWithId(1));
+    when(daaDAO.findById(daaId)).thenReturn(null);
+
+    initService();
+    assertThrows(
+        NotFoundException.class, () -> service.bulkAddUsersToDaa(daaId, users, signingOfficial));
+    verify(daaServiceDAO, never()).bulkAddUsersToDaa(any(), any(), any());
+  }
+
+  @Test
+  void testBulkRemoveUsersFromDaaDelegatesWithoutEmail() throws Exception {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    List<User> users = List.of(userWithId(1), userWithId(2));
+
+    when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
+    when(daaServiceDAO.bulkRemoveUsersFromDaa(daaId, users, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    DaaBulkRelationResult result = service.bulkRemoveUsersFromDaa(daaId, users, signingOfficial);
+
+    assertEquals(2, result.getApplied());
+    verify(daaServiceDAO).bulkRemoveUsersFromDaa(daaId, users, signingOfficial);
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddDaasToUserSendsEmailWhenNoCard() throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+
+    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId())).thenReturn(null);
+    when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    DaaBulkRelationResult result = service.bulkAddDaasToUser(researcher, daaIds, signingOfficial);
+
+    assertEquals(2, result.getApplied());
+    verify(libraryCardService, times(1)).sendNewLibraryCardIssuedMessage(researcher);
+  }
+
+  @Test
+  void testBulkAddDaasToUserNoEmailWhenCardExists() throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+
+    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId()))
+        .thenReturn(new LibraryCard());
+    when(daaServiceDAO.bulkAddDaasToUser(researcher, daaIds, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    service.bulkAddDaasToUser(researcher, daaIds, signingOfficial);
+
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkRemoveDaasFromUserDelegates() throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+
+    when(daaServiceDAO.bulkRemoveDaasFromUser(researcher, daaIds, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    DaaBulkRelationResult result =
+        service.bulkRemoveDaasFromUser(researcher, daaIds, signingOfficial);
+
+    assertEquals(2, result.getApplied());
+    verify(daaServiceDAO).bulkRemoveDaasFromUser(researcher, daaIds, signingOfficial);
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddUsersToDaaValidatesOnlyUsersNeedingACard() {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    User withCard = userWithId(1);
+    User withoutCard = userWithId(2);
+    List<User> users = List.of(withCard, withoutCard);
+
+    when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
+    when(libraryCardService.findLibraryCardByUserId(withCard.getUserId()))
+        .thenReturn(new LibraryCard());
+    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
+    when(daaServiceDAO.bulkAddUsersToDaa(daaId, users, signingOfficial))
+        .thenReturn(DaaBulkRelationResult.allApplied(2));
+
+    initService();
+    service.bulkAddUsersToDaa(daaId, users, signingOfficial);
+
+    // The user who would have a card auto-created is validated; the one who already has one is not.
+    verify(libraryCardService, times(1))
+        .validateNewLibraryCardCreation(withoutCard, signingOfficial);
+    verify(libraryCardService, never()).validateNewLibraryCardCreation(withCard, signingOfficial);
+  }
+
+  @Test
+  void testBulkAddUsersToDaaRejectsBeforeMutatingWhenValidationFails() throws Exception {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    User withoutCard = userWithId(2);
+    List<User> users = List.of(withoutCard);
+
+    when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
+    when(libraryCardService.findLibraryCardByUserId(withoutCard.getUserId())).thenReturn(null);
+    doThrow(new BadRequestException("invalid"))
+        .when(libraryCardService)
+        .validateNewLibraryCardCreation(withoutCard, signingOfficial);
+
+    initService();
+    assertThrows(
+        BadRequestException.class, () -> service.bulkAddUsersToDaa(daaId, users, signingOfficial));
+    verify(daaServiceDAO, never()).bulkAddUsersToDaa(any(), any(), any());
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddDaasToUserRejectsBeforeMutatingWhenValidationFails() throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+
+    when(libraryCardService.findLibraryCardByUserId(researcher.getUserId())).thenReturn(null);
+    doThrow(new BadRequestException("invalid"))
+        .when(libraryCardService)
+        .validateNewLibraryCardCreation(researcher, signingOfficial);
+
+    initService();
+    assertThrows(
+        BadRequestException.class,
+        () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
+    verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddUsersToDaaRejectsWhenSigningOfficialHasNoInstitutionBeforeAnyCardLookup()
+      throws Exception {
+    Integer daaId = randomInt(10, 100);
+    User signingOfficial = userWithId(500);
+    List<User> users = List.of(userWithId(1), userWithId(2));
+
+    when(daaDAO.findById(daaId)).thenReturn(new DataAccessAgreement());
+    doThrow(new BadRequestException("This signing official does not have an institution."))
+        .when(libraryCardService)
+        .requireSigningOfficialInstitution(signingOfficial);
+
+    initService();
+    assertThrows(
+        BadRequestException.class, () -> service.bulkAddUsersToDaa(daaId, users, signingOfficial));
+    // The SO guard runs first and unconditionally: no per-user card lookup, validation, or mutation
+    // happens — so a bulk add is rejected even when every targeted user already has a card.
+    verify(daaServiceDAO, never()).bulkAddUsersToDaa(any(), any(), any());
+    verify(libraryCardService, never()).findLibraryCardByUserId(any());
+    verify(libraryCardService, never()).validateNewLibraryCardCreation(any(), any());
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
+  }
+
+  @Test
+  void testBulkAddDaasToUserRejectsWhenSigningOfficialHasNoInstitutionBeforeAnyCardLookup()
+      throws Exception {
+    User signingOfficial = userWithId(500);
+    User researcher = userWithId(1);
+    List<Integer> daaIds = List.of(10, 11);
+
+    doThrow(new BadRequestException("This signing official does not have an institution."))
+        .when(libraryCardService)
+        .requireSigningOfficialInstitution(signingOfficial);
+
+    initService();
+    assertThrows(
+        BadRequestException.class,
+        () -> service.bulkAddDaasToUser(researcher, daaIds, signingOfficial));
+    verify(daaServiceDAO, never()).bulkAddDaasToUser(any(), any(), any());
+    verify(libraryCardService, never()).findLibraryCardByUserId(any());
+    verify(libraryCardService, never()).validateNewLibraryCardCreation(any(), any());
+    verify(libraryCardService, never()).sendNewLibraryCardIssuedMessage(any());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/LibraryCardServiceTest.java
@@ -11,8 +11,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -350,9 +350,9 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(userDAO.findUserById(user.getUserId())).thenReturn(user);
     when(libraryCardDAO.findLibraryCardById(card.getId())).thenReturn(card);
     when(daaDAO.findById(daa.getDaaId())).thenReturn(daa);
-    doNothing()
-        .when(libraryCardDAO)
-        .createLibraryCardDaaRelation(user.getUserId(), so.getUserId(), card.getId(), 1);
+    when(libraryCardDAO.createLibraryCardDaaRelation(
+            user.getUserId(), so.getUserId(), card.getId(), 1))
+        .thenReturn(1);
 
     assertDoesNotThrow(
         () -> service.addDaaToLibraryCard(user.getUserId(), so.getUserId(), card.getId(), 1));
@@ -365,9 +365,9 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     LibraryCard card = testLibraryCard(1);
     User so = new User();
     so.setUserId(2);
-    doNothing()
-        .when(libraryCardDAO)
-        .deleteLibraryCardDaaRelation(user.getUserId(), so.getUserId(), card.getId(), 1);
+    when(libraryCardDAO.deleteLibraryCardDaaRelation(
+            user.getUserId(), so.getUserId(), card.getId(), 1))
+        .thenReturn(1);
 
     assertDoesNotThrow(
         () -> service.removeDaaFromLibraryCard(user.getUserId(), so.getUserId(), card.getId(), 1));
@@ -391,7 +391,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     when(libraryCardDAO.findLibraryCardById(card.getId())).thenReturn(card);
     when(daaDAO.findById(daa.getDaaId())).thenReturn(daa);
     when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(card);
-    doNothing().when(libraryCardDAO).createLibraryCardDaaRelation(any(), any(), any(), any());
+    when(libraryCardDAO.createLibraryCardDaaRelation(any(), any(), any(), any())).thenReturn(1);
     LibraryCard foundCard = service.addDaaToUserLibraryCard(user, signingOfficial, 1);
     assertNotNull(foundCard);
   }
@@ -507,7 +507,7 @@ class LibraryCardServiceTest extends AbstractTestHelper {
         .thenReturn(testLibraryCard(userId));
     User so = new User();
     so.setUserId(2);
-    doNothing().when(libraryCardDAO).deleteLibraryCardDaaRelation(any(), any(), any(), any());
+    when(libraryCardDAO.deleteLibraryCardDaaRelation(any(), any(), any(), any())).thenReturn(1);
     LibraryCard card = service.removeDaaFromUserLibraryCard(user, so, 1);
     // The above deletion only affects the lc-daa join table and does not remove library cards
     assertNotNull(card);
@@ -612,6 +612,84 @@ class LibraryCardServiceTest extends AbstractTestHelper {
     libraryCard.setUserId(userId);
 
     return libraryCard;
+  }
+
+  @Test
+  void testValidateNewLibraryCardCreationPasses() {
+    Institution institution = testInstitution();
+    User user = testUser(institution.getId());
+    User soUser =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    soUser.setInstitutionId(institution.getId());
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(null);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(institutionDAO.findInstitutionById(institution.getId())).thenReturn(institution);
+    when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(institution);
+
+    assertDoesNotThrow(() -> service.validateNewLibraryCardCreation(user, soUser));
+    // Validation must never write anything — the bulk transaction owns the insert.
+    verify(libraryCardDAO, never())
+        .insertLibraryCard(anyInt(), any(), anyString(), anyInt(), any());
+  }
+
+  @Test
+  void testRequireSigningOfficialInstitutionThrowsWhenNull() {
+    User soUser =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    soUser.setInstitutionId(null);
+
+    assertThrows(
+        BadRequestException.class, () -> service.requireSigningOfficialInstitution(soUser));
+  }
+
+  @Test
+  void testRequireSigningOfficialInstitutionPassesWhenPresent() {
+    Institution institution = testInstitution();
+    User soUser =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    soUser.setInstitutionId(institution.getId());
+
+    assertDoesNotThrow(() -> service.requireSigningOfficialInstitution(soUser));
+  }
+
+  @Test
+  void testValidateNewLibraryCardCreationThrowsWhenCardAlreadyExists() {
+    Institution institution = testInstitution();
+    User user = testUser(institution.getId());
+    User soUser =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    soUser.setInstitutionId(institution.getId());
+    LibraryCard existing = new LibraryCard();
+    existing.setUserId(user.getUserId());
+    existing.setUserEmail(user.getEmail());
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(existing);
+
+    assertThrows(
+        ConsentConflictException.class, () -> service.validateNewLibraryCardCreation(user, soUser));
+  }
+
+  @Test
+  void testValidateNewLibraryCardCreationThrowsWhenEmailInstitutionMismatch() {
+    Institution institution = testInstitution();
+    User user = testUser(institution.getId());
+    User soUser =
+        createUserWithRole(
+            UserRoles.SIGNINGOFFICIAL.getRoleId(), UserRoles.SIGNINGOFFICIAL.getRoleName());
+    soUser.setInstitutionId(institution.getId());
+    when(libraryCardDAO.findLibraryCardByUserId(user.getUserId())).thenReturn(null);
+    when(userDAO.findUserById(user.getUserId())).thenReturn(user);
+    when(institutionDAO.findInstitutionById(institution.getId())).thenReturn(institution);
+    // The user's email resolves to a different institution than their own.
+    Institution otherInstitution = new Institution();
+    otherInstitution.setId(institution.getId() + 1);
+    when(institutionService.findInstitutionForEmail(user.getEmail())).thenReturn(otherInstitution);
+
+    assertThrows(
+        BadRequestException.class, () -> service.validateNewLibraryCardCreation(user, soUser));
   }
 
   private Institution testInstitution() {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -3,8 +3,10 @@ package org.broadinstitute.consent.http.service.dao;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,13 +16,17 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.cloud.storage.BlobId;
 import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.DaaAudit;
+import org.broadinstitute.consent.http.models.DaaBulkRelationResult;
 import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
+import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -153,6 +159,157 @@ class DaaServiceDAOTest extends DAOTestHelper {
     assertThrows(
         IllegalArgumentException.class,
         () -> serviceDAO.createDaaWithFso(user.getUserId(), dacId, fso));
+  }
+
+  // ── Atomic bulk pre-authorization (DT-3325) ─────────────────────────────────────
+
+  private static final int NONEXISTENT_DAA_ID = 999_999_999;
+
+  private Integer createDaaId(User creator) {
+    int dacId =
+        dacDAO.createDac(
+            randomAlphabetic(10), randomAlphabetic(10), randomAlphabetic(10), creator.getUserId());
+    Instant now = Instant.now();
+    return daaDAO.createDaa(creator.getUserId(), now, creator.getUserId(), now, dacId);
+  }
+
+  private LibraryCard insertCardFor(User user, User creator) {
+    Integer id =
+        libraryCardDAO.insertLibraryCard(
+            user.getUserId(),
+            user.getDisplayName(),
+            user.getEmail(),
+            creator.getUserId(),
+            new Date());
+    return libraryCardDAO.findLibraryCardById(id);
+  }
+
+  @Test
+  void testBulkAddDaasToUserHappyPath() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    insertCardFor(researcher, signingOfficial);
+    Integer daaId1 = createDaaId(signingOfficial);
+    Integer daaId2 = createDaaId(signingOfficial);
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkAddDaasToUser(researcher, List.of(daaId1, daaId2), signingOfficial);
+
+    assertEquals(2, result.getApplied());
+    List<Integer> daaIds =
+        libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds();
+    assertTrue(daaIds.contains(daaId1));
+    assertTrue(daaIds.contains(daaId2));
+  }
+
+  @Test
+  void testBulkAddUsersToDaaAutoCreatesLibraryCard() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    // No library card inserted for the researcher — the transaction should create one.
+    assertNull(libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()));
+    Integer daaId = createDaaId(signingOfficial);
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkAddUsersToDaa(daaId, List.of(researcher), signingOfficial);
+
+    assertEquals(1, result.getApplied());
+    LibraryCard card = libraryCardDAO.findLibraryCardByUserId(researcher.getUserId());
+    assertNotNull(card);
+    assertTrue(card.getDaaIds().contains(daaId));
+  }
+
+  @Test
+  void testBulkAddDaasToUserRollsBackOnMidBatchFailure() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    insertCardFor(researcher, signingOfficial);
+    Integer validDaaId = createDaaId(signingOfficial);
+
+    // The second id violates the lc_daa -> data_access_agreement foreign key, failing mid-batch.
+    assertThrows(
+        Exception.class,
+        () ->
+            serviceDAO.bulkAddDaasToUser(
+                researcher, List.of(validDaaId, NONEXISTENT_DAA_ID), signingOfficial));
+
+    // The valid relation inserted before the failure must have been rolled back.
+    List<Integer> daaIds =
+        libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds();
+    assertFalse(daaIds.contains(validDaaId));
+  }
+
+  @Test
+  void testBulkRemoveDaasFromUser() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    LibraryCard card = insertCardFor(researcher, signingOfficial);
+    Integer daaId = createDaaId(signingOfficial);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        researcher.getUserId(), signingOfficial.getUserId(), card.getId(), daaId);
+    assertTrue(
+        libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds().contains(daaId));
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkRemoveDaasFromUser(researcher, List.of(daaId), signingOfficial);
+
+    assertEquals(1, result.getApplied());
+    assertFalse(
+        libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds().contains(daaId));
+  }
+
+  @Test
+  void testBulkRemoveUsersFromDaa() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    LibraryCard card = insertCardFor(researcher, signingOfficial);
+    Integer daaId = createDaaId(signingOfficial);
+    libraryCardDAO.createLibraryCardDaaRelation(
+        researcher.getUserId(), signingOfficial.getUserId(), card.getId(), daaId);
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkRemoveUsersFromDaa(daaId, List.of(researcher), signingOfficial);
+
+    assertEquals(1, result.getApplied());
+    assertFalse(
+        libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds().contains(daaId));
+  }
+
+  @Test
+  void testBulkAddDaasToUserCountsOnlyGenuinelyNewRelations() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    LibraryCard card = insertCardFor(researcher, signingOfficial);
+    Integer alreadyLinkedDaaId = createDaaId(signingOfficial);
+    Integer newDaaId = createDaaId(signingOfficial);
+    // Pre-link the first DAA so re-adding it is a no-op (ON CONFLICT DO NOTHING).
+    libraryCardDAO.createLibraryCardDaaRelation(
+        researcher.getUserId(), signingOfficial.getUserId(), card.getId(), alreadyLinkedDaaId);
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkAddDaasToUser(
+            researcher, List.of(alreadyLinkedDaaId, newDaaId), signingOfficial);
+
+    // applied must reflect only the one relation that actually changed, not the requested count.
+    assertEquals(2, result.getRequested());
+    assertEquals(1, result.getApplied());
+    assertEquals(1, result.getSkipped());
+  }
+
+  @Test
+  void testBulkRemoveDaasFromUserCountsOnlyRelationsThatExisted() {
+    User signingOfficial = createUser();
+    User researcher = createUser();
+    insertCardFor(researcher, signingOfficial);
+    Integer neverLinkedDaaId = createDaaId(signingOfficial);
+    // No relation was ever created for this DAA, so removing it is a no-op.
+
+    DaaBulkRelationResult result =
+        serviceDAO.bulkRemoveDaasFromUser(researcher, List.of(neverLinkedDaaId), signingOfficial);
+
+    assertEquals(1, result.getRequested());
+    assertEquals(0, result.getApplied());
+    assertEquals(1, result.getSkipped());
   }
 
   private FileStorageObject createFileStorageObject() {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DaaServiceDAOTest.java
@@ -28,6 +28,7 @@ import org.broadinstitute.consent.http.models.DataAccessAgreement;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.LibraryCard;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.dao.DaaServiceDAO.BulkAddResult;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.AfterEach;
@@ -192,10 +193,12 @@ class DaaServiceDAOTest extends DAOTestHelper {
     Integer daaId1 = createDaaId(signingOfficial);
     Integer daaId2 = createDaaId(signingOfficial);
 
-    DaaBulkRelationResult result =
+    BulkAddResult result =
         serviceDAO.bulkAddDaasToUser(researcher, List.of(daaId1, daaId2), signingOfficial);
 
-    assertEquals(2, result.getApplied());
+    assertEquals(2, result.summary().getApplied());
+    // The researcher already had a card, so none was created.
+    assertTrue(result.usersWithNewCard().isEmpty());
     List<Integer> daaIds =
         libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()).getDaaIds();
     assertTrue(daaIds.contains(daaId1));
@@ -210,10 +213,12 @@ class DaaServiceDAOTest extends DAOTestHelper {
     assertNull(libraryCardDAO.findLibraryCardByUserId(researcher.getUserId()));
     Integer daaId = createDaaId(signingOfficial);
 
-    DaaBulkRelationResult result =
+    BulkAddResult result =
         serviceDAO.bulkAddUsersToDaa(daaId, List.of(researcher), signingOfficial);
 
-    assertEquals(1, result.getApplied());
+    assertEquals(1, result.summary().getApplied());
+    // The transaction created the card and reported it, so the caller can notify the researcher.
+    assertTrue(result.usersWithNewCard().contains(researcher.getUserId()));
     LibraryCard card = libraryCardDAO.findLibraryCardByUserId(researcher.getUserId());
     assertNotNull(card);
     assertTrue(card.getDaaIds().contains(daaId));
@@ -286,14 +291,14 @@ class DaaServiceDAOTest extends DAOTestHelper {
     libraryCardDAO.createLibraryCardDaaRelation(
         researcher.getUserId(), signingOfficial.getUserId(), card.getId(), alreadyLinkedDaaId);
 
-    DaaBulkRelationResult result =
+    BulkAddResult result =
         serviceDAO.bulkAddDaasToUser(
             researcher, List.of(alreadyLinkedDaaId, newDaaId), signingOfficial);
 
     // applied must reflect only the one relation that actually changed, not the requested count.
-    assertEquals(2, result.getRequested());
-    assertEquals(1, result.getApplied());
-    assertEquals(1, result.getSkipped());
+    assertEquals(2, result.summary().getRequested());
+    assertEquals(1, result.summary().getApplied());
+    assertEquals(1, result.summary().getSkipped());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3325](https://broadworkbench.atlassian.net/browse/DT-3325)

### Summary

The SO "Pre-Authorize Researchers" bulk **Approve All / Remove All** actions (`/api/daa/bulk/...`)
previously applied relationships in a plain loop and returned an empty `200` — a mid-batch failure
could leave a **partially applied** batch, and the UI had no count to report. This PR makes each
bulk operation **atomic**, returns a structured result, and brings the bulk path to full validation
parity with the single-relationship flow.

> Companion UI change: `duos-ui` (`otchet-dt-3325-bulk-daa-ops`). **Deploy this service first** —
> the UI reads the new response body.

#### Changes
- **`DaaBulkRelationResult`** (new): `{ requested, applied, skipped, errors }`. `applied` counts only
  relationships that actually changed; no-ops (re-add existing / remove absent) fall under `skipped`.
- **Atomic DAO ops** (`DaaServiceDAO`): all four bulk methods run in a single transaction, so a
  mid-batch failure rolls back the whole batch. Inserts are idempotent (`ON CONFLICT DO NOTHING`);
  the accurate `applied` count comes from the audit statement's row count.
- **Validation parity** (`DaaService`/`LibraryCardService`): add paths now reject before mutating in
  every case the single-link flow would — `requireSigningOfficialInstitution` (unconditional) and
  `validateNewLibraryCardCreation` (per card-less user). Single-link `addDaaToUserLibraryCard` reuses
  the same guard.
- **Post-commit email**: the "card issued" notification is sent after commit, best-effort, so it can't
  roll back a committed batch.
- **`DaaResource`**: bulk endpoints now produce/return the result body.
----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
