### PR TITLE
[DT-3806] Correct NPU data use classification

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/TranslationUtil.java
@@ -37,7 +37,8 @@ public class TranslationUtil implements ConsentLogger {
       "Future use for population origins or ancestry research is prohibited. [POA]";
   public static final String NMDS =
       "Data use for methods development research ONLY within the bounds of other data use limitations. [NMDS]";
-  public static final String NCU = "Commercial use prohibited. [NCU]";
+  public static final String NPU =
+      "Use is limited to non-profit and non-commercial research. [NPU]";
   protected static final String OTHER = "Other restrictions: %s.";
   protected static final String SECONDARY_OTHER = "Secondary other restrictions: %s.";
   protected static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
@@ -110,7 +111,7 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (BooleanUtils.isTrue(dataUse.getNonProfitUse())) {
-      summary.add(NCU);
+      summary.add(NPU);
     }
 
     if (StringUtils.isNotBlank(dataUse.getOther())) {
@@ -212,7 +213,7 @@ public class TranslationUtil implements ConsentLogger {
     }
 
     if (BooleanUtils.isTrue(dataUse.getNonProfitUse())) {
-      secondary.add(new DataUseTerm("NCU", NCU));
+      secondary.add(new DataUseTerm("NPU", NPU));
     }
 
     if (StringUtils.isNotBlank(dataUse.getSecondaryOther())) {

--- a/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/TranslationUtilTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.matching;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -83,6 +84,14 @@ class TranslationUtilTest extends AbstractTestHelper {
     assertNotNull(translation);
     assertTrue(translation.contains(TranslationUtil.PURPOSE_HEADER));
     assertTrue(translation.contains("[GRU]"));
+  }
+
+  @Test
+  void testTranslateNonProfitUse() {
+    DataUse dataUse = new DataUseBuilder().setNonProfitUse(true).build();
+    String translation = service.translate(dataUse, DataUseTranslationType.DATASET);
+    assertTrue(translation.contains(TranslationUtil.NPU));
+    assertFalse(translation.contains("[NCU]"));
   }
 
   @Test
@@ -294,14 +303,13 @@ class TranslationUtilTest extends AbstractTestHelper {
   }
 
   @Test
-  void testTranslateSummaryNCU() {
+  void testTranslateSummaryNPU() {
     DataUse dataUse = new DataUseBuilder().setNonProfitUse(true).build();
     DataUseSummary summary = service.translateSummary(dataUse);
     assertTrue(summary.getPrimary().isEmpty());
     assertFalse(summary.getSecondary().isEmpty());
-    assertTrue(summary.getSecondary().getFirst().getCode().equalsIgnoreCase("NCU"));
-    assertTrue(
-        summary.getSecondary().getFirst().getDescription().equalsIgnoreCase(TranslationUtil.NCU));
+    assertEquals("NPU", summary.getSecondary().getFirst().getCode());
+    assertEquals(TranslationUtil.NPU, summary.getSecondary().getFirst().getDescription());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3806

### Summary

Corrects data use translation so nonProfitUse is classified as NPU instead of NCU. Updates both text and structured Elasticsearch summaries and adds regression tests.

N/B: Existing datasets should be reindexed after deployment to refresh stored summaries.

- https://consent.dsde-dev.broadinstitute.org/#/Dataset/apiDatasetIndexPost
- https://consent.dsde-prod.broadinstitute.org/#/Dataset/apiDatasetIndexPost

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
