### PR TITLE
[DT-1583] Make DAR and progress report creation transactional

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -411,17 +411,23 @@ public class DataAccessRequestResource extends Resource {
       }
       DataAccessRequest payload =
           DataAccessRequest.populateProgressReportFromJsonString(dar, parentDar);
-      populateProgressReportWithDocuments(
-          user,
-          collabInputStream,
-          collabFileDetails,
-          ethicsInputStream,
-          ethicsFileDetails,
-          payload,
-          parentDar);
-      DataAccessRequest progressReport =
-          dataAccessRequestService.createProgressReport(
-              user, payload, parentDar, (ContainerRequest) request);
+      DataAccessRequest progressReport;
+      try {
+        populateProgressReportWithDocuments(
+            user,
+            collabInputStream,
+            collabFileDetails,
+            ethicsInputStream,
+            ethicsFileDetails,
+            payload,
+            parentDar);
+        progressReport =
+            dataAccessRequestService.createProgressReport(
+                user, payload, parentDar, (ContainerRequest) request);
+      } catch (Exception e) {
+        rollbackProgressReportDocuments(payload);
+        throw e;
+      }
       if (Objects.nonNull(progressReport) && !progressReport.getIsCloseoutProgressReport()) {
         processNewDarCollection(parentDar.getCollectionId());
       }
@@ -486,6 +492,15 @@ public class DataAccessRequestResource extends Resource {
         uploadDocumentContents(DarDocumentType.IRB, childDar, ethicsInputStream, ethicsFileDetails);
       }
     }
