### PR TITLE
[DT-2408] Add ECM health check

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -44,6 +44,7 @@ import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.filters.RateLimitFilter;
 import org.broadinstitute.consent.http.filters.RequestHeaderCacheFilter;
 import org.broadinstitute.consent.http.filters.ResponseServerFilter;
+import org.broadinstitute.consent.http.health.EcmHealthCheck;
 import org.broadinstitute.consent.http.health.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.health.GCSHealthCheck;
 import org.broadinstitute.consent.http.health.SamHealthCheck;
@@ -100,6 +101,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
   public static final String GCS_CHECK = "google-cloud-storage";
   public static final String ES_CHECK = "elastic-search";
+  public static final String ECM_CHECK = "ecm";
   public static final String SAM_CHECK = "sam";
   public static final String SG_CHECK = "sendgrid";
   private static final Logger LOGGER = LoggerFactory.getLogger("ConsentApplication");
@@ -149,6 +151,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     // Health Checks
     env.healthChecks().register(GCS_CHECK, injector.getInstance(GCSHealthCheck.class));
     env.healthChecks().register(ES_CHECK, injector.getInstance(ElasticSearchHealthCheck.class));
+    env.healthChecks().register(ECM_CHECK, injector.getInstance(EcmHealthCheck.class));
     env.healthChecks().register(SAM_CHECK, injector.getInstance(SamHealthCheck.class));
     env.healthChecks().register(SG_CHECK, injector.getInstance(SendGridHealthCheck.class));
 

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -19,6 +19,9 @@ public class ServicesConfiguration {
   public static final String REJECT_TOS_PATH = "api/termsOfService/v1/user/self/reject";
   public static final String SAM_V1_USER_EMAIL = "api/users/v1";
   public static final String ECM_RAS_PROVIDER = "/api/oauth/v1/ras";
+  // ECM's detailed status endpoint is auth-gated at the environment proxy. This legacy endpoint
+  // remains public specifically for unauthenticated service health checks.
+  public static final String ECM_STATUS_PATH = "/status";
   // nosemgrep
   public static final String BROAD_ZENDESK_URL = "https://broadinstitute.zendesk.com";
 
@@ -78,6 +81,15 @@ public class ServicesConfiguration {
 
   public String getEcmRasProviderUrl() {
     return getEcmUrl() + ECM_RAS_PROVIDER;
+  }
+
+  public String getEcmStatusUrl() {
+    String baseUrl = getEcmUrl();
+    int end = baseUrl.length();
+    while (end > 0 && baseUrl.charAt(end - 1) == '/') {
+      end--;
+    }
+    return baseUrl.substring(0, end) + ECM_STATUS_PATH;
   }
 
   public String getV1ResourceTypesUrl() {

--- a/src/main/java/org/broadinstitute/consent/http/health/EcmHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/EcmHealthCheck.java
@@ -1,0 +1,51 @@
+package org.broadinstitute.consent.http.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.resources.StatusResource;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
+
+public class EcmHealthCheck extends HealthCheck {
+
+  private final HttpClientUtil clientUtil;
+  private final ServicesConfiguration configuration;
+
+  @Inject
+  public EcmHealthCheck(HttpClientUtil clientUtil, ServicesConfiguration configuration) {
+    this.clientUtil = clientUtil;
+    this.configuration = configuration;
+  }
+
+  @Override
+  protected Result check() {
+    try {
+      HttpGet httpGet = new HttpGet(configuration.getEcmStatusUrl());
+      SimpleResponse response = clientUtil.getCachedResponse(httpGet);
+      if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
+        EcmStatus ecmStatus = new Gson().fromJson(response.entity(), EcmStatus.class);
+        ResultBuilder result =
+            Result.builder()
+                .withDetail(StatusResource.OK, ecmStatus.ok)
+                .withDetail(StatusResource.SYSTEMS, ecmStatus.systems);
+        if (ecmStatus.ok) {
+          return result.healthy().build();
+        }
+        return result.unhealthy().withMessage("ECM reported an unhealthy status").build();
+      }
+      return Result.unhealthy("ECM status is unhealthy: " + response.code());
+    } catch (Exception e) {
+      return Result.unhealthy(e);
+    }
+  }
+
+  private static class EcmStatus {
+
+    boolean ok;
+    Object systems;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/health/EcmHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/EcmHealthCheck.java
@@ -12,6 +12,8 @@ import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
 
 public class EcmHealthCheck extends HealthCheck {
 
+  private static final Gson GSON = new Gson();
+
   private final HttpClientUtil clientUtil;
   private final ServicesConfiguration configuration;
 
@@ -27,7 +29,7 @@ public class EcmHealthCheck extends HealthCheck {
       HttpGet httpGet = new HttpGet(configuration.getEcmStatusUrl());
       SimpleResponse response = clientUtil.getCachedResponse(httpGet);
       if (response.code() == HttpStatusCodes.STATUS_CODE_OK) {
-        EcmStatus ecmStatus = new Gson().fromJson(response.entity(), EcmStatus.class);
+        EcmStatus ecmStatus = GSON.fromJson(response.entity(), EcmStatus.class);
         ResultBuilder result =
             Result.builder()
                 .withDetail(StatusResource.OK, ecmStatus.ok)

--- a/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
@@ -69,6 +69,9 @@ public class StatusResource extends Resource {
         results.getOrDefault(
             ConsentApplication.ES_CHECK,
             HealthCheck.Result.unhealthy("Unable to access Elastic Search"));
+    HealthCheck.Result ecm =
+        results.getOrDefault(
+            ConsentApplication.ECM_CHECK, HealthCheck.Result.unhealthy("Unable to access ECM"));
     HealthCheck.Result sam =
         results.getOrDefault(
             ConsentApplication.SAM_CHECK, HealthCheck.Result.unhealthy("Unable to access Sam"));
@@ -78,6 +81,7 @@ public class StatusResource extends Resource {
     boolean degraded =
         (!gcs.isHealthy()
             || !elasticSearch.isHealthy()
+            || !ecm.isHealthy()
             || !sam.isHealthy()
             || !sendGrid.isHealthy());
     formattedResults.put(DEGRADED, degraded);

--- a/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StatusResource.java
@@ -85,7 +85,9 @@ public class StatusResource extends Resource {
             || !sam.isHealthy()
             || !sendGrid.isHealthy());
     formattedResults.put(DEGRADED, degraded);
-    formattedResults.put(SYSTEMS, results);
+    Map<String, HealthCheck.Result> systems = new LinkedHashMap<>(results);
+    systems.putIfAbsent(ConsentApplication.ECM_CHECK, ecm);
+    formattedResults.put(SYSTEMS, systems);
     return formattedResults;
   }
 

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -1152,9 +1152,9 @@ paths:
       description: |
         A detailed description of the various subsystem statuses that Consent relies upon.
         Current systems include:
+          * ECM
           * Elastic Search
           * GCS
-          * Ontology
           * Postgres DB
           * Sam
           * Sendgrid

--- a/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.consent.http.configurations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ServicesConfigurationTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "https://externalcreds.example.org, https://externalcreds.example.org/status",
+    "https://externalcreds.example.org/, https://externalcreds.example.org/status",
+    "https://externalcreds.example.org///, https://externalcreds.example.org/status"
+  })
+  void testGetEcmStatusUrl(String ecmUrl, String expectedStatusUrl) {
+    ServicesConfiguration configuration = new ServicesConfiguration();
+    configuration.setEcmUrl(ecmUrl);
+
+    assertEquals(expectedStatusUrl, configuration.getEcmStatusUrl());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/health/EcmHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/EcmHealthCheckTest.java
@@ -1,0 +1,105 @@
+package org.broadinstitute.consent.http.health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.broadinstitute.consent.http.configurations.ServicesConfiguration;
+import org.broadinstitute.consent.http.util.HttpClientUtil;
+import org.broadinstitute.consent.http.util.HttpClientUtil.SimpleResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EcmHealthCheckTest {
+
+  @Mock private HttpClientUtil clientUtil;
+  @Mock private SimpleResponse response;
+  @Mock private ServicesConfiguration servicesConfiguration;
+
+  private EcmHealthCheck healthCheck;
+
+  @BeforeEach
+  void setUp() {
+    healthCheck = new EcmHealthCheck(clientUtil, servicesConfiguration);
+  }
+
+  @Test
+  void testCheckSuccess() throws Exception {
+    String okResponse =
+        """
+        {
+          "ok": true,
+          "systems": {
+            "postgres": true
+          }
+        }
+        """;
+    when(servicesConfiguration.getEcmStatusUrl()).thenReturn("http://localhost:8000/status");
+    when(clientUtil.getCachedResponse(any())).thenReturn(response);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.entity()).thenReturn(okResponse);
+
+    HealthCheck.Result result = healthCheck.check();
+
+    assertTrue(result.isHealthy());
+    assertEquals(Boolean.TRUE, result.getDetails().get("ok"));
+    ArgumentCaptor<HttpGet> request = ArgumentCaptor.forClass(HttpGet.class);
+    verify(clientUtil).getCachedResponse(request.capture());
+    assertEquals("http://localhost:8000/status", request.getValue().getUri().toString());
+  }
+
+  @Test
+  void testCheckFailure() throws Exception {
+    when(servicesConfiguration.getEcmStatusUrl()).thenReturn("http://localhost:8000/status");
+    when(clientUtil.getCachedResponse(any())).thenReturn(response);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
+
+    HealthCheck.Result result = healthCheck.check();
+
+    assertFalse(result.isHealthy());
+  }
+
+  @Test
+  void testCheckUnhealthyResponseBody() throws Exception {
+    String unhealthyResponse =
+        """
+        {
+          "ok": false,
+          "systems": {
+            "postgres": false
+          }
+        }
+        """;
+    when(servicesConfiguration.getEcmStatusUrl()).thenReturn("http://localhost:8000/status");
+    when(clientUtil.getCachedResponse(any())).thenReturn(response);
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.entity()).thenReturn(unhealthyResponse);
+
+    HealthCheck.Result result = healthCheck.check();
+
+    assertFalse(result.isHealthy());
+    assertEquals(Boolean.FALSE, result.getDetails().get("ok"));
+  }
+
+  @Test
+  void testCheckException() throws Exception {
+    when(servicesConfiguration.getEcmStatusUrl()).thenReturn("http://localhost:8000/status");
+    doThrow(new RuntimeException("ECM unavailable")).when(clientUtil).getCachedResponse(any());
+
+    HealthCheck.Result result = healthCheck.check();
+
+    assertFalse(result.isHealthy());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
@@ -68,6 +68,7 @@ class StatusResourceTest {
     SortedMap<String, Result> checks = new TreeMap<>();
     checks.put(DB_ENV, Result.healthy());
     checks.put(ConsentApplication.ES_CHECK, Result.healthy());
+    checks.put(ConsentApplication.ECM_CHECK, Result.healthy());
     checks.put(ConsentApplication.GCS_CHECK, Result.healthy());
     checks.put(ConsentApplication.SAM_CHECK, Result.healthy());
     checks.put(ConsentApplication.SG_CHECK, Result.healthy());
@@ -93,6 +94,24 @@ class StatusResourceTest {
     // A failing sam check should not fail the status
     assertEquals(200, response.getStatus());
     // A failing sam check should mark the system as degraded
+    @SuppressWarnings("rawtypes")
+    LinkedHashMap content = (LinkedHashMap) response.getEntity();
+    assertEquals(Boolean.TRUE, content.get(StatusResource.DEGRADED));
+  }
+
+  @Test
+  void testDegradedWhenEcmIsUnhealthy() {
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ES_CHECK, Result.healthy());
+    checks.put(ConsentApplication.ECM_CHECK, Result.unhealthy("ECM is down"));
+    checks.put(ConsentApplication.GCS_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SAM_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SG_CHECK, Result.healthy());
+    StatusResource statusResource = initStatusResource(checks);
+
+    Response response = statusResource.getStatus();
+    assertEquals(200, response.getStatus());
     @SuppressWarnings("rawtypes")
     LinkedHashMap content = (LinkedHashMap) response.getEntity();
     assertEquals(Boolean.TRUE, content.get(StatusResource.DEGRADED));

--- a/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StatusResourceTest.java
@@ -2,12 +2,14 @@ package org.broadinstitute.consent.http.resources;
 
 import static org.broadinstitute.consent.http.ConsentModule.DB_ENV;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.health.HealthCheck.Result;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.broadinstitute.consent.http.ConsentApplication;
@@ -115,5 +117,26 @@ class StatusResourceTest {
     @SuppressWarnings("rawtypes")
     LinkedHashMap content = (LinkedHashMap) response.getEntity();
     assertEquals(Boolean.TRUE, content.get(StatusResource.DEGRADED));
+  }
+
+  @Test
+  void testMissingEcmResultIsIncludedInSystems() {
+    SortedMap<String, Result> checks = new TreeMap<>();
+    checks.put(DB_ENV, Result.healthy());
+    checks.put(ConsentApplication.ES_CHECK, Result.healthy());
+    checks.put(ConsentApplication.GCS_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SAM_CHECK, Result.healthy());
+    checks.put(ConsentApplication.SG_CHECK, Result.healthy());
+    StatusResource statusResource = initStatusResource(checks);
+
+    Response response = statusResource.getStatus();
+
+    assertEquals(200, response.getStatus());
+    @SuppressWarnings("unchecked")
+    LinkedHashMap<String, Object> content = (LinkedHashMap<String, Object>) response.getEntity();
+    assertEquals(Boolean.TRUE, content.get(StatusResource.DEGRADED));
+    @SuppressWarnings("unchecked")
+    Map<String, Result> systems = (Map<String, Result>) content.get(StatusResource.SYSTEMS);
+    assertFalse(systems.get(ConsentApplication.ECM_CHECK).isHealthy());
   }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2408

### Summary

- Add ECM to Consent’s dependent service health checks.
- Mark Consent as degraded when ECM is unhealthy.
- Include ECM details in the /status response.
- Update API documentation and tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
