### PR TITLE
[DT-2560] Improve `Elasticsearch` indexing logs

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -329,9 +329,9 @@ public class ElasticSearchService implements ConsentLogger {
 
   public Response indexStudy(Integer studyId) {
     Study study = studyDAO.findStudyById(studyId);
-    logWarn("Loading datasets for study: %d".formatted(studyId));
+    logInfo("Loading datasets for study: %d".formatted(studyId));
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(study.getDatasetIds());
-    logWarn("Loaded %d datasets for study: %d".formatted(datasets.size(), studyId));
+    logInfo("Loaded %d datasets for study: %d".formatted(datasets.size(), studyId));
     datasets.forEach(d -> d.setStudy(study));
     if (datasets.isEmpty()) {
       return Response.status(Status.NOT_FOUND).build();
@@ -339,7 +339,8 @@ public class ElasticSearchService implements ConsentLogger {
     try {
       synchronizeDatasetListInESIndex(datasets);
       return Response.ok().build();
-    } catch (Exception _) {
+    } catch (Exception e) {
+      logWarn("Exception, unable to index study: %d".formatted(studyId), e);
       return Response.status(500, "Indexing failed.").build();
     }
   }
@@ -381,9 +382,9 @@ public class ElasticSearchService implements ConsentLogger {
   public Response indexDatasets(List<Integer> datasetIds) throws IOException {
     // Datasets in list context may not have their study populated, so we need to ensure that is
     // true before trying to index them in ES.
-    logWarn("Fetching %d datasets from database".formatted(datasetIds.size()));
+    logInfo("Fetching %d datasets from database".formatted(datasetIds.size()));
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(datasetIds);
-    logWarn("Fetched %d datasets from database".formatted(datasetIds.size()));
+    logInfo("Fetched %d datasets from database".formatted(datasets.size()));
     Map<Integer, Study> studyCache = new HashMap<>();
     datasets.forEach(
         dataset -> {
@@ -392,9 +393,9 @@ public class ElasticSearchService implements ConsentLogger {
                 studyCache.computeIfAbsent(
                     dataset.getStudyId(),
                     k -> {
-                      logWarn("Fetching study id %d from database".formatted(k));
+                      logInfo("Fetching study id %d from database".formatted(k));
                       Study study = studyDAO.findStudyById(k);
-                      logWarn("Study id %d fetched.".formatted(k));
+                      logInfo("Study id %d fetched.".formatted(k));
                       return study;
                     }));
           }

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.JsonArray;
@@ -284,8 +285,10 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     Level previousLevel = logger.getLevel();
     logger.setLevel(Level.INFO);
     TestAppender appender = new TestAppender();
-    appender.start();
+    appender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    appender.reset();
     logger.addAppender(appender);
+    appender.start();
     try (jakarta.ws.rs.core.Response response =
         elasticSearchSpy.indexStudy(datasetRecord.study.getStudyId())) {
       // Ensure that the synchronous method was called with the expected parameters
@@ -334,10 +337,14 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     RuntimeException failure = new RuntimeException("synthetic indexing failure");
     doThrow(failure).when(elasticSearchSpy).synchronizeDatasetListInESIndex(List.of(dataset));
 
-    Logger logger = (Logger) LoggerFactory.getLogger(ElasticSearchService.class);
+    Logger logger = (Logger) LoggerFactory.getLogger(elasticSearchSpy.getClass());
+    Level previousLevel = logger.getLevel();
+    logger.setLevel(Level.WARN);
     TestAppender appender = new TestAppender();
-    appender.start();
+    appender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+    appender.reset();
     logger.addAppender(appender);
+    appender.start();
     try (jakarta.ws.rs.core.Response response = elasticSearchSpy.indexStudy(study.getStudyId())) {
       assertEquals(500, response.getStatus());
       assertTrue(
@@ -352,6 +359,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     } finally {
       logger.detachAppender(appender);
       appender.stop();
+      logger.setLevel(previousLevel);
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -280,7 +280,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
     ElasticSearchService elasticSearchSpy = spy(service);
 
-    Logger logger = (Logger) LoggerFactory.getLogger(ElasticSearchService.class);
+    Logger logger = (Logger) LoggerFactory.getLogger(elasticSearchSpy.getClass());
     Level previousLevel = logger.getLevel();
     logger.setLevel(Level.INFO);
     TestAppender appender = new TestAppender();

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -19,6 +20,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.JsonArray;
 import jakarta.ws.rs.core.StreamingOutput;
@@ -67,6 +71,7 @@ import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
+import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -81,6 +86,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class ElasticSearchServiceTest extends AbstractTestHelper {
@@ -274,12 +280,79 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
     ElasticSearchService elasticSearchSpy = spy(service);
 
-    jakarta.ws.rs.core.Response response =
-        elasticSearchSpy.indexStudy(datasetRecord.study.getStudyId());
-    // Ensure that the synchronous method was called with the expected parameters
-    verify(elasticSearchSpy, timeout(1000))
-        .synchronizeDatasetListInESIndex(List.of(datasetRecord.dataset));
-    assertEquals(200, response.getStatus());
+    Logger logger = (Logger) LoggerFactory.getLogger(ElasticSearchService.class);
+    Level previousLevel = logger.getLevel();
+    logger.setLevel(Level.INFO);
+    TestAppender appender = new TestAppender();
+    appender.start();
+    logger.addAppender(appender);
+    try (jakarta.ws.rs.core.Response response =
+        elasticSearchSpy.indexStudy(datasetRecord.study.getStudyId())) {
+      // Ensure that the synchronous method was called with the expected parameters
+      verify(elasticSearchSpy, timeout(1000))
+          .synchronizeDatasetListInESIndex(List.of(datasetRecord.dataset));
+      assertEquals(200, response.getStatus());
+      List<ILoggingEvent> events = appender.getLoggedEvents();
+      assertTrue(
+          events.stream()
+              .anyMatch(
+                  event ->
+                      event.getLevel() == Level.INFO
+                          && event
+                              .getFormattedMessage()
+                              .equals(
+                                  "Loading datasets for study: %d"
+                                      .formatted(datasetRecord.study.getStudyId()))));
+      assertTrue(
+          events.stream()
+              .anyMatch(
+                  event ->
+                      event.getLevel() == Level.INFO
+                          && event
+                              .getFormattedMessage()
+                              .equals(
+                                  "Loaded 1 datasets for study: %d"
+                                      .formatted(datasetRecord.study.getStudyId()))));
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+      logger.setLevel(previousLevel);
+    }
+  }
+
+  @Test
+  void testIndexStudyLogsWarningOnFailure() {
+    Study study = new Study();
+    study.setStudyId(1);
+    study.addDatasetId(1);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    when(studyDAO.findStudyById(1)).thenReturn(study);
+    when(datasetDAO.findDatasetsByIdList(study.getDatasetIds())).thenReturn(List.of(dataset));
+
+    ElasticSearchService elasticSearchSpy = spy(service);
+    RuntimeException failure = new RuntimeException("synthetic indexing failure");
+    doThrow(failure).when(elasticSearchSpy).synchronizeDatasetListInESIndex(List.of(dataset));
+
+    Logger logger = (Logger) LoggerFactory.getLogger(ElasticSearchService.class);
+    TestAppender appender = new TestAppender();
+    appender.start();
+    logger.addAppender(appender);
+    try (jakarta.ws.rs.core.Response response = elasticSearchSpy.indexStudy(study.getStudyId())) {
+      assertEquals(500, response.getStatus());
+      assertTrue(
+          appender.getLoggedEvents().stream()
+              .anyMatch(
+                  event ->
+                      event.getLevel() == Level.WARN
+                          && event
+                              .getFormattedMessage()
+                              .equals("Exception, unable to index study: 1")
+                          && event.getThrowableProxy() != null));
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2560

### Summary

- Log routine Elasticsearch indexing progress at INFO.
- Log study indexing failures at WARN with the exception.
- Add tests verifying both log levels are emitted.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