+  }
+
+  private void rollbackProgressReportDocuments(DataAccessRequest progressReport) {
+    Set<String> uploadedDocumentLocations = new java.util.HashSet<>();
+    uploadedDocumentLocations.add(progressReport.getData().getCollaborationLetterLocation());
+    uploadedDocumentLocations.add(progressReport.getData().getIrbDocumentLocation());
+    uploadedDocumentLocations.stream()
+        .filter(Objects::nonNull)
+        .forEach(location -> deleteDarDocument(progressReport, location));
   }
 
   @GET

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -454,6 +455,8 @@ public class DataAccessRequestResource extends Resource {
       DataAccessRequest parentDar,
       ProgressReportDocumentUploads documentUploads)
       throws IOException {
+    // GCS cannot participate in the database transaction. Treat the upload and transactional
+    // create as one application-level unit by compensating for any uploaded blobs if either fails.
     try {
       populateProgressReportWithDocuments(
           user,
@@ -516,7 +519,7 @@ public class DataAccessRequestResource extends Resource {
   }
 
   private void rollbackProgressReportDocuments(DataAccessRequest progressReport) {
-    Set<String> uploadedDocumentLocations = new java.util.HashSet<>();
+    Set<String> uploadedDocumentLocations = new HashSet<>();
     uploadedDocumentLocations.add(progressReport.getData().getCollaborationLetterLocation());
     uploadedDocumentLocations.add(progressReport.getData().getIrbDocumentLocation());
     uploadedDocumentLocations.stream()

--- a/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DataAccessRequestResource.java
@@ -411,23 +411,14 @@ public class DataAccessRequestResource extends Resource {
       }
       DataAccessRequest payload =
           DataAccessRequest.populateProgressReportFromJsonString(dar, parentDar);
-      DataAccessRequest progressReport;
-      try {
-        populateProgressReportWithDocuments(
-            user,
-            collabInputStream,
-            collabFileDetails,
-            ethicsInputStream,
-            ethicsFileDetails,
-            payload,
-            parentDar);
-        progressReport =
-            dataAccessRequestService.createProgressReport(
-                user, payload, parentDar, (ContainerRequest) request);
-      } catch (Exception e) {
-        rollbackProgressReportDocuments(payload);
-        throw e;
-      }
+      DataAccessRequest progressReport =
+          createProgressReportWithDocuments(
+              user,
+              (ContainerRequest) request,
+              payload,
+              parentDar,
+              new ProgressReportDocumentUploads(
+                  collabInputStream, collabFileDetails, ethicsInputStream, ethicsFileDetails));
       if (Objects.nonNull(progressReport) && !progressReport.getIsCloseoutProgressReport()) {
         processNewDarCollection(parentDar.getCollectionId());
       }
@@ -455,6 +446,36 @@ public class DataAccessRequestResource extends Resource {
   private void logCaughtEmailException(Integer collectionId, Exception e) {
     logException("Exception sending email for collection id: " + collectionId, e);
   }
+
+  private DataAccessRequest createProgressReportWithDocuments(
+      User user,
+      ContainerRequest request,
+      DataAccessRequest progressReport,
+      DataAccessRequest parentDar,
+      ProgressReportDocumentUploads documentUploads)
+      throws IOException {
+    try {
+      populateProgressReportWithDocuments(
+          user,
+          documentUploads.collaborationInputStream(),
+          documentUploads.collaborationFileDetails(),
+          documentUploads.ethicsInputStream(),
+          documentUploads.ethicsFileDetails(),
+          progressReport,
+          parentDar);
+      return dataAccessRequestService.createProgressReport(
+          user, progressReport, parentDar, request);
+    } catch (IOException | RuntimeException e) {
+      rollbackProgressReportDocuments(progressReport);
+      throw e;
+    }
+  }
+
+  private record ProgressReportDocumentUploads(
+      InputStream collaborationInputStream,
+      FormDataContentDisposition collaborationFileDetails,
+      InputStream ethicsInputStream,
+      FormDataContentDisposition ethicsFileDetails) {}
 
   public void populateProgressReportWithDocuments(
       User user,

--- a/src/main/java/org/broadinstitute/consent/http/service/CounterService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/CounterService.java
@@ -17,4 +17,8 @@ public class CounterService {
   public Integer getNextDarSequence() {
     return counterDAO.incrementCountByName(DAR_COUNTER);
   }
+
+  public Integer getNextDarSequence(CounterDAO transactionalCounterDAO) {
+    return transactionalCounterDAO.incrementCountByName(DAR_COUNTER);
+  }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import freemarker.template.TemplateException;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotAcceptableException;
 import jakarta.ws.rs.NotFoundException;
 import java.io.IOException;
@@ -201,12 +200,17 @@ public class DataAccessRequestService implements ConsentLogger {
    * @param referenceId ReferenceId of the corresponding DAR
    */
   private void syncDataAccessRequestDatasets(List<Integer> datasetIds, String referenceId) {
+    syncDataAccessRequestDatasets(datasetIds, referenceId, dataAccessRequestDAO);
+  }
+
+  private void syncDataAccessRequestDatasets(
+      List<Integer> datasetIds, String referenceId, DataAccessRequestDAO targetDarDAO) {
     List<DarDataset> darDatasets =
         datasetIds.stream().map(datasetId -> new DarDataset(referenceId, datasetId)).toList();
-    dataAccessRequestDAO.deleteDARDatasetRelationByReferenceId(referenceId);
+    targetDarDAO.deleteDARDatasetRelationByReferenceId(referenceId);
 
     if (!darDatasets.isEmpty()) {
-      dataAccessRequestDAO.insertAllDarDatasets(darDatasets);
+      targetDarDAO.insertAllDarDatasets(darDatasets);
     }
   }
 
@@ -240,41 +244,62 @@ public class DataAccessRequestService implements ConsentLogger {
     if (existingDar != null && !existingDar.getDraft()) {
       throw new SubmittedDARCannotBeEditedException();
     }
-    Integer collectionId;
-    // Only create a new DarCollection if we haven't done so already
-    if (Objects.nonNull(existingDar) && Objects.nonNull(existingDar.getCollectionId())) {
-      collectionId = existingDar.getCollectionId();
-    } else {
-      String darCodeSequence = "DAR-" + counterService.getNextDarSequence();
-      collectionId = darCollectionDAO.insertDarCollection(darCodeSequence, user.getUserId(), now);
-    }
-    String referenceId;
     List<Integer> datasetIds = dataAccessRequest.getDatasetIds();
-    Integer darId;
-    if (Objects.nonNull(existingDar)) {
-      referenceId = dataAccessRequest.getReferenceId();
-      darId = existingDar.getId();
-      dataAccessRequestDAO.updateDraftToSubmittedForCollection(collectionId, referenceId);
-      dataAccessRequestDAO.updateDataByReferenceId(
-          referenceId, user.getUserId(), now, now, darData, user.getEraCommonsId());
-      daaDAO.deleteDarDAARelationship(darId);
-    } else {
-      referenceId = UUID.randomUUID().toString();
-      darId =
-          dataAccessRequestDAO.insertDataAccessRequest(
-              collectionId,
-              referenceId,
-              user.getUserId(),
-              now,
-              now,
-              now,
-              darData,
-              user.getEraCommonsId());
-    }
-    daaDAO.insertDarDAARelationship(darId, dataAccessRequest.data.getDaaIds());
-    syncDataAccessRequestDatasets(datasetIds, referenceId);
-    captureDatasetDaaSnapshots(darId, datasetIds, new Timestamp(now.getTime()));
-    boolean requiresSOApproval = flagIfSOApprovalIsNeeded(user, datasetIds, referenceId);
+    String darCodeSequence =
+        Objects.nonNull(existingDar) && Objects.nonNull(existingDar.getCollectionId())
+            ? null
+            : "DAR-" + counterService.getNextDarSequence();
+    boolean requiresSOApproval = requiresSOApproval(user, datasetIds);
+    String referenceId =
+        dataAccessRequestServiceDAO.inTransaction(
+            transactionDAOs -> {
+              DataAccessRequestDAO transactionalDarDAO = transactionDAOs.dataAccessRequestDAO();
+              DaaDAO transactionalDaaDAO = transactionDAOs.daaDAO();
+              Integer collectionId =
+                  Objects.nonNull(existingDar) && Objects.nonNull(existingDar.getCollectionId())
+                      ? existingDar.getCollectionId()
+                      : transactionDAOs
+                          .darCollectionDAO()
+                          .insertDarCollection(darCodeSequence, user.getUserId(), now);
+              String transactionReferenceId;
+              Integer darId;
+              if (Objects.nonNull(existingDar)) {
+                transactionReferenceId = dataAccessRequest.getReferenceId();
+                darId = existingDar.getId();
+                transactionalDarDAO.updateDraftToSubmittedForCollection(
+                    collectionId, transactionReferenceId);
+                transactionalDarDAO.updateDataByReferenceId(
+                    transactionReferenceId,
+                    user.getUserId(),
+                    now,
+                    now,
+                    darData,
+                    user.getEraCommonsId());
+                transactionalDaaDAO.deleteDarDAARelationship(darId);
+              } else {
+                transactionReferenceId = UUID.randomUUID().toString();
+                darId =
+                    transactionalDarDAO.insertDataAccessRequest(
+                        collectionId,
+                        transactionReferenceId,
+                        user.getUserId(),
+                        now,
+                        now,
+                        now,
+                        darData,
+                        user.getEraCommonsId());
+              }
+              transactionalDaaDAO.insertDarDAARelationship(
+                  darId, dataAccessRequest.data.getDaaIds());
+              syncDataAccessRequestDatasets(
+                  datasetIds, transactionReferenceId, transactionalDarDAO);
+              captureDatasetDaaSnapshots(
+                  darId, datasetIds, new Timestamp(now.getTime()), transactionalDaaDAO);
+              if (requiresSOApproval) {
+                transactionalDarDAO.updateRequiresSOApproval(true, transactionReferenceId);
+              }
+              return transactionReferenceId;
+            });
     if (!requiresSOApproval) {
       ruleService.triggerDACRuleSettings(user, datasetIds, referenceId, request);
     }
@@ -306,25 +331,43 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new BadRequestException(
           "Progress report can only be created for approved datasets in the parent DAR");
     }
-    Integer id;
+    boolean userIsPreAuthedForDaas =
+        isUserPreAuthorizedForAllDaas(user, progressReport.getDatasetIds());
     try {
-      id =
-          dataAccessRequestDAO.insertProgressReport(
-              progressReport.getParentId(),
-              progressReport.getCollectionId(),
-              referenceId,
-              user.getUserId(),
-              progressReport.getData(),
-              user.getEraCommonsId());
-      if (!progressReport.getIsCloseoutProgressReport()) {
-        daaDAO.insertDarDAARelationship(id, progressReport.getData().getDaaIds());
-      }
+      dataAccessRequestServiceDAO.inTransaction(
+          transactionDAOs -> {
+            DataAccessRequestDAO transactionalDarDAO = transactionDAOs.dataAccessRequestDAO();
+            DaaDAO transactionalDaaDAO = transactionDAOs.daaDAO();
+            Integer progressReportId =
+                transactionalDarDAO.insertProgressReport(
+                    progressReport.getParentId(),
+                    progressReport.getCollectionId(),
+                    referenceId,
+                    user.getUserId(),
+                    progressReport.getData(),
+                    user.getEraCommonsId());
+            if (!progressReport.getIsCloseoutProgressReport()) {
+              transactionalDaaDAO.insertDarDAARelationship(
+                  progressReportId, progressReport.getData().getDaaIds());
+            }
+            if (!progressReport.getIsCloseoutProgressReport() && !userIsPreAuthedForDaas) {
+              transactionalDarDAO.updateRequiresSOApproval(true, referenceId);
+            }
+            syncDataAccessRequestDatasets(
+                progressReportDatasetIds, referenceId, transactionalDarDAO);
+            if (!progressReport.getIsCloseoutProgressReport()) {
+              captureDatasetDaaSnapshots(
+                  progressReportId,
+                  progressReportDatasetIds,
+                  Timestamp.from(Instant.now()),
+                  transactionalDaaDAO);
+            }
+            return progressReportId;
+          });
     } catch (JdbiException _) {
       throw new BadRequestException(
           "Unable to create progress report for Data Access Request " + parentDar.getReferenceId());
     }
-    boolean userIsPreAuthedForDaas =
-        isUserPreAuthorizedForAllDaas(user, progressReport.getDatasetIds());
     if (progressReport.getIsCloseoutProgressReport()) {
       try {
         User signingOfficialUser =
@@ -336,15 +379,10 @@ public class DataAccessRequestService implements ConsentLogger {
             referenceId,
             serverUrl + "dar_application_review/%d".formatted(parentDar.getCollectionId()));
       } catch (TemplateException | IOException e) {
-        throw new InternalServerErrorException(e);
+        // Persistence has already committed, so a notification failure must not make the caller
+        // treat creation as failed and compensate by deleting the progress report documents.
+        logException("Unable to send submitted closeout message for " + referenceId, e);
       }
-    } else if (!userIsPreAuthedForDaas) {
-      dataAccessRequestDAO.updateRequiresSOApproval(true, referenceId);
-    }
-
-    syncDataAccessRequestDatasets(progressReportDatasetIds, referenceId);
-    if (!progressReport.getIsCloseoutProgressReport()) {
-      captureDatasetDaaSnapshots(id, progressReportDatasetIds, Timestamp.from(Instant.now()));
     }
 
     if (!progressReport.getIsCloseoutProgressReport()
@@ -857,24 +895,19 @@ public class DataAccessRequestService implements ConsentLogger {
     return electionDAO.findOpenElectionsByReferenceIds(List.of(referenceId));
   }
 
-  private boolean flagIfSOApprovalIsNeeded(
-      User user, List<Integer> datasetIds, String referenceId) {
-    if (!datasetDAO
+  private boolean requiresSOApproval(User user, List<Integer> datasetIds) {
+    return !datasetDAO
             .filterDatasetIdsByAutomationRuleType(
                 datasetIds, DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL.name())
             .isEmpty()
-        || !isUserPreAuthorizedForAllDaas(user, datasetIds)) {
-      dataAccessRequestDAO.updateRequiresSOApproval(true, referenceId);
-      return true;
-    }
-    return false;
+        || !isUserPreAuthorizedForAllDaas(user, datasetIds);
   }
 
   private void captureDatasetDaaSnapshots(
-      Integer darId, List<Integer> datasetIds, Timestamp capturedAt) {
+      Integer darId, List<Integer> datasetIds, Timestamp capturedAt, DaaDAO targetDaaDAO) {
     List<DatasetDaaMapping> datasetDaaMappings =
         Objects.requireNonNullElse(
-            daaDAO.findCurrentDaaMappingsByDatasetIds(datasetIds), List.of());
+            targetDaaDAO.findCurrentDaaMappingsByDatasetIds(datasetIds), List.of());
     if (datasetDaaMappings.isEmpty()) {
       return;
     }
@@ -885,6 +918,6 @@ public class DataAccessRequestService implements ConsentLogger {
                     new DarDatasetDaaSnapshot(
                         darId, mapping.datasetId(), mapping.daaId(), capturedAt))
             .toList();
-    daaDAO.insertDarDatasetDaaSnapshots(snapshots);
+    targetDaaDAO.insertDarDatasetDaaSnapshots(snapshots);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -245,10 +245,6 @@ public class DataAccessRequestService implements ConsentLogger {
       throw new SubmittedDARCannotBeEditedException();
     }
     List<Integer> datasetIds = dataAccessRequest.getDatasetIds();
-    String darCodeSequence =
-        Objects.nonNull(existingDar) && Objects.nonNull(existingDar.getCollectionId())
-            ? null
-            : "DAR-" + counterService.getNextDarSequence();
     boolean requiresSOApproval = requiresSOApproval(user, datasetIds);
     String referenceId =
         dataAccessRequestServiceDAO.inTransaction(
@@ -260,7 +256,11 @@ public class DataAccessRequestService implements ConsentLogger {
                       ? existingDar.getCollectionId()
                       : transactionDAOs
                           .darCollectionDAO()
-                          .insertDarCollection(darCodeSequence, user.getUserId(), now);
+                          .insertDarCollection(
+                              "DAR-"
+                                  + counterService.getNextDarSequence(transactionDAOs.counterDAO()),
+                              user.getUserId(),
+                              now);
               String transactionReferenceId;
               Integer darId;
               if (Objects.nonNull(existingDar)) {
@@ -378,7 +378,7 @@ public class DataAccessRequestService implements ConsentLogger {
             parentDar.getDarCode(),
             referenceId,
             serverUrl + "dar_application_review/%d".formatted(parentDar.getCollectionId()));
-      } catch (TemplateException | IOException e) {
+      } catch (Exception e) {
         // Persistence has already committed, so a notification failure must not make the caller
         // treat creation as failed and compensate by deleting the progress report documents.
         logException("Unable to send submitted closeout message for " + referenceId, e);

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
@@ -14,6 +16,11 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Update;
 
 public class DataAccessRequestServiceDAO {
+
+  public record TransactionDAOs(
+      DataAccessRequestDAO dataAccessRequestDAO,
+      DaaDAO daaDAO,
+      DarCollectionDAO darCollectionDAO) {}
 
   private final Jdbi jdbi;
   private final DataAccessRequestDAO dataAccessRequestDAO;
@@ -24,6 +31,20 @@ public class DataAccessRequestServiceDAO {
     this.jdbi = jdbi;
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     this.darCollectionDAO = jdbi.onDemand(DarCollectionDAO.class);
+  }
+
+  /**
+   * Runs a data access request workflow with every participating DAO attached to the same handle.
+   * Any exception from the callback rolls back all database changes made by the workflow.
+   */
+  public <T> T inTransaction(Function<TransactionDAOs, T> callback) {
+    return jdbi.inTransaction(
+        handle ->
+            callback.apply(
+                new TransactionDAOs(
+                    handle.attach(DataAccessRequestDAO.class),
+                    handle.attach(DaaDAO.class),
+                    handle.attach(DarCollectionDAO.class))));
   }
 
   public DataAccessRequest updateByReferenceId(User user, DataAccessRequest dar)

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAO.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+import org.broadinstitute.consent.http.db.CounterDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -20,7 +21,8 @@ public class DataAccessRequestServiceDAO {
   public record TransactionDAOs(
       DataAccessRequestDAO dataAccessRequestDAO,
       DaaDAO daaDAO,
-      DarCollectionDAO darCollectionDAO) {}
+      DarCollectionDAO darCollectionDAO,
+      CounterDAO counterDAO) {}
 
   private final Jdbi jdbi;
   private final DataAccessRequestDAO dataAccessRequestDAO;
@@ -44,7 +46,8 @@ public class DataAccessRequestServiceDAO {
                 new TransactionDAOs(
                     handle.attach(DataAccessRequestDAO.class),
                     handle.attach(DaaDAO.class),
-                    handle.attach(DarCollectionDAO.class))));
+                    handle.attach(DarCollectionDAO.class),
+                    handle.attach(CounterDAO.class))));
   }
 
   public DataAccessRequest updateByReferenceId(User user, DataAccessRequest dar)

--- a/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DataAccessRequestResourceTest.java
@@ -613,6 +613,45 @@ class DataAccessRequestResourceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testPostProgressReportDeletesUploadedDocumentsWhenCreationFails() throws Exception {
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    parentDar.setUserId(user.getUserId());
+    mockProgressReportUserAndParentDar(parentDar);
+    mockNoOpenProgressReportElections(parentDar);
+
+    Dataset dataset = new Dataset();
+    dataset.setDataUse(new DataUseBuilder().setCollaboratorRequired(true).build());
+    when(datasetService.findDatasetById(user, 1)).thenReturn(dataset);
+
+    InputStream collaborationInput =
+        IOUtils.toInputStream("synthetic collaboration", Charset.defaultCharset());
+    FormDataContentDisposition collaborationFile = mock(FormDataContentDisposition.class);
+    when(collaborationFile.getSize()).thenReturn(1L);
+    when(collaborationFile.getFileName()).thenReturn("collaboration.txt");
+    when(collaborationFile.getType()).thenReturn("text/plain");
+    when(gcsService.storeDocument(any(), eq("text/plain"), any()))
+        .thenReturn(BlobId.of("bucket", "uploaded-collaboration"));
+    doThrow(new BadRequestException("persistence failed"))
+        .when(dataAccessRequestService)
+        .createProgressReport(eq(user), any(), eq(parentDar), eq(request));
+
+    try (var response =
+        resource.postProgressReport(
+            duosUser,
+            request,
+            "",
+            "{\"datasetIds\":[1]}",
+            collaborationInput,
+            collaborationFile,
+            null,
+            null)) {
+      assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    }
+
+    verify(gcsService).deleteDocument("uploaded-collaboration");
+  }
+
+  @Test
   void testPostProgressReportDelegatesToCreateProgressReport() {
     DataAccessRequest parentDar = generateDataAccessRequest();
     mockProgressReportUserAndParentDar(parentDar);

--- a/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/CounterServiceTest.java
@@ -17,6 +17,7 @@ class CounterServiceTest {
 
   @Mock private Jdbi jdbi;
   @Mock private CounterDAO counterDAO;
+  @Mock private CounterDAO transactionalCounterDAO;
 
   private CounterService service;
 
@@ -32,6 +33,17 @@ class CounterServiceTest {
     when(counterDAO.incrementCountByName(any())).thenReturn(count);
 
     Integer seq = service.getNextDarSequence();
+    assertEquals(count, seq.intValue());
+  }
+
+  @Test
+  void testGetNextDarSequenceWithTransactionalDao() {
+    int count = 11;
+    when(transactionalCounterDAO.incrementCountByName(CounterService.DAR_COUNTER))
+        .thenReturn(count);
+
+    Integer seq = service.getNextDarSequence(transactionalCounterDAO);
+
     assertEquals(count, seq.intValue());
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.db.DaaDAO;
@@ -190,8 +192,22 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
             config);
   }
 
+  private void mockTransactionalDaos() {
+    doAnswer(
+            invocation -> {
+              Function<DataAccessRequestServiceDAO.TransactionDAOs, ?> callback =
+                  invocation.getArgument(0);
+              return callback.apply(
+                  new DataAccessRequestServiceDAO.TransactionDAOs(
+                      dataAccessRequestDAO, daaDAO, darCollectionDAO));
+            })
+        .when(dataAccessRequestServiceDAO)
+        .inTransaction(any());
+  }
+
   @Test
   void testCreateDataAccessRequest_Update() {
+    mockTransactionalDaos();
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setCollectionId(null);
     dar.addDatasetIds(List.of(1, 2, 3));
@@ -209,6 +225,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateDataAccessRequest_Create() {
+    mockTransactionalDaos();
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
@@ -242,6 +259,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateDataAccessRequest_CapturesDatasetDaaSnapshots() {
+    mockTransactionalDaos();
     DataAccessRequest dar = generateDataAccessRequest();
     dar.setReferenceId("id");
     dar.setDatasetIds(List.of(1, 2));
@@ -295,6 +313,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateDataAccessRequest_Create_Missing_DAAs() {
+    mockTransactionalDaos();
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
@@ -330,6 +349,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void testCreateDataAccessRequest_Create_SO_Approval_Required_By_Rule() {
+    mockTransactionalDaos();
     DataAccessRequest dar = generateDataAccessRequest();
     dar.addDatasetIds(List.of(1, 2, 3));
     dar.setCreateDate(new Timestamp(1000));
@@ -411,6 +431,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createProgressReport() {
+    mockTransactionalDaos();
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
@@ -443,6 +464,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createProgressReportCapturesDatasetDaaSnapshots() {
+    mockTransactionalDaos();
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
@@ -486,6 +508,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createProgressReportDmi() {
+    mockTransactionalDaos();
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
@@ -520,6 +543,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createProgressReportNotPreAuthed() {
+    mockTransactionalDaos();
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());
@@ -555,6 +579,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createCloseoutProgressReport() throws TemplateException, IOException {
+    mockTransactionalDaos();
     User user = createUserWithPrerequisites();
     User signingOfficial = createUserWithPrerequisites();
     signingOfficial.setInstitutionId(user.getInstitutionId());
@@ -646,6 +671,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
 
   @Test
   void createProgressReportFailsIfDAOOperationFails() {
+    mockTransactionalDaos();
     DataAccessRequest parentDar = generateDataAccessRequest();
     DataAccessRequest progressReport = generateProgressReport();
     progressReport.setParentId(parentDar.getId());

--- a/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DataAccessRequestServiceTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
+import org.broadinstitute.consent.http.db.CounterDAO;
 import org.broadinstitute.consent.http.db.DaaDAO;
 import org.broadinstitute.consent.http.db.DarCollectionDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -103,6 +104,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
   private final List<UserRole> roles = List.of(UserRoles.Researcher());
   @Mock private Jdbi jdbi;
   @Mock private CounterService counterService;
+  @Mock private CounterDAO counterDAO;
   @Mock private DataAccessRequestDAO dataAccessRequestDAO;
   @Mock private DarCollectionDAO darCollectionDAO;
   @Mock private UserDAO userDAO;
@@ -199,7 +201,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
                   invocation.getArgument(0);
               return callback.apply(
                   new DataAccessRequestServiceDAO.TransactionDAOs(
-                      dataAccessRequestDAO, daaDAO, darCollectionDAO));
+                      dataAccessRequestDAO, daaDAO, darCollectionDAO, counterDAO));
             })
         .when(dataAccessRequestServiceDAO)
         .inTransaction(any());
@@ -214,7 +216,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
-    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(counterService.getNextDarSequence(counterDAO)).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId(any())).thenReturn(dar);
     doNothing()
         .when(dataAccessRequestDAO)
@@ -233,7 +235,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
-    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(counterService.getNextDarSequence(counterDAO)).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
     when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class)))
@@ -266,7 +268,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
-    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(counterService.getNextDarSequence(counterDAO)).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
     when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class)))
@@ -323,7 +325,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     dar.getData().setDaaIds(Set.of(1));
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
-    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(counterService.getNextDarSequence(counterDAO)).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
     when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class)))
@@ -357,7 +359,7 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
     User user = createUserWithPrerequisites();
     mockApprovedDatasets(dar.getDatasetIds());
     when(institutionService.findInstitutionForEmail(any())).thenReturn(user.getInstitution());
-    when(counterService.getNextDarSequence()).thenReturn(1);
+    when(counterService.getNextDarSequence(counterDAO)).thenReturn(1);
     when(dataAccessRequestDAO.findByReferenceId("id")).thenReturn(null);
     when(dataAccessRequestDAO.findByReferenceId(argThat(new LongerThanTwo()))).thenReturn(dar);
     when(darCollectionDAO.insertDarCollection(anyString(), anyInt(), any(Date.class)))
@@ -620,6 +622,41 @@ class DataAccessRequestServiceTest extends AbstractTestHelper {
         .insertAllDarDatasets(argThat(new DarDatasetMatcher(progressReport)));
     verify(dataAccessRequestDAO, never()).updateRequiresSOApproval(eq(true), anyString());
     verify(daaDAO, never()).insertDarDatasetDaaSnapshots(any());
+  }
+
+  @Test
+  void createCloseoutProgressReportIgnoresUncheckedNotificationFailure() throws Exception {
+    mockTransactionalDaos();
+    User user = createUserWithPrerequisites();
+    User signingOfficial = createUserWithPrerequisites();
+    signingOfficial.setInstitutionId(user.getInstitutionId());
+    signingOfficial.setSigningOfficialRole();
+    DataAccessRequest progressReport = generateProgressReport();
+    DataAccessRequest parentDar = generateDataAccessRequest();
+    parentDar.setSubmissionDate(FIXED_TIMESTAMP);
+    parentDar.setUserId(user.getUserId());
+    progressReport.setDatasetIds(List.of(3, 4, 5));
+    parentDar.setDatasetIds(List.of(3, 4, 5));
+    progressReport.setSubmissionDate(FIXED_TIMESTAMP);
+    progressReport.setParentId(parentDar.getId());
+    progressReport.setCollectionId(parentDar.getCollectionId());
+    progressReport.getData().setCloseoutSupplement(new CloseoutSupplement(List.of("test"), "", 2));
+    mockApprovedDatasets(progressReport.getDatasetIds());
+
+    when(userService.findUserById(2)).thenReturn(signingOfficial);
+    when(dataAccessRequestDAO.findByReferenceId(progressReport.getReferenceId()))
+        .thenReturn(progressReport);
+    when(dataAccessRequestDAO.findDatasetApprovalsByDar(parentDar.getReferenceId()))
+        .thenReturn(Set.copyOf(progressReport.getDatasetIds()));
+    doThrow(new RuntimeException("notification failed"))
+        .when(emailService)
+        .sendMessage(any(SubmittedCloseoutMessage.class), any());
+
+    DataAccessRequest createdProgressReport =
+        assertDoesNotThrow(
+            () -> service.createProgressReport(user, progressReport, parentDar, request));
+
+    assertNotNull(createdProgressReport);
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -25,6 +25,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.CounterService;
 import org.jdbi.v3.core.JdbiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -139,12 +140,14 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
   void transactionRollsBackDataAccessRequestWhenDatasetInsertFails() {
     User user = createUser();
     String referenceId = UUID.randomUUID().toString();
+    counterDAO.addCounter(CounterService.DAR_COUNTER, 0);
 
     assertThrows(
         JdbiException.class,
         () ->
             serviceDAO.inTransaction(
                 transactionDAOs -> {
+                  transactionDAOs.counterDAO().incrementCountByName(CounterService.DAR_COUNTER);
                   Integer collectionId =
                       transactionDAOs
                           .darCollectionDAO()
@@ -167,6 +170,7 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
                 }));
 
     assertNull(dataAccessRequestDAO.findByReferenceId(referenceId));
+    assertEquals(1, counterDAO.incrementCountByName(CounterService.DAR_COUNTER));
   }
 
   private Dataset createDataset() {

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DataAccessRequestServiceDAOTest.java
@@ -2,6 +2,8 @@ package org.broadinstitute.consent.http.service.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.JdbiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -130,6 +133,40 @@ class DataAccessRequestServiceDAOTest extends DAOTestHelper {
     Timestamp oldTimestamp = new Timestamp(old.getTime());
     assertFalse(oldTimestamp.equals(updatedDar.getUpdateDate()));
     assertEquals(List.of(dataset.getDatasetId()), updatedDar.getDatasetIds());
+  }
+
+  @Test
+  void transactionRollsBackDataAccessRequestWhenDatasetInsertFails() {
+    User user = createUser();
+    String referenceId = UUID.randomUUID().toString();
+
+    assertThrows(
+        JdbiException.class,
+        () ->
+            serviceDAO.inTransaction(
+                transactionDAOs -> {
+                  Integer collectionId =
+                      transactionDAOs
+                          .darCollectionDAO()
+                          .insertDarCollection("DAR-ROLLBACK", user.getUserId(), new Date());
+                  transactionDAOs
+                      .dataAccessRequestDAO()
+                      .insertDataAccessRequest(
+                          collectionId,
+                          referenceId,
+                          user.getUserId(),
+                          new Date(),
+                          new Date(),
+                          new Date(),
+                          new DataAccessRequestData(),
+                          user.getEraCommonsId());
+                  transactionDAOs
+                      .dataAccessRequestDAO()
+                      .insertAllDarDatasets(List.of(new DarDataset(referenceId, -1)));
+                  return null;
+                }));
+
+    assertNull(dataAccessRequestDAO.findByReferenceId(referenceId));
   }
 
   private Dataset createDataset() {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1583

### Summary

- Make DAR v2 and progress report database writes atomic using a shared JDBI transaction handle.
- Roll back collection, DAR, dataset/DAA relationship, snapshot, and SO-approval changes when persistence fails.
- Delete newly uploaded progress-report documents from GCS when validation or persistence fails.
- Treat post-commit closeout notification failures as non-fatal to avoid deleting documents referenced by committed records.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
