### PR TITLE
[DT-3862] Enforce canonical primary Data Use validation

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -178,9 +178,19 @@ public interface StudyDAO extends Transactional<StudyDAO> {
       FROM study
           INNER JOIN dataset
               ON study.study_id = dataset.study_id
-          INNER JOIN dataset_property prop
-              ON prop.dataset_id = dataset.dataset_id
-             AND prop.schema_property = 'accessManagement'
+          INNER JOIN LATERAL (
+              SELECT dataset_property.property_value
+              FROM dataset_property
+              WHERE dataset_property.dataset_id = dataset.dataset_id
+                AND LOWER(dataset_property.schema_property)
+                    IN ('accessmanagement', 'consentgroup.accessmanagement')
+              ORDER BY
+                  CASE
+                      WHEN LOWER(dataset_property.schema_property) = 'accessmanagement' THEN 0
+                      ELSE 1
+                  END
+              LIMIT 1
+          ) prop ON TRUE
       WHERE study.study_id IN (<studyIds>)
       GROUP BY study.study_id, study.name
       """)

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.consent.http.db.mapper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -22,7 +25,10 @@ public class DataUseParser implements ConsentLogger {
           try {
             return gson.fromJson(dataUseString, DataUse.class);
           } catch (Exception _) {
-            logWarn("Unable to parse data use string");
+            String hashPrefix = Hashing.sha256().hashString(s, UTF_8).toString().substring(0, 12);
+            logWarn(
+                "Unable to parse data use string (length=%d, sha256Prefix=%s)"
+                    .formatted(s.length(), hashPrefix));
           }
           return null;
         });

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
@@ -21,8 +21,8 @@ public class DataUseParser implements ConsentLogger {
         s -> {
           try {
             return gson.fromJson(dataUseString, DataUse.class);
-          } catch (Exception e) {
-            logWarn(String.format("Unable to parse data use string: '%s'", dataUseString));
+          } catch (Exception _) {
+            logWarn("Unable to parse data use string");
           }
           return null;
         });

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DataUseParser.java
@@ -25,6 +25,7 @@ public class DataUseParser implements ConsentLogger {
           try {
             return gson.fromJson(dataUseString, DataUse.class);
           } catch (Exception _) {
+            // Correlate repeated malformed rows without exposing their raw Data Use JSON.
             String hashPrefix = Hashing.sha256().hashString(s, UTF_8).toString().substring(0, 12);
             logWarn(
                 "Unable to parse data use string (length=%d, sha256Prefix=%s)"

--- a/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Dataset.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -16,6 +17,12 @@ import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Dataset implements ConsentLogger {
+
+  public static final String ACCESS_MANAGEMENT_SCHEMA_PROPERTY =
+      DatasetRegistrationSchemaV1Builder.accessManagement;
+  // Older dataset-registration records persisted the consent-group path as the schema property.
+  public static final String LEGACY_ACCESS_MANAGEMENT_SCHEMA_PROPERTY =
+      "consentGroup." + ACCESS_MANAGEMENT_SCHEMA_PROPERTY;
 
   private Integer datasetId;
 
@@ -188,6 +195,42 @@ public class Dataset implements ConsentLogger {
     this.properties.add(property);
   }
 
+  /**
+   * Returns the persisted access-management value, preferring the canonical schema property over
+   * the legacy consent-group-prefixed property.
+   */
+  public AccessManagement getAccessManagement() {
+    return parseAccessManagementProperty(ACCESS_MANAGEMENT_SCHEMA_PROPERTY)
+        .or(() -> parseAccessManagementProperty(LEGACY_ACCESS_MANAGEMENT_SCHEMA_PROPERTY))
+        .orElse(null);
+  }
+
+  private Optional<AccessManagement> parseAccessManagementProperty(String schemaProperty) {
+    if (properties == null) {
+      return Optional.empty();
+    }
+    return properties.stream()
+        .filter(property -> schemaProperty.equalsIgnoreCase(property.getSchemaProperty()))
+        .map(DatasetProperty::getPropertyValue)
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .map(String::trim)
+        .map(this::parseAccessManagementValue)
+        .filter(Objects::nonNull)
+        .findFirst();
+  }
+
+  private AccessManagement parseAccessManagementValue(String value) {
+    try {
+      return AccessManagement.fromValue(value.toLowerCase(Locale.ROOT));
+    } catch (IllegalArgumentException _) {
+      logWarn(
+          "Unable to parse access management value '%s' for dataset id: %s"
+              .formatted(value, datasetId));
+      return null;
+    }
+  }
+
   public Boolean getDacApproval() {
     return dacApproval;
   }
@@ -288,19 +331,12 @@ public class Dataset implements ConsentLogger {
     matchTerms.add(this.getDatasetIdentifier());
 
     if (Objects.nonNull(getProperties()) && !getProperties().isEmpty()) {
-      Optional<DatasetProperty> accessManagementProp =
-          getProperties().stream()
-              .filter((dp) -> Objects.nonNull(dp.getPropertyValue()))
-              .filter((dp) -> Objects.equals(dp.getPropertyName(), "Access Management"))
-              .findFirst();
-
-      if (accessManagementProp.isEmpty()) {
+      AccessManagement datasetAccessManagement = getAccessManagement();
+      if (datasetAccessManagement == null) {
         if (accessManagement.equals(AccessManagement.OPEN)) {
           return false;
         }
-      } else if (!accessManagement
-          .toString()
-          .equals(accessManagementProp.get().getPropertyValueAsString())) {
+      } else if (!accessManagement.equals(datasetAccessManagement)) {
         return false;
       }
 

--- a/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDataset.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.models.dataset_registration_v1.builder;
 
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.accessManagement;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.fileTypes;
@@ -21,7 +20,6 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.FileTypeObject;
 import org.broadinstitute.consent.http.service.ElasticSearchService;
@@ -35,10 +33,8 @@ public class ConsentGroupFromDataset {
       consentGroup.setDatasetId(dataset.getDatasetId());
       consentGroup.setDatasetIdentifier(dataset.getDatasetIdentifier());
       consentGroup.setConsentGroupName(dataset.getName());
-      String accessManagementVal = findStringDSPropValue(dataset.getProperties(), accessManagement);
-      if (Objects.nonNull(accessManagementVal)) {
-        consentGroup.setAccessManagement(AccessManagement.fromValue(accessManagementVal));
-      }
+      Optional.ofNullable(dataset.getAccessManagement())
+          .ifPresent(consentGroup::setAccessManagement);
       if (dataset.getDataUse() != null) {
         DataUse dataUse = dataset.getDataUse();
         consentGroup.setGeneralResearchUse(dataUse.getGeneralUse());

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryCategory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryCategory.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models.datause;
 
 /** Canonical primary categories supported by dataset Data Use. */
 public enum DataUsePrimaryCategory {
+  // Declaration order defines the canonical order used in classifications and audit reporting.
   GRU,
   HMB,
   POA,

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryCategory.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryCategory.java
@@ -1,0 +1,10 @@
+package org.broadinstitute.consent.http.models.datause;
+
+/** Canonical primary categories supported by dataset Data Use. */
+public enum DataUsePrimaryCategory {
+  GRU,
+  HMB,
+  POA,
+  DS,
+  OTHER
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassification.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassification.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.consent.http.models.datause;
+
+import java.util.List;
+
+/** Immutable classification of the primary categories present in a dataset Data Use. */
+public record DataUsePrimaryClassification(List<DataUsePrimaryCategory> categories) {
+
+  public DataUsePrimaryClassification {
+    categories = List.copyOf(categories);
+  }
+
+  public Shape shape() {
+    return switch (categories.size()) {
+      case 0 -> Shape.NONE;
+      case 1 -> Shape.SINGLE;
+      default -> Shape.MULTIPLE;
+    };
+  }
+
+  public enum Shape {
+    NONE,
+    SINGLE,
+    MULTIPLE
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassification.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassification.java
@@ -1,12 +1,20 @@
 package org.broadinstitute.consent.http.models.datause;
 
+import java.util.EnumSet;
 import java.util.List;
 
-/** Immutable classification of the primary categories present in a dataset Data Use. */
+/**
+ * Immutable classification of the primary categories present in a dataset Data Use. The category
+ * list is retained for audit reporting and matcher diagnostics in addition to shape validation.
+ */
 public record DataUsePrimaryClassification(List<DataUsePrimaryCategory> categories) {
 
   public DataUsePrimaryClassification {
-    categories = List.copyOf(categories);
+    EnumSet<DataUsePrimaryCategory> normalizedCategories =
+        categories.isEmpty()
+            ? EnumSet.noneOf(DataUsePrimaryCategory.class)
+            : EnumSet.copyOf(categories);
+    categories = List.copyOf(normalizedCategories);
   }
 
   public Shape shape() {

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.models.datause;
 
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -11,9 +10,6 @@ public final class DataUsePrimaryClassifier {
   private DataUsePrimaryClassifier() {}
 
   public static DataUsePrimaryClassification classify(DataUse dataUse) {
-    if (dataUse == null) {
-      return new DataUsePrimaryClassification(List.of());
-    }
     return classify(
         dataUse.getGeneralUse(),
         dataUse.getHmbResearch(),
@@ -26,7 +22,7 @@ public final class DataUsePrimaryClassifier {
       Boolean generalUse,
       Boolean hmbResearch,
       Boolean populationOriginsAncestry,
-      Collection<?> diseaseRestrictions,
+      List<String> diseaseRestrictions,
       String other) {
     EnumSet<DataUsePrimaryCategory> categories = EnumSet.noneOf(DataUsePrimaryCategory.class);
     if (Boolean.TRUE.equals(generalUse)) {

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
@@ -1,0 +1,49 @@
+package org.broadinstitute.consent.http.models.datause;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import org.broadinstitute.consent.http.models.DataUse;
+
+/** Classifies primary dataset Data Use fields without applying access-management policy. */
+public final class DataUsePrimaryClassifier {
+
+  private DataUsePrimaryClassifier() {}
+
+  public static DataUsePrimaryClassification classify(DataUse dataUse) {
+    if (dataUse == null) {
+      return new DataUsePrimaryClassification(List.of());
+    }
+    return classify(
+        dataUse.getGeneralUse(),
+        dataUse.getHmbResearch(),
+        dataUse.getPopulationOriginsAncestry(),
+        dataUse.getDiseaseRestrictions(),
+        dataUse.getOther());
+  }
+
+  public static DataUsePrimaryClassification classify(
+      Boolean generalUse,
+      Boolean hmbResearch,
+      Boolean populationOriginsAncestry,
+      Collection<?> diseaseRestrictions,
+      String other) {
+    EnumSet<DataUsePrimaryCategory> categories = EnumSet.noneOf(DataUsePrimaryCategory.class);
+    if (Boolean.TRUE.equals(generalUse)) {
+      categories.add(DataUsePrimaryCategory.GRU);
+    }
+    if (Boolean.TRUE.equals(hmbResearch)) {
+      categories.add(DataUsePrimaryCategory.HMB);
+    }
+    if (Boolean.TRUE.equals(populationOriginsAncestry)) {
+      categories.add(DataUsePrimaryCategory.POA);
+    }
+    if (diseaseRestrictions != null && !diseaseRestrictions.isEmpty()) {
+      categories.add(DataUsePrimaryCategory.DS);
+    }
+    if (other != null && !other.isBlank()) {
+      categories.add(DataUsePrimaryCategory.OTHER);
+    }
+    return new DataUsePrimaryClassification(List.copyOf(categories));
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidator.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.consent.http.models.datause;
+
+import jakarta.ws.rs.BadRequestException;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
+
+/** Applies dataset access-management policy to canonical primary Data Use classifications. */
+public final class DataUsePrimaryValidator {
+
+  public static final String VALIDATION_MESSAGE =
+      "Dataset must have exactly one primary data use (open access, or one of:"
+          + " general research use, health/medical/biomedical, populations/origins/ancestry,"
+          + " disease-specific, other)";
+
+  private DataUsePrimaryValidator() {}
+
+  public static void validate(DataUse dataUse, AccessManagement accessManagement) {
+    if (dataUse == null) {
+      throw new BadRequestException("Data Use is required");
+    }
+    validate(DataUsePrimaryClassifier.classify(dataUse), accessManagement);
+  }
+
+  public static void validate(
+      DataUsePrimaryClassification classification, AccessManagement accessManagement) {
+    boolean valid =
+        AccessManagement.OPEN.equals(accessManagement)
+            ? classification.shape() == Shape.NONE
+            : classification.shape() == Shape.SINGLE;
+    if (!valid) {
+      throw new BadRequestException(VALIDATION_MESSAGE);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidator.java
@@ -9,9 +9,10 @@ import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassificati
 public final class DataUsePrimaryValidator {
 
   public static final String VALIDATION_MESSAGE =
-      "Dataset must have exactly one primary data use (open access, or one of:"
+      "Open-access datasets must have no primary data use; controlled, external, and datasets"
+          + " with missing access management must have exactly one primary data use:"
           + " general research use, health/medical/biomedical, populations/origins/ancestry,"
-          + " disease-specific, other)";
+          + " disease-specific, or other";
 
   private DataUsePrimaryValidator() {}
 

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/StudyRegistrationRequestValidator.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryValidator;
 
 public class StudyRegistrationRequestValidator {
 
@@ -290,19 +292,14 @@ public class StudyRegistrationRequestValidator {
   }
 
   protected void validateDataUseConsistency(ConsentGroupRequest cg) {
-    int count = 0;
-    if (AccessManagement.OPEN.equals(cg.getAccessManagement())) count++;
-    if (Boolean.TRUE.equals(cg.getGeneralResearchUse())) count++;
-    if (Boolean.TRUE.equals(cg.getHmb())) count++;
-    if (Boolean.TRUE.equals(cg.getPoa())) count++;
-    if (cg.getDiseaseSpecificUse() != null && !cg.getDiseaseSpecificUse().isEmpty()) count++;
-    if (cg.getOtherPrimary() != null && !cg.getOtherPrimary().isBlank()) count++;
-    if (count != 1) {
-      throw new BadRequestException(
-          "Dataset must have exactly one primary data use (open access, or one of:"
-              + " general research use, health/medical/biomedical, populations/origins/ancestry,"
-              + " disease-specific, other)");
-    }
+    DataUsePrimaryValidator.validate(
+        DataUsePrimaryClassifier.classify(
+            cg.getGeneralResearchUse(),
+            cg.getHmb(),
+            cg.getPoa(),
+            cg.getDiseaseSpecificUse(),
+            cg.getOtherPrimary()),
+        cg.getAccessManagement());
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -481,6 +481,9 @@ public class DatasetResource extends Resource {
       // investigation
       Gson gson = new Gson();
       DataUse dataUse = gson.fromJson(dataUseJson, DataUse.class);
+      if (dataUse == null) {
+        throw new BadRequestException("Data Use JSON must be an object");
+      }
       Dataset originalDataset = datasetService.findDatasetById(user, id);
       if (Objects.isNull(originalDataset)) {
         throw new NotFoundException("Dataset not found: " + id);
@@ -491,8 +494,7 @@ public class DatasetResource extends Resource {
       Dataset dataset = datasetService.updateDatasetDataUse(user, id, dataUse);
       return Response.ok().entity(dataset).build();
     } catch (JsonSyntaxException _) {
-      return createExceptionResponse(
-          new BadRequestException("Invalid JSON Syntax: " + dataUseJson));
+      return createExceptionResponse(new BadRequestException("Invalid Data Use JSON"));
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyResource.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
@@ -88,8 +89,13 @@ public class StudyResource extends Resource {
       // TODO: Replace new Gson() with GsonUtil.buildGson() — deferred pending Gson configuration
       // investigation
       StudyConversion studyConversion = new Gson().fromJson(json, StudyConversion.class);
+      if (studyConversion == null) {
+        throw new BadRequestException("Study conversion JSON must be an object");
+      }
       Study study = datasetService.convertDatasetToStudy(user, dataset, studyConversion);
       return Response.ok(study).build();
+    } catch (JsonSyntaxException _) {
+      return createExceptionResponse(new BadRequestException("Invalid study conversion JSON"));
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.service;
 
-import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.accessManagement;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -20,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -50,7 +48,6 @@ import org.broadinstitute.consent.http.models.StudyConversion;
 import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.datause.DataUsePrimaryValidator;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
@@ -58,8 +55,6 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Jdbi;
 
 public class DatasetService implements ConsentLogger {
-
-  private static final String LEGACY_ACCESS_MANAGEMENT = "consentGroup." + accessManagement;
 
   private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private final DatasetDAO datasetDAO;
@@ -300,7 +295,7 @@ public class DatasetService implements ConsentLogger {
     if (!user.hasUserRole(UserRoles.ADMIN)) {
       throw new IllegalArgumentException("Admin use only");
     }
-    DataUsePrimaryValidator.validate(dataUse, findAccessManagement(d));
+    DataUsePrimaryValidator.validate(dataUse, d.getAccessManagement());
     String translation = ontologyService.translateDataUse(dataUse, DataUseTranslationType.DATASET);
     datasetServiceDAO.updateDatasetDataUse(user, d, dataUse, translation);
     elasticSearchService.synchronizeDatasetInESIndex(d, false);
@@ -481,8 +476,9 @@ public class DatasetService implements ConsentLogger {
     if (studyConversion == null) {
       throw new BadRequestException("Study conversion is required");
     }
+    // StudyConversion has patch semantics: an omitted Data Use preserves the persisted value.
     if (studyConversion.getDataUse() != null) {
-      DataUsePrimaryValidator.validate(studyConversion.getDataUse(), findAccessManagement(dataset));
+      DataUsePrimaryValidator.validate(studyConversion.getDataUse(), dataset.getAccessManagement());
     }
     // Study updates:
     Integer studyId = updateStudyFromConversion(user, dataset, studyConversion);
@@ -562,36 +558,6 @@ public class DatasetService implements ConsentLogger {
     }
 
     return studyDAO.findStudyById(studyId);
-  }
-
-  private AccessManagement findAccessManagement(Dataset dataset) {
-    if (dataset == null || dataset.getProperties() == null) {
-      return null;
-    }
-    return findAccessManagement(dataset.getProperties(), accessManagement)
-        .or(() -> findAccessManagement(dataset.getProperties(), LEGACY_ACCESS_MANAGEMENT))
-        .orElse(null);
-  }
-
-  private Optional<AccessManagement> findAccessManagement(
-      Set<DatasetProperty> properties, String schemaProperty) {
-    return properties.stream()
-        .filter(property -> schemaProperty.equalsIgnoreCase(property.getSchemaProperty()))
-        .map(DatasetProperty::getPropertyValue)
-        .filter(Objects::nonNull)
-        .map(Object::toString)
-        .map(String::trim)
-        .map(value -> value.toLowerCase(Locale.ROOT))
-        .map(
-            value -> {
-              try {
-                return AccessManagement.fromValue(value);
-              } catch (IllegalArgumentException _) {
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .findFirst();
   }
 
   public Study updateStudyCustodians(User user, Integer studyId, String custodians) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -568,11 +568,15 @@ public class DatasetService implements ConsentLogger {
     if (dataset == null || dataset.getProperties() == null) {
       return null;
     }
-    return dataset.getProperties().stream()
-        .filter(
-            property ->
-                accessManagement.equalsIgnoreCase(property.getSchemaProperty())
-                    || LEGACY_ACCESS_MANAGEMENT.equalsIgnoreCase(property.getSchemaProperty()))
+    return findAccessManagement(dataset.getProperties(), accessManagement)
+        .or(() -> findAccessManagement(dataset.getProperties(), LEGACY_ACCESS_MANAGEMENT))
+        .orElse(null);
+  }
+
+  private Optional<AccessManagement> findAccessManagement(
+      Set<DatasetProperty> properties, String schemaProperty) {
+    return properties.stream()
+        .filter(property -> schemaProperty.equalsIgnoreCase(property.getSchemaProperty()))
         .map(DatasetProperty::getPropertyValue)
         .filter(Objects::nonNull)
         .map(Object::toString)
@@ -587,8 +591,7 @@ public class DatasetService implements ConsentLogger {
               }
             })
         .filter(Objects::nonNull)
-        .findFirst()
-        .orElse(null);
+        .findFirst();
   }
 
   public Study updateStudyCustodians(User user, Integer studyId, String custodians) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -59,6 +59,8 @@ import org.jdbi.v3.core.Jdbi;
 
 public class DatasetService implements ConsentLogger {
 
+  private static final String LEGACY_ACCESS_MANAGEMENT = "consentGroup." + accessManagement;
+
   private final DatasetAuthorizationReaderDAO datasetAuthorizationReaderDAO;
   private final DatasetDAO datasetDAO;
   private final DaaDAO daaDAO;
@@ -567,7 +569,10 @@ public class DatasetService implements ConsentLogger {
       return null;
     }
     return dataset.getProperties().stream()
-        .filter(property -> accessManagement.equals(property.getSchemaProperty()))
+        .filter(
+            property ->
+                accessManagement.equalsIgnoreCase(property.getSchemaProperty())
+                    || LEGACY_ACCESS_MANAGEMENT.equalsIgnoreCase(property.getSchemaProperty()))
         .map(DatasetProperty::getPropertyValue)
         .filter(Objects::nonNull)
         .map(Object::toString)

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.service;
 
+import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.accessManagement;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.dataCustodianEmail;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -48,6 +50,8 @@ import org.broadinstitute.consent.http.models.StudyConversion;
 import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryValidator;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -294,6 +298,7 @@ public class DatasetService implements ConsentLogger {
     if (!user.hasUserRole(UserRoles.ADMIN)) {
       throw new IllegalArgumentException("Admin use only");
     }
+    DataUsePrimaryValidator.validate(dataUse, findAccessManagement(d));
     String translation = ontologyService.translateDataUse(dataUse, DataUseTranslationType.DATASET);
     datasetServiceDAO.updateDatasetDataUse(user, d, dataUse, translation);
     elasticSearchService.synchronizeDatasetInESIndex(d, false);
@@ -471,6 +476,12 @@ public class DatasetService implements ConsentLogger {
     if (!user.hasUserRole(UserRoles.ADMIN)) {
       throw new NotAuthorizedException("Admin use only");
     }
+    if (studyConversion == null) {
+      throw new BadRequestException("Study conversion is required");
+    }
+    if (studyConversion.getDataUse() != null) {
+      DataUsePrimaryValidator.validate(studyConversion.getDataUse(), findAccessManagement(dataset));
+    }
     // Study updates:
     Integer studyId = updateStudyFromConversion(user, dataset, studyConversion);
 
@@ -549,6 +560,30 @@ public class DatasetService implements ConsentLogger {
     }
 
     return studyDAO.findStudyById(studyId);
+  }
+
+  private AccessManagement findAccessManagement(Dataset dataset) {
+    if (dataset == null || dataset.getProperties() == null) {
+      return null;
+    }
+    return dataset.getProperties().stream()
+        .filter(property -> accessManagement.equals(property.getSchemaProperty()))
+        .map(DatasetProperty::getPropertyValue)
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .map(String::trim)
+        .map(value -> value.toLowerCase(Locale.ROOT))
+        .map(
+            value -> {
+              try {
+                return AccessManagement.fromValue(value);
+              } catch (IllegalArgumentException _) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 
   public Study updateStudyCustodians(User user, Integer studyId, String custodians) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -483,10 +483,8 @@ public class ElasticSearchService implements ConsentLogger {
     Optional.ofNullable(dataset.getNihInstitutionalCertificationFile())
         .ifPresent(obj -> term.setHasInstitutionCertification(true));
 
-    findDatasetProperty(dataset.getProperties(), "accessManagement")
-        .ifPresent(
-            datasetProperty ->
-                term.setAccessManagement(datasetProperty.getPropertyValueAsString()));
+    Optional.ofNullable(dataset.getAccessManagement())
+        .ifPresent(accessManagement -> term.setAccessManagement(accessManagement.value()));
 
     findFirstDatasetPropertyByName(dataset.getProperties(), "# of participants")
         .ifPresent(

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -4,7 +4,7 @@ put:
   description: | 
     Admin Only API to update the Dataset's Data Use object from JSON.
     The Data Use must be consistent with the dataset's access management:
-    open datasets have no controlled primary category, while controlled,
+    open datasets have no primary category, while controlled,
     external, and datasets with missing access management have exactly one
     primary category.
     ## Note

--- a/src/main/resources/assets/paths/datasetByIdDataUse.yaml
+++ b/src/main/resources/assets/paths/datasetByIdDataUse.yaml
@@ -3,6 +3,10 @@ put:
   operationId: apiDatasetIdDatausePut
   description: | 
     Admin Only API to update the Dataset's Data Use object from JSON.
+    The Data Use must be consistent with the dataset's access management:
+    open datasets have no controlled primary category, while controlled,
+    external, and datasets with missing access management have exactly one
+    primary category.
     ## Note
     This endpoint is restricted to updating the data use object only and does
     not perform any logical checks to determine if match results for existing 
@@ -34,7 +38,7 @@ put:
     304:
       description: Not modified
     400:
-      description: Bad Request (invalid input)
+      description: Bad Request (invalid JSON, JSON null, or inconsistent primary Data Use)
     401:
       description: Unauthorized.
     404:

--- a/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
+++ b/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
@@ -4,7 +4,7 @@ put:
   description: |
     Converts a Dataset into a Study and updates modifiable fields.
     When Data Use is supplied, it must be consistent with the dataset's access
-    management: open datasets have no controlled primary category, while
+    management: open datasets have no primary category, while
     controlled, external, and datasets with missing access management have
     exactly one primary category.
   tags:

--- a/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
+++ b/src/main/resources/assets/paths/studyConvertByIdentifier.yaml
@@ -1,7 +1,12 @@
 put:
   summary: Convert Dataset to Study
   operationId: apiDatasetStudyConvertDatasetIdentifierPut
-  description: Converts a Dataset into a Study and updates modifiable fields
+  description: |
+    Converts a Dataset into a Study and updates modifiable fields.
+    When Data Use is supplied, it must be consistent with the dataset's access
+    management: open datasets have no controlled primary category, while
+    controlled, external, and datasets with missing access management have
+    exactly one primary category.
   tags:
     - Admin
   parameters:
@@ -26,7 +31,7 @@ put:
           schema:
             $ref: '../schemas/Study.yaml'
     400:
-      description: Bad Request
+      description: Bad Request (invalid JSON, JSON null, or inconsistent primary Data Use)
     404:
       description: Not Found
     429:

--- a/src/main/resources/assets/schemas/ConsentGroup.yaml
+++ b/src/main/resources/assets/schemas/ConsentGroup.yaml
@@ -3,8 +3,8 @@ description: |
   Each Consent Group is translated into a separate Dataset. `consentGroupName`
   and `numberOfParticipants` are required when creating a new consent group —
   either via registration create, or by adding a new consent group (no
-  `datasetId`) during a study update. Exactly one primary data use must be
-  set: `accessManagement: open`, or exactly one of `generalResearchUse`,
+  `datasetId`) during a study update. Open-access datasets must have no primary
+  data use. All other datasets must have exactly one of `generalResearchUse`,
   `hmb`, `poa`, `diseaseSpecificUse` (non-empty), or `otherPrimary`.
   `dataAccessCommitteeId` is required unless `accessManagement` is `open` or
   `external` — a missing `accessManagement` is treated the same as

--- a/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
@@ -1,15 +1,22 @@
 package org.broadinstitute.consent.http.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.DataUseParser;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.util.TestAppender;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class DataUseParserTest {
@@ -25,9 +32,26 @@ class DataUseParserTest {
 
   @Test
   void testParseInvalidDataUse() {
+    String submittedDataUse = "sensitive invalid data use";
+    Logger logger = (Logger) LoggerFactory.getLogger(DataUseParser.class);
+    TestAppender appender = new TestAppender();
+    appender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(appender);
+    appender.start();
     DataUseParser dataUseParser = new DataUseParser();
-    DataUse dataUse = dataUseParser.parseDataUse("test");
-    assertNull(dataUse);
+    try {
+      DataUse dataUse = dataUseParser.parseDataUse(submittedDataUse);
+      assertNull(dataUse);
+      List<ILoggingEvent> events = appender.getLoggedEvents();
+      assertFalse(events.isEmpty());
+      assertFalse(
+          events.stream()
+              .map(ILoggingEvent::getFormattedMessage)
+              .anyMatch(message -> message.contains(submittedDataUse)));
+    } finally {
+      appender.stop();
+      logger.detachAppender(appender);
+    }
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataUseParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -44,10 +45,15 @@ class DataUseParserTest {
       assertNull(dataUse);
       List<ILoggingEvent> events = appender.getLoggedEvents();
       assertFalse(events.isEmpty());
-      assertFalse(
-          events.stream()
-              .map(ILoggingEvent::getFormattedMessage)
-              .anyMatch(message -> message.contains(submittedDataUse)));
+      List<String> messages = events.stream().map(ILoggingEvent::getFormattedMessage).toList();
+      assertFalse(messages.stream().anyMatch(message -> message.contains(submittedDataUse)));
+      assertTrue(
+          messages.stream()
+              .anyMatch(
+                  message ->
+                      message.matches(
+                          "Unable to parse data use string \\(length=26,"
+                              + " sha256Prefix=[0-9a-f]{12}\\)")));
     } finally {
       appender.stop();
       logger.detachAppender(appender);

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -426,6 +426,16 @@ class StudyDAOTest extends DAOTestHelper {
               insertAccessManagementDatasetProperty(dataset.getDatasetId(), "open");
             });
 
+    Dataset legacyOpenDataset = insertDatasetForStudy(study2.getStudyId());
+    insertAccessManagementDatasetProperty(
+        legacyOpenDataset.getDatasetId(), "consentGroup.accessManagement", "open");
+
+    Dataset conflictingDataset = insertDatasetForStudy(study2.getStudyId());
+    insertAccessManagementDatasetProperty(
+        conflictingDataset.getDatasetId(), "consentGroup.accessManagement", "open");
+    insertAccessManagementDatasetProperty(
+        conflictingDataset.getDatasetId(), "ACCESSMANAGEMENT", "controlled");
+
     List<StudyDatasetCountRecord> records =
         studyDAO.findStudyDatasetCounts(Set.of(study1.getStudyId()));
 
@@ -440,8 +450,8 @@ class StudyDAOTest extends DAOTestHelper {
     assertEquals(1, records.size());
     assertEquals(study2.getStudyId(), records.getFirst().id());
     assertEquals(study2.getName(), records.getFirst().name());
-    assertEquals("open", records.getFirst().accessTypes());
-    assertEquals(5, records.getFirst().datasetCount());
+    assertEquals("controlled,open", records.getFirst().accessTypes());
+    assertEquals(7, records.getFirst().datasetCount());
 
     records = studyDAO.findStudyDatasetCounts(Set.of(study1.getStudyId(), study2.getStudyId()));
 
@@ -457,10 +467,11 @@ class StudyDAOTest extends DAOTestHelper {
     assertEquals(
         "controlled,external,open", recordsByStudyId.get(study1.getStudyId()).accessTypes());
 
-    // study2 has exactly 5 open datasets created in the second loop.
+    // study2 has 5 canonical open datasets, 1 legacy open dataset, and 1 dataset where the
+    // canonical controlled value takes precedence over a conflicting legacy open value.
     // The initial 3 datasets created for study1 are not included here.
-    assertEquals(5, recordsByStudyId.get(study2.getStudyId()).datasetCount());
-    assertEquals("open", recordsByStudyId.get(study2.getStudyId()).accessTypes());
+    assertEquals(7, recordsByStudyId.get(study2.getStudyId()).datasetCount());
+    assertEquals("controlled,open", recordsByStudyId.get(study2.getStudyId()).accessTypes());
   }
 
   private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
@@ -537,13 +548,18 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   private void insertAccessManagementDatasetProperty(Integer datasetId, String propertyValue) {
+    insertAccessManagementDatasetProperty(datasetId, "accessManagement", propertyValue);
+  }
+
+  private void insertAccessManagementDatasetProperty(
+      Integer datasetId, String schemaProperty, String propertyValue) {
     datasetDAO.insertDatasetProperties(
         List.of(
             new DatasetProperty(
                 1,
                 datasetId,
                 1,
-                "accessManagement",
+                schemaProperty,
                 propertyValue,
                 PropertyType.String,
                 Date.from(Instant.now()))));

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -3,8 +3,12 @@ package org.broadinstitute.consent.http.models;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.gson.JsonArray;
 import java.util.List;
 import java.util.Set;
@@ -13,9 +17,11 @@ import org.apache.commons.lang3.RandomUtils;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
+import org.broadinstitute.consent.http.util.TestAppender;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class DatasetTests {
@@ -243,5 +249,32 @@ class DatasetTests {
 
     assertTrue(ds.isDatasetMatch(value, AccessManagement.CONTROLLED));
     assertFalse(ds.isDatasetMatch(RandomStringUtils.randomAlphanumeric(25), AccessManagement.OPEN));
+  }
+
+  @Test
+  void testGetAccessManagementLogsUnparseableValue() {
+    String invalidValue = "unknown";
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(42);
+    DatasetProperty property = new DatasetProperty();
+    property.setSchemaProperty(Dataset.ACCESS_MANAGEMENT_SCHEMA_PROPERTY);
+    property.setPropertyValue(invalidValue);
+    dataset.setProperties(Set.of(property));
+
+    Logger logger = (Logger) LoggerFactory.getLogger(Dataset.class);
+    TestAppender appender = new TestAppender();
+    appender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    logger.addAppender(appender);
+    appender.start();
+    try {
+      assertNull(dataset.getAccessManagement());
+      List<String> messages =
+          appender.getLoggedEvents().stream().map(ILoggingEvent::getFormattedMessage).toList();
+      assertTrue(messages.stream().anyMatch(message -> message.contains(invalidValue)));
+      assertTrue(messages.stream().anyMatch(message -> message.contains("dataset id: 42")));
+    } finally {
+      appender.stop();
+      logger.detachAppender(appender);
+    }
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dataset_registration_v1/builder/ConsentGroupFromDatasetTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models.dataset_registration_v1.builder;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.requestLocation;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.url;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -13,6 +14,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.junit.jupiter.api.Test;
 
 class ConsentGroupFromDatasetTest extends AbstractTestHelper {
@@ -29,6 +31,23 @@ class ConsentGroupFromDatasetTest extends AbstractTestHelper {
     Dataset dataset = new Dataset();
     ConsentGroup result = builder.build(dataset);
     assertNotNull(result);
+  }
+
+  @Test
+  void testBuildUsesLegacyAccessManagementProperty() {
+    ConsentGroupFromDataset builder = new ConsentGroupFromDataset();
+    Dataset dataset = createMockDataset();
+    dataset.addProperty(
+        createDatasetProperty(
+            dataset,
+            Dataset.LEGACY_ACCESS_MANAGEMENT_SCHEMA_PROPERTY,
+            PropertyType.String,
+            "OPEN"));
+
+    ConsentGroup result = builder.build(dataset);
+
+    assertNotNull(result);
+    assertEquals(AccessManagement.OPEN, result.getAccessManagement());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifierTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifierTest.java
@@ -1,0 +1,116 @@
+package org.broadinstitute.consent.http.models.datause;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.ws.rs.BadRequestException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DataUsePrimaryClassifierTest {
+
+  @Test
+  void classifyNullAsNone() {
+    assertClassification(null, Shape.NONE, List.of());
+  }
+
+  @Test
+  void classifyEmptyAndSecondaryOnlyAsNone() {
+    assertClassification(new DataUse(), Shape.NONE, List.of());
+    assertClassification(
+        new DataUseBuilder().setSecondaryOther("secondary text").build(), Shape.NONE, List.of());
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleCategoryDataUses")
+  void classifyEverySingleCategory(DataUse dataUse, DataUsePrimaryCategory expectedCategory) {
+    assertClassification(dataUse, Shape.SINGLE, List.of(expectedCategory));
+  }
+
+  static Stream<Arguments> singleCategoryDataUses() {
+    return Stream.of(
+        Arguments.of(new DataUseBuilder().setGeneralUse(true).build(), DataUsePrimaryCategory.GRU),
+        Arguments.of(new DataUseBuilder().setHmbResearch(true).build(), DataUsePrimaryCategory.HMB),
+        Arguments.of(
+            new DataUseBuilder().setPopulationOriginsAncestry(true).build(),
+            DataUsePrimaryCategory.POA),
+        Arguments.of(
+            new DataUseBuilder().setDiseaseRestrictions(List.of("DOID:1")).build(),
+            DataUsePrimaryCategory.DS),
+        Arguments.of(
+            new DataUseBuilder().setOther("primary text").build(), DataUsePrimaryCategory.OTHER));
+  }
+
+  @Test
+  void classifyMultipleCategoriesInCanonicalOrder() {
+    DataUse dataUse =
+        new DataUseBuilder()
+            .setOther("primary text")
+            .setDiseaseRestrictions(List.of("DOID:1"))
+            .setGeneralUse(true)
+            .build();
+
+    assertClassification(
+        dataUse,
+        Shape.MULTIPLE,
+        List.of(
+            DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.DS, DataUsePrimaryCategory.OTHER));
+  }
+
+  @ParameterizedTest
+  @MethodSource("accessManagementValidationCases")
+  void validateAccessManagementAgainstPrimaryShape(
+      AccessManagement accessManagement,
+      DataUsePrimaryClassification classification,
+      boolean valid) {
+    if (valid) {
+      assertDoesNotThrow(() -> DataUsePrimaryValidator.validate(classification, accessManagement));
+    } else {
+      BadRequestException exception =
+          assertThrows(
+              BadRequestException.class,
+              () -> DataUsePrimaryValidator.validate(classification, accessManagement));
+      assertEquals(DataUsePrimaryValidator.VALIDATION_MESSAGE, exception.getMessage());
+    }
+  }
+
+  static Stream<Arguments> accessManagementValidationCases() {
+    DataUsePrimaryClassification none = classification();
+    DataUsePrimaryClassification single = classification(DataUsePrimaryCategory.GRU);
+    DataUsePrimaryClassification multiple =
+        classification(DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.HMB);
+    return Stream.of(
+        Arguments.of(AccessManagement.OPEN, none, true),
+        Arguments.of(AccessManagement.OPEN, single, false),
+        Arguments.of(AccessManagement.OPEN, multiple, false),
+        Arguments.of(AccessManagement.CONTROLLED, none, false),
+        Arguments.of(AccessManagement.CONTROLLED, single, true),
+        Arguments.of(AccessManagement.CONTROLLED, multiple, false),
+        Arguments.of(AccessManagement.EXTERNAL, none, false),
+        Arguments.of(AccessManagement.EXTERNAL, single, true),
+        Arguments.of(AccessManagement.EXTERNAL, multiple, false),
+        Arguments.of(null, none, false),
+        Arguments.of(null, single, true),
+        Arguments.of(null, multiple, false));
+  }
+
+  private static DataUsePrimaryClassification classification(DataUsePrimaryCategory... categories) {
+    return new DataUsePrimaryClassification(List.of(categories));
+  }
+
+  private static void assertClassification(
+      DataUse dataUse, Shape shape, List<DataUsePrimaryCategory> categories) {
+    DataUsePrimaryClassification classification = DataUsePrimaryClassifier.classify(dataUse);
+    assertEquals(shape, classification.shape());
+    assertEquals(categories, classification.categories());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifierTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifierTest.java
@@ -1,15 +1,11 @@
 package org.broadinstitute.consent.http.models.datause;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import jakarta.ws.rs.BadRequestException;
 import java.util.List;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
-import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,11 +13,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DataUsePrimaryClassifierTest {
-
-  @Test
-  void classifyNullAsNone() {
-    assertClassification(null, Shape.NONE, List.of());
-  }
 
   @Test
   void classifyEmptyAndSecondaryOnlyAsNone() {
@@ -66,45 +57,19 @@ class DataUsePrimaryClassifierTest {
             DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.DS, DataUsePrimaryCategory.OTHER));
   }
 
-  @ParameterizedTest
-  @MethodSource("accessManagementValidationCases")
-  void validateAccessManagementAgainstPrimaryShape(
-      AccessManagement accessManagement,
-      DataUsePrimaryClassification classification,
-      boolean valid) {
-    if (valid) {
-      assertDoesNotThrow(() -> DataUsePrimaryValidator.validate(classification, accessManagement));
-    } else {
-      BadRequestException exception =
-          assertThrows(
-              BadRequestException.class,
-              () -> DataUsePrimaryValidator.validate(classification, accessManagement));
-      assertEquals(DataUsePrimaryValidator.VALIDATION_MESSAGE, exception.getMessage());
-    }
-  }
+  @Test
+  void classificationNormalizesDuplicatesInCanonicalOrder() {
+    DataUsePrimaryClassification classification =
+        new DataUsePrimaryClassification(
+            List.of(
+                DataUsePrimaryCategory.OTHER,
+                DataUsePrimaryCategory.GRU,
+                DataUsePrimaryCategory.OTHER));
 
-  static Stream<Arguments> accessManagementValidationCases() {
-    DataUsePrimaryClassification none = classification();
-    DataUsePrimaryClassification single = classification(DataUsePrimaryCategory.GRU);
-    DataUsePrimaryClassification multiple =
-        classification(DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.HMB);
-    return Stream.of(
-        Arguments.of(AccessManagement.OPEN, none, true),
-        Arguments.of(AccessManagement.OPEN, single, false),
-        Arguments.of(AccessManagement.OPEN, multiple, false),
-        Arguments.of(AccessManagement.CONTROLLED, none, false),
-        Arguments.of(AccessManagement.CONTROLLED, single, true),
-        Arguments.of(AccessManagement.CONTROLLED, multiple, false),
-        Arguments.of(AccessManagement.EXTERNAL, none, false),
-        Arguments.of(AccessManagement.EXTERNAL, single, true),
-        Arguments.of(AccessManagement.EXTERNAL, multiple, false),
-        Arguments.of(null, none, false),
-        Arguments.of(null, single, true),
-        Arguments.of(null, multiple, false));
-  }
-
-  private static DataUsePrimaryClassification classification(DataUsePrimaryCategory... categories) {
-    return new DataUsePrimaryClassification(List.of(categories));
+    assertEquals(Shape.MULTIPLE, classification.shape());
+    assertEquals(
+        List.of(DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.OTHER),
+        classification.categories());
   }
 
   private static void assertClassification(

--- a/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidatorTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryValidatorTest.java
@@ -1,0 +1,69 @@
+package org.broadinstitute.consent.http.models.datause;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.ws.rs.BadRequestException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DataUsePrimaryValidatorTest {
+
+  @Test
+  void rejectNullDataUse() {
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> DataUsePrimaryValidator.validate((DataUse) null, AccessManagement.OPEN));
+
+    assertEquals("Data Use is required", exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("accessManagementValidationCases")
+  void validateAccessManagementAgainstPrimaryShape(
+      AccessManagement accessManagement,
+      DataUsePrimaryClassification classification,
+      boolean valid) {
+    if (valid) {
+      assertDoesNotThrow(() -> DataUsePrimaryValidator.validate(classification, accessManagement));
+    } else {
+      BadRequestException exception =
+          assertThrows(
+              BadRequestException.class,
+              () -> DataUsePrimaryValidator.validate(classification, accessManagement));
+      assertEquals(DataUsePrimaryValidator.VALIDATION_MESSAGE, exception.getMessage());
+    }
+  }
+
+  static Stream<Arguments> accessManagementValidationCases() {
+    DataUsePrimaryClassification none = classification();
+    DataUsePrimaryClassification single = classification(DataUsePrimaryCategory.GRU);
+    DataUsePrimaryClassification multiple =
+        classification(DataUsePrimaryCategory.GRU, DataUsePrimaryCategory.HMB);
+    return Stream.of(
+        Arguments.of(AccessManagement.OPEN, none, true),
+        Arguments.of(AccessManagement.OPEN, single, false),
+        Arguments.of(AccessManagement.OPEN, multiple, false),
+        Arguments.of(AccessManagement.CONTROLLED, none, false),
+        Arguments.of(AccessManagement.CONTROLLED, single, true),
+        Arguments.of(AccessManagement.CONTROLLED, multiple, false),
+        Arguments.of(AccessManagement.EXTERNAL, none, false),
+        Arguments.of(AccessManagement.EXTERNAL, single, true),
+        Arguments.of(AccessManagement.EXTERNAL, multiple, false),
+        Arguments.of(null, none, false),
+        Arguments.of(null, single, true),
+        Arguments.of(null, multiple, false));
+  }
+
+  private static DataUsePrimaryClassification classification(DataUsePrimaryCategory... categories) {
+    return new DataUsePrimaryClassification(List.of(categories));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -707,8 +707,19 @@ class DatasetResourceTest extends AbstractTestHelper {
 
   @Test
   void testUpdateDatasetDataUse_BadRequestJson() {
-    try (var response = resource.updateDatasetDataUse(duosUser, 1, "invalid json")) {
+    String submittedDataUse = "sensitive invalid json";
+    try (var response = resource.updateDatasetDataUse(duosUser, 1, submittedDataUse)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      assertFalse(((Error) response.getEntity()).message().contains(submittedDataUse));
+    }
+  }
+
+  @Test
+  void testUpdateDatasetDataUse_BadRequestJsonNull() {
+    try (var response = resource.updateDatasetDataUse(duosUser, 1, "null")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      verify(datasetService, never()).findDatasetById(any(), any());
+      verify(datasetService, never()).updateDatasetDataUse(any(), any(), any());
     }
   }
 
@@ -792,17 +803,21 @@ class DatasetResourceTest extends AbstractTestHelper {
       """;
     try (var response = resource.createDatasetRegistration(duosUser, null, invalidJson)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
-      String entity = response.getEntity().toString();
+      Error entity = (Error) response.getEntity();
 
       // Check for specific user-facing error messages, all reported together in one response
-      assertTrue(entity.contains("Please correct the following fields:"));
-      assertTrue(entity.contains("Study Name is required"));
-      assertTrue(entity.contains("Study Description is required"));
-      assertTrue(entity.contains("Data Types is required"));
-      assertTrue(entity.contains("At least one Dataset is required"));
-      assertTrue(entity.contains("NIH Anvil Use is required"));
-      assertTrue(entity.contains("Principal Investigator Name is required"));
-      assertTrue(entity.contains("Public Visibility is required"));
+      assertEquals(
+          """
+          Please correct the following fields:
+           - Study Name is required
+           - Study Description is required
+           - Data Types is required
+           - Public Visibility is required
+           - NIH Anvil Use is required
+           - Principal Investigator Name is required
+           - At least one Dataset is required
+          """,
+          entity.message());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyResourceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -22,6 +23,7 @@ import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
@@ -70,6 +72,30 @@ class StudyResourceTest extends AbstractTestHelper {
     try (var response =
         resource.updateCustodians(duosUser, 1, "[\"user_1@test.com\", \"user_2@test.com\"]")) {
       assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    }
+  }
+
+  @Test
+  void testConvertToStudyRejectsInvalidJsonWithoutEchoingPayload() {
+    String submittedConversion = "sensitive invalid json";
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdentifier(user, "DUOS-000001")).thenReturn(new Dataset());
+
+    try (var response = resource.convertToStudy(duosUser, "DUOS-000001", submittedConversion)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      assertFalse(((Error) response.getEntity()).message().contains(submittedConversion));
+      verify(datasetService, never()).convertDatasetToStudy(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testConvertToStudyRejectsJsonNull() {
+    when(duosUser.getUser()).thenReturn(user);
+    when(datasetService.findDatasetByIdentifier(user, "DUOS-000001")).thenReturn(new Dataset());
+
+    try (var response = resource.convertToStudy(duosUser, "DUOS-000001", "null")) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+      verify(datasetService, never()).convertDatasetToStudy(any(), any(), any());
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -416,6 +416,35 @@ class DatasetServiceTest extends AbstractTestHelper {
     verify(elasticSearchService).synchronizeDatasetInESIndex(dataset, false);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"OPEN", " open "})
+  void testUpdateDatasetDataUseNormalizesAccessManagementValue(String propertyValue) {
+    Dataset dataset = new Dataset();
+    setAccessManagement(
+        dataset, propertyValue, DatasetRegistrationSchemaV1Builder.accessManagement);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+    DataUse dataUse = new DataUseBuilder().setMethodsResearch(true).build();
+
+    assertDoesNotThrow(() -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
+
+    verify(datasetServiceDAO).updateDatasetDataUse(eq(admin), eq(dataset), eq(dataUse), any());
+  }
+
+  @Test
+  void testUpdateDatasetDataUseTreatsUnknownAccessManagementAsControlled() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    setAccessManagement(dataset, "unknown", DatasetRegistrationSchemaV1Builder.accessManagement);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+
+    assertDoesNotThrow(() -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
+
+    verify(datasetServiceDAO).updateDatasetDataUse(eq(admin), eq(dataset), eq(dataUse), any());
+  }
+
   @Test
   void testUpdateDatasetDataUsePrefersCanonicalAccessManagement() {
     Dataset dataset = new Dataset();
@@ -1743,14 +1772,22 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   private void setAccessManagement(Dataset dataset, AccessManagement value, String schemaProperty) {
+    setAccessManagement(dataset, value.value(), schemaProperty);
+  }
+
+  private void setAccessManagement(Dataset dataset, String value, String schemaProperty) {
     dataset.setProperties(Set.of(accessManagementProperty(schemaProperty, value)));
   }
 
   private DatasetProperty accessManagementProperty(String schemaProperty, AccessManagement value) {
+    return accessManagementProperty(schemaProperty, value.value());
+  }
+
+  private DatasetProperty accessManagementProperty(String schemaProperty, String value) {
     DatasetProperty property = new DatasetProperty();
     property.setSchemaProperty(schemaProperty);
     property.setPropertyType(PropertyType.String);
-    property.setPropertyValue(value.value());
+    property.setPropertyValue(value);
     return property;
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -359,10 +359,10 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setProperties(Collections.emptySet());
     when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
     User admin = getAdmin();
+    DataUse dataUse = new DataUse();
 
     assertThrows(
-        BadRequestException.class,
-        () -> datasetService.updateDatasetDataUse(admin, 1, new DataUse()));
+        BadRequestException.class, () -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
 
     verifyNoInteractions(ontologyService, datasetServiceDAO, elasticSearchService);
   }
@@ -394,10 +394,17 @@ class DatasetServiceTest extends AbstractTestHelper {
     verifyNoInteractions(ontologyService, datasetServiceDAO, elasticSearchService);
   }
 
-  @Test
-  void testUpdateDatasetDataUseAcceptsOpenWithNoPrimary() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "accessManagement",
+        "ACCESSMANAGEMENT",
+        "consentGroup.accessManagement",
+        "CONSENTGROUP.ACCESSMANAGEMENT"
+      })
+  void testUpdateDatasetDataUseAcceptsOpenWithNoPrimary(String schemaProperty) {
     Dataset dataset = new Dataset();
-    setAccessManagement(dataset, AccessManagement.OPEN);
+    setAccessManagement(dataset, AccessManagement.OPEN, schemaProperty);
     when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
     User admin = getAdmin();
     DataUse dataUse = new DataUseBuilder().setMethodsResearch(true).build();
@@ -1715,8 +1722,12 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   private void setAccessManagement(Dataset dataset, AccessManagement value) {
+    setAccessManagement(dataset, value, DatasetRegistrationSchemaV1Builder.accessManagement);
+  }
+
+  private void setAccessManagement(Dataset dataset, AccessManagement value, String schemaProperty) {
     DatasetProperty property = new DatasetProperty();
-    property.setSchemaProperty(DatasetRegistrationSchemaV1Builder.accessManagement);
+    property.setSchemaProperty(schemaProperty);
     property.setPropertyType(PropertyType.String);
     property.setPropertyValue(value.value());
     dataset.setProperties(Set.of(property));

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -417,6 +417,23 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testUpdateDatasetDataUsePrefersCanonicalAccessManagement() {
+    Dataset dataset = new Dataset();
+    dataset.setProperties(
+        Set.of(
+            accessManagementProperty("accessManagement", AccessManagement.OPEN),
+            accessManagementProperty(
+                "consentGroup.accessManagement", AccessManagement.CONTROLLED)));
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+    DataUse dataUse = new DataUseBuilder().setMethodsResearch(true).build();
+
+    assertDoesNotThrow(() -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
+
+    verify(datasetServiceDAO).updateDatasetDataUse(eq(admin), eq(dataset), eq(dataUse), any());
+  }
+
+  @Test
   void testUpdateDatasetDataUseNonAdmin() {
     when(datasetDAO.findDatasetById(any())).thenReturn(new Dataset());
     User u = new User();
@@ -1726,11 +1743,15 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   private void setAccessManagement(Dataset dataset, AccessManagement value, String schemaProperty) {
+    dataset.setProperties(Set.of(accessManagementProperty(schemaProperty, value)));
+  }
+
+  private DatasetProperty accessManagementProperty(String schemaProperty, AccessManagement value) {
     DatasetProperty property = new DatasetProperty();
     property.setSchemaProperty(schemaProperty);
     property.setPropertyType(PropertyType.String);
     property.setPropertyValue(value.value());
-    dataset.setProperties(Set.of(property));
+    return property;
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
@@ -43,6 +44,7 @@ import org.broadinstitute.consent.http.db.DatasetAuthorizationReaderDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.mail.message.DatasetApprovedMessage;
@@ -63,6 +65,7 @@ import org.broadinstitute.consent.http.models.StudyPatch;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.StudyType;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
@@ -348,6 +351,62 @@ class DatasetServiceTest extends AbstractTestHelper {
     } catch (Exception e) {
       fail(e.getMessage());
     }
+  }
+
+  @Test
+  void testUpdateDatasetDataUseRejectsMissingPrimaryBeforeSideEffects() {
+    Dataset dataset = new Dataset();
+    dataset.setProperties(Collections.emptySet());
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+
+    assertThrows(
+        BadRequestException.class,
+        () -> datasetService.updateDatasetDataUse(admin, 1, new DataUse()));
+
+    verifyNoInteractions(ontologyService, datasetServiceDAO, elasticSearchService);
+  }
+
+  @Test
+  void testUpdateDatasetDataUseRejectsOpenWithPrimaryBeforeSideEffects() {
+    Dataset dataset = new Dataset();
+    setAccessManagement(dataset, AccessManagement.OPEN);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+
+    assertThrows(
+        BadRequestException.class, () -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
+
+    verifyNoInteractions(ontologyService, datasetServiceDAO, elasticSearchService);
+  }
+
+  @Test
+  void testUpdateDatasetDataUseRejectsNullBeforeSideEffects() {
+    Dataset dataset = new Dataset();
+    setAccessManagement(dataset, AccessManagement.OPEN);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+
+    assertThrows(
+        BadRequestException.class, () -> datasetService.updateDatasetDataUse(admin, 1, null));
+
+    verifyNoInteractions(ontologyService, datasetServiceDAO, elasticSearchService);
+  }
+
+  @Test
+  void testUpdateDatasetDataUseAcceptsOpenWithNoPrimary() {
+    Dataset dataset = new Dataset();
+    setAccessManagement(dataset, AccessManagement.OPEN);
+    when(datasetDAO.findDatasetById(1)).thenReturn(dataset);
+    User admin = getAdmin();
+    DataUse dataUse = new DataUseBuilder().setMethodsResearch(true).build();
+
+    assertDoesNotThrow(() -> datasetService.updateDatasetDataUse(admin, 1, dataUse));
+
+    verify(ontologyService).translateDataUse(dataUse, DataUseTranslationType.DATASET);
+    verify(datasetServiceDAO).updateDatasetDataUse(eq(admin), eq(dataset), eq(dataUse), any());
+    verify(elasticSearchService).synchronizeDatasetInESIndex(dataset, false);
   }
 
   @Test
@@ -1173,6 +1232,36 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testConvertDatasetToStudy_InvalidDataUseHasNoSideEffects() {
+    User admin = getAdmin();
+    Dataset dataset = buildDataset(10, 5);
+    StudyConversion conversion = new StudyConversion();
+    conversion.setName("Study");
+    conversion.setDacId(99);
+    conversion.setDataUse(new DataUse());
+
+    assertThrows(
+        BadRequestException.class,
+        () -> datasetService.convertDatasetToStudy(admin, dataset, conversion));
+
+    verifyNoInteractions(
+        studyDAO, datasetDAO, datasetServiceDAO, ontologyService, elasticSearchService, userDAO);
+  }
+
+  @Test
+  void testConvertDatasetToStudy_NullConversionHasNoSideEffects() {
+    User admin = getAdmin();
+    Dataset dataset = buildDataset(10, 5);
+
+    assertThrows(
+        BadRequestException.class,
+        () -> datasetService.convertDatasetToStudy(admin, dataset, null));
+
+    verifyNoInteractions(
+        studyDAO, datasetDAO, datasetServiceDAO, ontologyService, elasticSearchService, userDAO);
+  }
+
+  @Test
   void testConvertDatasetToStudy_DatasetNameUpdated() {
     User admin = getAdmin();
     Dataset dataset = buildDataset(10, 5);
@@ -1623,6 +1712,14 @@ class DatasetServiceTest extends AbstractTestHelper {
     dataset.setCreateUserId(createUserId);
     dataset.setProperties(Collections.emptySet());
     return dataset;
+  }
+
+  private void setAccessManagement(Dataset dataset, AccessManagement value) {
+    DatasetProperty property = new DatasetProperty();
+    property.setSchemaProperty(DatasetRegistrationSchemaV1Builder.accessManagement);
+    property.setPropertyType(PropertyType.String);
+    property.setPropertyValue(value.value());
+    dataset.setProperties(Set.of(property));
   }
 
   /* Helper functions */

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -242,9 +242,12 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         createStudyProperty("externalIdentifier", PropertyType.String),
         createStudyProperty("externalIdentifierType", PropertyType.String));
     Dataset dataset = createDataset(user, updateUser, new DataUse(), dac);
+    DatasetProperty accessManagement =
+        createDatasetProperty("accessManagement", PropertyType.String, "accessManagement");
+    accessManagement.setPropertyValue("open");
     dataset.setProperties(
         Set.of(
-            createDatasetProperty("accessManagement", PropertyType.Boolean, "accessManagement"),
+            accessManagement,
             createDatasetProperty("numberOfParticipants", PropertyType.Number, "# of participants"),
             createDatasetProperty("url", PropertyType.String, "url"),
             createDatasetProperty("dataLocation", PropertyType.String, "dataLocation")));
@@ -492,6 +495,21 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             .findFirst();
     assertTrue(dataProp.isPresent());
     assertEquals(refMap, term.getData());
+  }
+
+  @Test
+  void testToDatasetTermUsesLegacyAccessManagementProperty() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    DatasetProperty property = new DatasetProperty();
+    property.setSchemaProperty(Dataset.LEGACY_ACCESS_MANAGEMENT_SCHEMA_PROPERTY);
+    property.setPropertyName("Access Management");
+    property.setPropertyValue("open");
+    dataset.setProperties(Set.of(property));
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertEquals("open", term.getAccessManagement());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3862

### Summary

- Add a shared classifier for primary Data Use categories.
- Enforce access-management rules during registration, admin updates, and dataset-to-study conversion.
- Reject invalid or null JSON without exposing submitted Data Use content.
- Update API documentation and add regression tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
