### PR TITLE
[DT-3790] Remove duplicate dataset update DAO method

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -496,22 +496,6 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @SqlUpdate(
       """
       UPDATE dataset
-      SET name = :datasetName,
-          update_date = :updateDate,
-          update_user_id = :updateUserId,
-          dac_id = :dacId
-      WHERE dataset_id = :datasetId
-      """)
-  void updateDataset(
-      @Bind("datasetId") Integer datasetId,
-      @Bind("datasetName") String datasetName,
-      @Bind("updateDate") Timestamp updateDate,
-      @Bind("updateUserId") Integer updateUserId,
-      @Bind("dacId") Integer updatedDacId);
-
-  @SqlUpdate(
-      """
-      UPDATE dataset
       SET data_use = :dataUse,
           translated_data_use = :translation,
           update_date = current_timestamp,

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -429,14 +429,15 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testUpdateDataset() {
+  void testUpdateDatasetByDatasetIdUpdatesNameAuditFieldsAndDac() {
     Dataset d = insertDataset();
     Dac dac = insertDac();
     String name = randomAlphanumeric(20);
     Timestamp now = new Timestamp(new Date().getTime());
     User user = createUser();
 
-    datasetDAO.updateDataset(d.getDatasetId(), name, now, user.getUserId(), dac.getDacId());
+    datasetDAO.updateDatasetByDatasetId(
+        d.getDatasetId(), name, now, user.getUserId(), dac.getDacId());
     Dataset updated = datasetDAO.findDatasetById(d.getDatasetId());
 
     assertEquals(name, updated.getName());
@@ -903,13 +904,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset1.getDatasetId(),
         dataset1.getDatasetName(),
         timestamp,
         user.getUserId(),
         dac1.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset2.getDatasetId(),
         dataset2.getDatasetName(),
         timestamp,
@@ -917,13 +918,13 @@ class DatasetDAOTest extends DAOTestHelper {
         dac1.getDacId());
 
     Dac dac2 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset3.getDatasetId(),
         dataset3.getDatasetName(),
         timestamp,
         user.getUserId(),
         dac2.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset4.getDatasetId(),
         dataset4.getDatasetName(),
         timestamp,
@@ -982,13 +983,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset1.getDatasetId(),
         dataset1.getDatasetName(),
         timestamp,
         user.getUserId(),
         dac1.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset2.getDatasetId(),
         dataset2.getDatasetName(),
         timestamp,
@@ -996,13 +997,13 @@ class DatasetDAOTest extends DAOTestHelper {
         dac1.getDacId());
 
     Dac dac2 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset3.getDatasetId(),
         dataset3.getDatasetName(),
         timestamp,
         user.getUserId(),
         dac2.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset4.getDatasetId(),
         dataset4.getDatasetName(),
         timestamp,
@@ -1092,13 +1093,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(new Date().getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset1.getDatasetId(),
         dataset1.getDatasetName(),
         timestamp,
         user.getUserId(),
         dac1.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset2.getDatasetId(),
         dataset2.getDatasetName(),
         timestamp,
@@ -1146,13 +1147,13 @@ class DatasetDAOTest extends DAOTestHelper {
     Timestamp timestamp = new Timestamp(now.getTime());
 
     Dac dac1 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset1.getDatasetId(),
         dataset1.getDatasetName(),
         timestamp,
         chairperson1.getUserId(),
         dac1.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset2.getDatasetId(),
         dataset2.getDatasetName(),
         timestamp,
@@ -1164,13 +1165,13 @@ class DatasetDAOTest extends DAOTestHelper {
         true, Instant.now(), chairperson1.getUserId(), dataset2.getDatasetId());
 
     Dac dac2 = insertDac();
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset3.getDatasetId(),
         dataset3.getDatasetName(),
         timestamp,
         chairperson2.getUserId(),
         dac2.getDacId());
-    datasetDAO.updateDataset(
+    datasetDAO.updateDatasetByDatasetId(
         dataset4.getDatasetId(),
         dataset4.getDatasetName(),
         timestamp,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3790

### Summary

- Remove the unused DatasetDAO.updateDataset method.
- Update DAO tests to use updateDatasetByDatasetId.
- Rename the focused test to describe the fields being updated.
- Preserve existing partial-update behavior.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
