### PR TITLE
[DT-3882] Standardize service URL construction

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotNull;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServicesConfiguration {
@@ -18,10 +19,11 @@ public class ServicesConfiguration {
   public static final String ACCEPT_TOS_PATH = "api/termsOfService/v1/user/self/accept";
   public static final String REJECT_TOS_PATH = "api/termsOfService/v1/user/self/reject";
   public static final String SAM_V1_USER_EMAIL = "api/users/v1";
-  public static final String ECM_RAS_PROVIDER = "/api/oauth/v1/ras";
+  public static final String SAM_STATUS_PATH = "status";
+  public static final String ECM_RAS_PROVIDER = "api/oauth/v1/ras";
   // ECM's detailed status endpoint is auth-gated at the environment proxy. This legacy endpoint
   // remains public specifically for unauthenticated service health checks.
-  public static final String ECM_STATUS_PATH = "/status";
+  public static final String ECM_STATUS_PATH = "status";
   // nosemgrep
   public static final String BROAD_ZENDESK_URL = "https://broadinstitute.zendesk.com";
 
@@ -60,7 +62,7 @@ public class ServicesConfiguration {
   }
 
   public void setLocalURL(String localURL) {
-    this.localURL = localURL;
+    this.localURL = normalizeBaseUrl(localURL);
   }
 
   public String getSamUrl() {
@@ -68,7 +70,7 @@ public class ServicesConfiguration {
   }
 
   public void setSamUrl(String samUrl) {
-    this.samUrl = samUrl;
+    this.samUrl = normalizeBaseUrl(samUrl);
   }
 
   public String getEcmUrl() {
@@ -76,7 +78,7 @@ public class ServicesConfiguration {
   }
 
   public void setEcmUrl(String ecmUrl) {
-    this.ecmUrl = ecmUrl;
+    this.ecmUrl = normalizeBaseUrl(ecmUrl);
   }
 
   public String getEcmRasProviderUrl() {
@@ -84,16 +86,15 @@ public class ServicesConfiguration {
   }
 
   public String getEcmStatusUrl() {
-    String baseUrl = getEcmUrl();
-    int end = baseUrl.length();
-    while (end > 0 && baseUrl.charAt(end - 1) == '/') {
-      end--;
-    }
-    return baseUrl.substring(0, end) + ECM_STATUS_PATH;
+    return getEcmUrl() + ECM_STATUS_PATH;
   }
 
   public String getV1ResourceTypesUrl() {
     return getSamUrl() + RESOURCE_TYPES_PATH;
+  }
+
+  public String getSamStatusUrl() {
+    return getSamUrl() + SAM_STATUS_PATH;
   }
 
   public String getRegisterUserV2SelfInfoUrl() {
@@ -171,5 +172,17 @@ public class ServicesConfiguration {
 
   public void setCacheExpireMinutes(Integer cacheExpireMinutes) {
     this.cacheExpireMinutes = cacheExpireMinutes;
+  }
+
+  private static String normalizeBaseUrl(String baseUrl) {
+    Objects.requireNonNull(baseUrl, "Service base URL must not be null");
+    if (baseUrl.isEmpty()) {
+      return baseUrl;
+    }
+    int end = baseUrl.length();
+    while (end > 0 && baseUrl.charAt(end - 1) == '/') {
+      end--;
+    }
+    return baseUrl.substring(0, end) + "/";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.consent.http.configurations;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.Objects;
@@ -27,11 +27,11 @@ public class ServicesConfiguration {
   // nosemgrep
   public static final String BROAD_ZENDESK_URL = "https://broadinstitute.zendesk.com";
 
-  @NotNull private String localURL;
+  @NotBlank private String localURL;
 
-  @NotNull private String samUrl;
+  @NotBlank private String samUrl;
 
-  @NotNull private String ecmUrl;
+  @NotBlank private String ecmUrl;
 
   /**
    * This represents the max time we'll wait for an external status check to return. If it does not
@@ -175,14 +175,15 @@ public class ServicesConfiguration {
   }
 
   private static String normalizeBaseUrl(String baseUrl) {
-    Objects.requireNonNull(baseUrl, "Service base URL must not be null");
-    if (baseUrl.isEmpty()) {
-      return baseUrl;
+    String normalizedBaseUrl =
+        Objects.requireNonNull(baseUrl, "Service base URL must not be null").strip();
+    if (normalizedBaseUrl.isEmpty()) {
+      throw new IllegalArgumentException("Service base URL must not be blank");
     }
-    int end = baseUrl.length();
-    while (end > 0 && baseUrl.charAt(end - 1) == '/') {
+    int end = normalizedBaseUrl.length();
+    while (end > 0 && normalizedBaseUrl.charAt(end - 1) == '/') {
       end--;
     }
-    return baseUrl.substring(0, end) + "/";
+    return normalizedBaseUrl.substring(0, end) + "/";
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
+++ b/src/main/java/org/broadinstitute/consent/http/configurations/ServicesConfiguration.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotBlank;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServicesConfiguration {
@@ -175,8 +174,10 @@ public class ServicesConfiguration {
   }
 
   private static String normalizeBaseUrl(String baseUrl) {
-    String normalizedBaseUrl =
-        Objects.requireNonNull(baseUrl, "Service base URL must not be null").strip();
+    if (baseUrl == null) {
+      throw new IllegalArgumentException("Service base URL must not be null");
+    }
+    String normalizedBaseUrl = baseUrl.strip();
     if (normalizedBaseUrl.isEmpty()) {
       throw new IllegalArgumentException("Service base URL must not be blank");
     }

--- a/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
+++ b/src/main/java/org/broadinstitute/consent/http/health/SamHealthCheck.java
@@ -25,7 +25,7 @@ public class SamHealthCheck extends HealthCheck implements Managed {
   @Override
   protected Result check() throws Exception {
     try {
-      String statusUrl = configuration.getSamUrl() + "status";
+      String statusUrl = configuration.getSamStatusUrl();
       HttpGet httpGet = new HttpGet(statusUrl);
       try {
         SimpleResponse response = clientUtil.getCachedResponse(httpGet);

--- a/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/UserResource.java
@@ -562,11 +562,8 @@ public class UserResource extends Resource {
                 });
       }
       User user = userService.createUser(createDuosUserRequest.newUser());
-      String localUrl =
-          servicesConfiguration.getLocalURL().endsWith("/")
-              ? servicesConfiguration.getLocalURL()
-              : servicesConfiguration.getLocalURL() + "/";
-      URI uri = new URI("%sapi/user/%d".formatted(localUrl, user.getUserId()));
+      URI uri =
+          new URI("%sapi/user/%d".formatted(servicesConfiguration.getLocalURL(), user.getUserId()));
       return Response.created(uri).entity(user).build();
     } catch (Exception e) {
       return createExceptionResponse(e);

--- a/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
@@ -1,22 +1,64 @@
 package org.broadinstitute.consent.http.configurations;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ServicesConfigurationTest {
 
   @ParameterizedTest
-  @CsvSource({
-    "https://externalcreds.example.org, https://externalcreds.example.org/status",
-    "https://externalcreds.example.org/, https://externalcreds.example.org/status",
-    "https://externalcreds.example.org///, https://externalcreds.example.org/status"
-  })
-  void testGetEcmStatusUrl(String ecmUrl, String expectedStatusUrl) {
+  @ValueSource(
+      strings = {
+        "https://services.example.org",
+        "https://services.example.org/",
+        "https://services.example.org///"
+      })
+  void testServiceBaseUrlNormalization(String configuredBaseUrl) {
     ServicesConfiguration configuration = new ServicesConfiguration();
-    configuration.setEcmUrl(ecmUrl);
+    configuration.setLocalURL(configuredBaseUrl);
+    configuration.setSamUrl(configuredBaseUrl);
+    configuration.setEcmUrl(configuredBaseUrl);
 
-    assertEquals(expectedStatusUrl, configuration.getEcmStatusUrl());
+    String baseUrl = "https://services.example.org/";
+    assertAll(
+        () -> assertEquals(baseUrl, configuration.getLocalURL()),
+        () -> assertEquals(baseUrl, configuration.getSamUrl()),
+        () -> assertEquals(baseUrl, configuration.getEcmUrl()),
+        () -> assertEquals(baseUrl + "api/oauth/v1/ras", configuration.getEcmRasProviderUrl()),
+        () -> assertEquals(baseUrl + "status", configuration.getEcmStatusUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/config/v1/resourceTypes", configuration.getV1ResourceTypesUrl()),
+        () -> assertEquals(baseUrl + "status", configuration.getSamStatusUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "register/user/v2/self/info",
+                configuration.getRegisterUserV2SelfInfoUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "register/user/v2/self/diagnostics",
+                configuration.getV2SelfDiagnosticsUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "register/user/v2/self", configuration.postRegisterUserV2SelfUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/users/v2/self/combinedState", configuration.getCombinedStateUrl()),
+        () -> assertEquals(baseUrl + "termsOfService/v1/docs", configuration.getToSTextUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/termsOfService/v1/user/self", configuration.getSelfTosUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/termsOfService/v1/user/self/accept", configuration.acceptTosUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/termsOfService/v1/user/self/reject", configuration.rejectTosUrl()),
+        () ->
+            assertEquals(
+                baseUrl + "api/users/v1/user%2Btag%40example.org",
+                configuration.getV1UserUrl("user+tag@example.org")));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.configurations;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,7 +14,8 @@ class ServicesConfigurationTest {
       strings = {
         "https://services.example.org",
         "https://services.example.org/",
-        "https://services.example.org///"
+        "https://services.example.org///",
+        "  https://services.example.org///  "
       })
   void testServiceBaseUrlNormalization(String configuredBaseUrl) {
     ServicesConfiguration configuration = new ServicesConfiguration();
@@ -60,5 +62,22 @@ class ServicesConfigurationTest {
             assertEquals(
                 baseUrl + "api/users/v1/user%2Btag%40example.org",
                 configuration.getV1UserUrl("user+tag@example.org")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "\t\n"})
+  void testBlankServiceBaseUrlsAreRejected(String configuredBaseUrl) {
+    ServicesConfiguration configuration = new ServicesConfiguration();
+
+    assertAll(
+        () ->
+            assertThrows(
+                IllegalArgumentException.class, () -> configuration.setLocalURL(configuredBaseUrl)),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class, () -> configuration.setSamUrl(configuredBaseUrl)),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class, () -> configuration.setEcmUrl(configuredBaseUrl)));
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/configurations/ServicesConfigurationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ServicesConfigurationTest {
@@ -65,8 +66,9 @@ class ServicesConfigurationTest {
   }
 
   @ParameterizedTest
+  @NullSource
   @ValueSource(strings = {"", " ", "\t\n"})
-  void testBlankServiceBaseUrlsAreRejected(String configuredBaseUrl) {
+  void testNullAndBlankServiceBaseUrlsAreRejected(String configuredBaseUrl) {
     ServicesConfiguration configuration = new ServicesConfiguration();
 
     assertAll(

--- a/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SamHealthCheckTest.java
@@ -48,7 +48,7 @@ class SamHealthCheckTest {
     try {
       when(response.entity()).thenReturn(okResponse);
       when(clientUtil.getCachedResponse(any())).thenReturn(response);
-      when(servicesConfiguration.getSamUrl()).thenReturn("http://localhost:8000/");
+      when(servicesConfiguration.getSamStatusUrl()).thenReturn("http://localhost:8000/status");
       healthCheck = new SamHealthCheck(clientUtil, servicesConfiguration);
     } catch (Exception e) {
       fail(e.getMessage());
@@ -63,7 +63,7 @@ class SamHealthCheckTest {
     when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
     try {
       when(clientUtil.getCachedResponse(any())).thenReturn(response);
-      when(servicesConfiguration.getSamUrl()).thenReturn("http://localhost:8000/");
+      when(servicesConfiguration.getSamStatusUrl()).thenReturn("http://localhost:8000/status");
       healthCheck = new SamHealthCheck(clientUtil, servicesConfiguration);
     } catch (Exception e) {
       fail(e.getMessage());
@@ -77,7 +77,7 @@ class SamHealthCheckTest {
   void testCheckException() throws Exception {
     try {
       when(clientUtil.getCachedResponse(any())).thenReturn(response);
-      when(servicesConfiguration.getSamUrl()).thenReturn("http://localhost:8000/");
+      when(servicesConfiguration.getSamStatusUrl()).thenReturn("http://localhost:8000/status");
       healthCheck = new SamHealthCheck(clientUtil, servicesConfiguration);
     } catch (Exception e) {
       fail(e.getMessage());
@@ -89,7 +89,7 @@ class SamHealthCheckTest {
 
   @Test
   void testConfigException() throws Exception {
-    doThrow(new RuntimeException()).when(servicesConfiguration).getSamUrl();
+    doThrow(new RuntimeException()).when(servicesConfiguration).getSamStatusUrl();
     try {
       healthCheck = new SamHealthCheck(clientUtil, servicesConfiguration);
     } catch (Exception e) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/UserResourceTest.java
@@ -1181,10 +1181,11 @@ class UserResourceTest extends AbstractTestHelper {
     DuosUser adminDuosUser = new DuosUser(authUser, adminUser);
 
     when(userService.createUser(request.newUser())).thenReturn(createdUser);
-    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
+    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080/");
 
     try (var response = userResource.createNewUser(adminDuosUser, gson.toJson(request))) {
       assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+      assertEquals(URI.create("http://localhost:8080/api/user/1"), response.getLocation());
     }
   }
 
@@ -1203,7 +1204,7 @@ class UserResourceTest extends AbstractTestHelper {
     institution.setDomains(List.of("@example.com"));
 
     when(userService.createUser(request.newUser())).thenReturn(createdUser);
-    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
+    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080/");
 
     try (var response = userResource.createNewUser(nonAdminDuosUser, gson.toJson(request))) {
       assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
@@ -1286,7 +1287,7 @@ class UserResourceTest extends AbstractTestHelper {
     User createdUser =
         new User(1, request.email(), request.displayName(), new Date(), request.roles());
     when(userService.createUser(request.newUser())).thenReturn(createdUser);
-    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080");
+    when(servicesConfiguration.getLocalURL()).thenReturn("http://localhost:8080/");
     try (var response = userResource.createNewUser(adminUser, gson.toJson(request))) {
       assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
     }

--- a/src/test/java/org/broadinstitute/consent/integration/user/UserTests.java
+++ b/src/test/java/org/broadinstitute/consent/integration/user/UserTests.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.integration.user;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,8 +26,7 @@ class UserTests extends ContainerTests {
    *       CombinedState} JSON so {@link
    *       org.broadinstitute.consent.http.authentication.DuosUserAuthenticator} can build a {@code
    *       DuosUser} with a non-null {@code UserStatusInfo}.
-   *   <li><b>ECM</b> {@code GET /api/oauth/v1/ras} (also matches the double-slash form produced by
-   *       the config concatenation): returns 404 so {@link
+   *   <li><b>ECM</b> {@code GET /api/oauth/v1/ras}: returns 404 so {@link
    *       org.broadinstitute.consent.http.service.NihService#syncAccount} treats the user as having
    *       no NIH account and returns the user record cleanly.
    * </ul>
@@ -67,10 +65,8 @@ class UserTests extends ContainerTests {
                     .withBody(combinedStateBody)));
 
     // ECM – RAS provider: 404 → NihService treats this as "no NIH account" and returns the user.
-    // The config concatenates ecmUrl ("…9999/") + "/api/oauth/v1/ras", which can produce a
-    // double slash, so the pattern matches both "/api/oauth/v1/ras" and "//api/oauth/v1/ras".
     WIRE_MOCK.stubFor(
-        get(urlPathMatching("/+api/oauth/v1/ras"))
+        get(urlPathEqualTo("/api/oauth/v1/ras"))
             .willReturn(aResponse().withStatus(HttpStatusCodes.STATUS_CODE_NOT_FOUND)));
   }
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3882

### Summary

- Normalize Local, Sam, and ECM base URLs to use one trailing slash.
- Standardize endpoint construction and remove one-off URL handling.
- Add coverage for zero, one, and multiple trailing slashes.
- Update health-check and integration tests to verify canonical URLs.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
