### PR TITLE
[DT-3865] Migrate match identity to dataset IDs

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -13,3 +13,4 @@ Use this directory for documents that describe a proposed path forward, migratio
 | `dataset-registration-schema-migration-plan.md` | Plan for migrating dataset/study registration away from `dataset-registration-schema_v1.json` backend validation. |
 | `elasticsearch-service-duos-ui-usage.md` | Plan for adding access control to the information in consent's Elasticsearch infrastructure. |
 | `es-security-capability-record.md` | Ticket A-1 record: measured Elasticsearch security capabilities (DLS/FLS/API keys/`run_as`) per environment, and the resulting Epic D / Epic E decision. |
+| `dataset-identity-migration-plan.md` | Plan for replacing alias-derived match identity with dataset foreign keys and sequence-backed public aliases. |

--- a/docs/plans/dataset-identity-migration-plan.md
+++ b/docs/plans/dataset-identity-migration-plan.md
@@ -24,7 +24,9 @@ HAVING COUNT(*) > 1;
 SELECT m.match_id, m.purpose, m.consent
 FROM match_entity m
 LEFT JOIN dataset d
-  ON m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+  ON m.consent = 'DUOS-'
+    || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+    || d.alias::text
 WHERE d.dataset_id IS NULL;
 
 SELECT COUNT(*) AS pre_migration_total,
@@ -32,7 +34,9 @@ SELECT COUNT(*) AS pre_migration_total,
        COUNT(*) - COUNT(d.dataset_id) AS unresolved
 FROM match_entity m
 LEFT JOIN dataset d
-  ON m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0');
+  ON m.consent = 'DUOS-'
+    || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+    || d.alias::text;
 ```
 
 Any unresolved match rows must be explicitly corrected or isolated before the final constraint
@@ -41,33 +45,50 @@ dataset aliases or match identifiers, so it cannot resolve an unmatched alias.
 
 ## Rollout
 
-The bounded compatibility phase runs during application startup, before the new application code
-serves traffic.
+This migration uses an expand/migrate/contract rollout so old and new instances can safely overlap.
 
-Deployment note: avoid mixed-version dataset writes during the alias sequence cutover (older
-`COALESCE(MAX(alias), 0) + 1` inserts won’t advance `dataset_alias_seq` and can cause alias collisions).
+### Compatibility release (this change)
+
 1. Verify aliases are non-null, non-negative, and unique.
-2. Create `dataset_alias_seq` above the audited maximum, make it the alias default, and add database
-   uniqueness and non-null constraints.
-3. Add nullable `match_entity.dataset_id` with its foreign key and index.
-4. Backfill only exact canonical alias matches.
-5. Halt if any match is unresolved or if `(purpose, dataset_id)` would be duplicated.
-6. Make `dataset_id` non-null, replace the old uniqueness constraint, and remove `consent`.
+2. Lock dataset writes while initializing `dataset_alias_seq` above the audited maximum.
+3. Install an alias-allocation trigger that overrides both legacy `MAX(alias) + 1` values and
+   omitted aliases with the next sequence value. Add database uniqueness and non-null constraints.
+4. Add nullable `match_entity.dataset_id` with a cascading foreign key and index. Match rationales
+   also cascade when their owning match is removed.
+5. Backfill only exact canonical alias matches.
+6. Install a compatibility trigger that populates `dataset_id` for legacy match writes that provide
+   only `consent`.
+7. Halt if any match is unresolved or if `(purpose, dataset_id)` would be duplicated, then enforce
+   non-null and `(purpose, dataset_id)` uniqueness.
+8. Keep the legacy `consent` column and `(purpose, consent)` constraint for old instances. New match
+   writes populate both identities during this bounded phase.
 
-The DAO change is deployed with the migration. Match writes use `dataset_id`; match reads join to
-`dataset` only to derive the existing public `consent` value.
+Dataset deletion cascades to its matches and their rationales, preserving the supported deletion
+workflow without leaving records that refer to a deleted dataset.
+
+### Contract release (required follow-up)
+
+After every environment is running the compatibility release and reconciliation still reports zero
+unresolved or conflicting rows:
+
+1. Remove the match compatibility trigger.
+2. Remove the legacy `(purpose, consent)` constraint and `match_entity.consent` column.
+3. Replace the temporary alias-allocation trigger with `dataset_alias_seq` as the column default.
+
+The contract changes must be delivered in a later release; they must not run while an older
+application instance can still serve traffic.
 
 ## Alias Lookup Inventory
 
 - `DatasetService` identifier lookup and `TDRService` identifier lookup remain public API/integration
   boundaries and may translate a `DUOS-######` identifier to an alias.
 - Dataset and DAC response projections may format aliases for user-facing output.
-- Match persistence and election joins use only `dataset_id` after this migration.
+- Match persistence and election joins use `dataset_id`; the compatibility trigger translates only
+  writes from older application instances.
 
 ## Rollback
 
-Liquibase rollback recreates and backfills `match_entity.consent` from the referenced dataset,
-restores `(purpose, consent)` uniqueness, removes `dataset_id`, removes alias constraints/default,
-and drops the alias sequence. Because aliases remain immutable public identifiers throughout the
-rollout, the reconstructed legacy values are compatible with the previous application version.
-
+Liquibase rollback removes the compatibility triggers and new constraints, restores the original
+match-rationale foreign key behavior, removes `dataset_id`, removes the alias constraints, and drops
+the alias sequence. The legacy `consent` column and its uniqueness constraint remain present
+throughout this release, so rollback does not need to reconstruct public identifiers.

--- a/docs/plans/dataset-identity-migration-plan.md
+++ b/docs/plans/dataset-identity-migration-plan.md
@@ -1,0 +1,71 @@
+# Dataset Identity Migration
+
+## Goal
+
+Use `dataset.dataset_id` for match persistence and relational joins while keeping the canonical
+`DUOS-######` alias as the public dataset identifier. Allocate new aliases from a PostgreSQL
+sequence and enforce uniqueness in the database.
+
+## Preflight Audit
+
+Before production rollout, run the following read-only checks. The Liquibase migration repeats the
+blocking checks and halts rather than guessing when the data is ambiguous.
+
+```sql
+SELECT dataset_id, alias
+FROM dataset
+WHERE alias IS NULL OR alias < 0;
+
+SELECT alias, COUNT(*)
+FROM dataset
+GROUP BY alias
+HAVING COUNT(*) > 1;
+
+SELECT m.match_id, m.purpose, m.consent
+FROM match_entity m
+LEFT JOIN dataset d
+  ON m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+WHERE d.dataset_id IS NULL;
+
+SELECT COUNT(*) AS pre_migration_total,
+       COUNT(d.dataset_id) AS exact_matches,
+       COUNT(*) - COUNT(d.dataset_id) AS unresolved
+FROM match_entity m
+LEFT JOIN dataset d
+  ON m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0');
+```
+
+Any unresolved match rows must be explicitly corrected or isolated before the final constraint
+change. The Data Use classification sample associated with the preceding ticket does not contain
+dataset aliases or match identifiers, so it cannot resolve an unmatched alias.
+
+## Rollout
+
+The bounded compatibility phase runs during application startup, before the new application code
+serves traffic:
+
+1. Verify aliases are non-null, non-negative, and unique.
+2. Create `dataset_alias_seq` above the audited maximum, make it the alias default, and add database
+   uniqueness and non-null constraints.
+3. Add nullable `match_entity.dataset_id` with its foreign key and index.
+4. Backfill only exact canonical alias matches.
+5. Halt if any match is unresolved or if `(purpose, dataset_id)` would be duplicated.
+6. Make `dataset_id` non-null, replace the old uniqueness constraint, and remove `consent`.
+
+The DAO change is deployed with the migration. Match writes use `dataset_id`; match reads join to
+`dataset` only to derive the existing public `consent` value.
+
+## Alias Lookup Inventory
+
+- `DatasetService` identifier lookup and `TDRService` identifier lookup remain public API/integration
+  boundaries and may translate a `DUOS-######` identifier to an alias.
+- Dataset and DAC response projections may format aliases for user-facing output.
+- Match persistence and election joins use only `dataset_id` after this migration.
+
+## Rollback
+
+Liquibase rollback recreates and backfills `match_entity.consent` from the referenced dataset,
+restores `(purpose, consent)` uniqueness, removes `dataset_id`, removes alias constraints/default,
+and drops the alias sequence. Because aliases remain immutable public identifiers throughout the
+rollout, the reconstructed legacy values are compatible with the previous application version.
+

--- a/docs/plans/dataset-identity-migration-plan.md
+++ b/docs/plans/dataset-identity-migration-plan.md
@@ -42,8 +42,10 @@ dataset aliases or match identifiers, so it cannot resolve an unmatched alias.
 ## Rollout
 
 The bounded compatibility phase runs during application startup, before the new application code
-serves traffic:
+serves traffic.
 
+Deployment note: avoid mixed-version dataset writes during the alias sequence cutover (older
+`COALESCE(MAX(alias), 0) + 1` inserts won’t advance `dataset_alias_seq` and can cause alias collisions).
 1. Verify aliases are non-null, non-negative, and unique.
 2. Create `dataset_alias_seq` above the audited maximum, make it the alias default, and add database
    uniqueness and non-null constraints.

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -132,9 +132,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """
           INSERT INTO dataset
               (name, create_date, create_user_id, update_date,
-              update_user_id, object_id, dac_id, alias, data_use)
-          (SELECT :name, :createDate, :createUserId, :createDate,
-              :createUserId, :objectId, :dacId, COALESCE(MAX(alias),0)+1, :dataUse FROM dataset)
+              update_user_id, object_id, dac_id, data_use)
+          VALUES (:name, :createDate, :createUserId, :createDate,
+              :createUserId, :objectId, :dacId, :dataUse)
           """)
   @GetGeneratedKeys
   Integer insertDataset(

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -74,11 +74,13 @@ public interface MatchDAO extends Transactional<MatchDAO> {
         INSERT INTO match_entity
           (dataset_id, consent, purpose, match_entity, failed, create_date, algorithm_version,
            abstain)
-        SELECT d.dataset_id,
-               'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text))) || d.alias::text,
-               :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain
-        FROM dataset d
-        WHERE d.dataset_id = :datasetId
+        VALUES (
+          :datasetId,
+          (SELECT 'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+                    || d.alias::text
+             FROM dataset d
+            WHERE d.dataset_id = :datasetId),
+          :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
       """)
   @GetGeneratedKeys
   Integer insertMatch(

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -23,7 +23,8 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       """
       SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
              m.create_date, m.algorithm_version, m.abstain,
-             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+               || d.alias::text AS consent,
              r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
@@ -37,7 +38,8 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       """
       SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
              m.create_date, m.algorithm_version, m.abstain,
-             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+               || d.alias::text AS consent,
              r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
@@ -51,7 +53,8 @@ public interface MatchDAO extends Transactional<MatchDAO> {
       """
       SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
              m.create_date, m.algorithm_version, m.abstain,
-             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+               || d.alias::text AS consent,
              r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
@@ -69,9 +72,13 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @SqlUpdate(
       """
         INSERT INTO match_entity
-          (dataset_id, purpose, match_entity, failed, create_date, algorithm_version, abstain)
-        VALUES
-          (:datasetId, :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
+          (dataset_id, consent, purpose, match_entity, failed, create_date, algorithm_version,
+           abstain)
+        SELECT d.dataset_id,
+               'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text))) || d.alias::text,
+               :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain
+        FROM dataset d
+        WHERE d.dataset_id = :datasetId
       """)
   @GetGeneratedKeys
   Integer insertMatch(

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -21,8 +21,9 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT m.*, r.*
+      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
         FROM match_entity m
+        INNER JOIN dataset d ON d.dataset_id = m.dataset_id
         LEFT JOIN match_rationale r on r.match_entity_id = m.match_id
         WHERE m.purpose = :purposeId
       """)
@@ -31,8 +32,9 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT m.*, r.*
+      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
         FROM match_entity m
+        INNER JOIN dataset d ON d.dataset_id = m.dataset_id
         LEFT JOIN match_rationale r on r.match_entity_id = m.match_id
         WHERE m.match_id = :id
       """)
@@ -41,14 +43,16 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT match_entity.*, r.* FROM match_entity
-        LEFT JOIN match_rationale r on r.match_entity_id = match_entity.match_id
+      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
+        FROM match_entity m
+        INNER JOIN dataset d ON d.dataset_id = m.dataset_id
+        LEFT JOIN match_rationale r on r.match_entity_id = m.match_id
         INNER JOIN (
           SELECT election.*, MAX(election.election_id) OVER (PARTITION BY election.reference_id, election.dataset_id) AS latest
           FROM election
           WHERE LOWER(election.election_type) = 'dataaccess'
-          ) AS e ON e.reference_id = match_entity.purpose
-        WHERE match_entity.purpose IN (<purposeIds>) AND e.election_id = latest
+          ) AS e ON e.reference_id = m.purpose AND e.dataset_id = m.dataset_id
+        WHERE m.purpose IN (<purposeIds>) AND e.election_id = latest
       """)
   List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(
       @BindList(value = "purposeIds", onEmpty = EmptyHandling.NULL_STRING) List<String> purposeIds);
@@ -56,13 +60,13 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @SqlUpdate(
       """
         INSERT INTO match_entity
-          (consent, purpose, match_entity, failed, create_date, algorithm_version, abstain)
+          (dataset_id, purpose, match_entity, failed, create_date, algorithm_version, abstain)
         VALUES
-          (:consentId, :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
+          (:datasetId, :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
       """)
   @GetGeneratedKeys
   Integer insertMatch(
-      @Bind("consentId") String consentId,
+      @Bind("datasetId") Integer datasetId,
       @Bind("purposeId") String purposeId,
       @Bind("match") Boolean match,
       @Bind("failed") Boolean failed,

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -21,7 +21,10 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
+      SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
+             m.create_date, m.algorithm_version, m.abstain,
+             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
         LEFT JOIN match_rationale r on r.match_entity_id = m.match_id
@@ -32,7 +35,10 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
+      SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
+             m.create_date, m.algorithm_version, m.abstain,
+             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
         LEFT JOIN match_rationale r on r.match_entity_id = m.match_id
@@ -43,7 +49,10 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @UseRowReducer(MatchReducer.class)
   @SqlQuery(
       """
-      SELECT m.*, 'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent, r.*
+      SELECT m.match_id, m.dataset_id, m.purpose, m.match_entity, m.failed,
+             m.create_date, m.algorithm_version, m.abstain,
+             'DUOS-' || LPAD(d.alias::text, 6, '0') AS consent,
+             r.rationale
         FROM match_entity m
         INNER JOIN dataset d ON d.dataset_id = m.dataset_id
         LEFT JOIN match_rationale r on r.match_entity_id = m.match_id

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
@@ -10,14 +10,17 @@ public class MatchMapper implements RowMapper<Match> {
 
   public Match map(ResultSet r, StatementContext ctx) throws SQLException {
 
-    return new Match(
-        r.getInt("match_id"),
-        r.getString("consent"),
-        r.getString("purpose"),
-        r.getBoolean("match_entity"),
-        r.getBoolean("abstain"),
-        r.getBoolean("failed"),
-        r.getDate("create_date"),
-        r.getString("algorithm_version"));
+    Match match =
+        new Match(
+            r.getInt("match_id"),
+            r.getString("consent"),
+            r.getString("purpose"),
+            r.getBoolean("match_entity"),
+            r.getBoolean("abstain"),
+            r.getBoolean("failed"),
+            r.getDate("create_date"),
+            r.getString("algorithm_version"));
+    match.setDatasetId(r.getInt("dataset_id"));
+    return match;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -14,6 +14,7 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         map.computeIfAbsent(
             rowView.getColumn("match_id", Integer.class), id -> rowView.getRow(Match.class));
     hasOptionalColumn(rowView, "consent", String.class).ifPresent(match::setConsent);
+    hasOptionalColumn(rowView, "dataset_id", Integer.class).ifPresent(match::setDatasetId);
     hasOptionalColumn(rowView, "purpose", String.class).ifPresent(match::setPurpose);
     hasOptionalColumn(rowView, "algorithm_version", String.class)
         .ifPresent(match::setAlgorithmVersion);

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Abstain;
 import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Approve;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -15,6 +16,8 @@ public class Match {
   private Integer id;
 
   private String consent;
+
+  @JsonIgnore private Integer datasetId;
 
   private String purpose;
 
@@ -85,6 +88,15 @@ public class Match {
     this.consent = consent;
   }
 
+  @JsonIgnore
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
+  }
+
   public String getPurpose() {
     return purpose;
   }
@@ -153,13 +165,30 @@ public class Match {
     }
   }
 
-  public static Match matchFailure(String consentId, String purposeId, List<String> rationales) {
-    return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V4, rationales);
+  public static Match matchFailure(
+      Integer datasetId, String consentId, String purposeId, List<String> rationales) {
+    Match match =
+        new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V4, rationales);
+    match.setDatasetId(datasetId);
+    return match;
   }
 
   public static Match matchSuccess(
-      String consentId, String purposeId, DataUseMatchResultType match, List<String> rationales) {
-    return new Match(
-        consentId, purposeId, Approve(match), Abstain(match), false, MatchAlgorithm.V4, rationales);
+      Integer datasetId,
+      String consentId,
+      String purposeId,
+      DataUseMatchResultType matchResult,
+      List<String> rationales) {
+    Match match =
+        new Match(
+            consentId,
+            purposeId,
+            Approve(matchResult),
+            Abstain(matchResult),
+            false,
+            MatchAlgorithm.V4,
+            rationales);
+    match.setDatasetId(datasetId);
+    return match;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -45,7 +45,7 @@ public class MatchService implements ConsentLogger {
         m -> {
           Integer id =
               matchDAO.insertMatch(
-                  m.getConsent(),
+                  m.getDatasetId(),
                   m.getPurpose(),
                   m.getMatch(),
                   m.getFailed(),
@@ -91,7 +91,10 @@ public class MatchService implements ConsentLogger {
                   logWarn(message);
                   matches.add(
                       matchFailure(
-                          dataset.getDatasetIdentifier(), dar.getReferenceId(), List.of(message)));
+                          dataset.getDatasetId(),
+                          dataset.getDatasetIdentifier(),
+                          dar.getReferenceId(),
+                          List.of(message)));
                 }
               }
             });
@@ -116,6 +119,7 @@ public class MatchService implements ConsentLogger {
     MatchResult matchResult =
         dataUseMatcherV4.matchPurposeAndDatasetV4(darDataUse, dataset.getDataUse());
     return matchSuccess(
+        dataset.getDatasetId(),
         dataset.getDatasetIdentifier(),
         dar.getReferenceId(),
         matchResult.getMatchResultType(),

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
@@ -91,9 +91,15 @@ public class DacServiceDAO implements ConsentLogger {
             FROM (
               SELECT dd.reference_id,
                      STRING_AGG(
-                       COALESCE('DUOS-' || LPAD(d.alias::TEXT, 6, '0'), d.object_id, d.dataset_id::TEXT),
+                       COALESCE(
+                         'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::TEXT))) || d.alias::TEXT,
+                         d.object_id,
+                         d.dataset_id::TEXT),
                        ', '
-                       ORDER BY COALESCE('DUOS-' || LPAD(d.alias::TEXT, 6, '0'), d.object_id, d.dataset_id::TEXT)
+                       ORDER BY COALESCE(
+                         'DUOS-' || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::TEXT))) || d.alias::TEXT,
+                         d.object_id,
+                         d.dataset_id::TEXT)
                      ) AS removed_dataset_identifiers
               FROM dar_dataset dd
               INNER JOIN dataset d ON d.dataset_id = dd.dataset_id

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -254,4 +254,5 @@
   <include file="changesets/changelog-consent-2026-06-16-bff-02-user-session-audit.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-07-14-election-type.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-08-05-dataset-identity.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
@@ -33,6 +33,8 @@
       <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
       <dropDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"/>
       <dropSequence sequenceName="dataset_alias_seq"/>
+      <addDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"
+        defaultValueNumeric="0"/>
     </rollback>
   </changeSet>
 

--- a/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
@@ -1,0 +1,115 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="changelog-consent-2026-08-05-audit-and-sequence-dataset-alias" author="kmarete">
+    <preConditions onFail="HALT" onError="HALT">
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*) FROM dataset WHERE alias IS NULL OR alias &lt; 0
+      </sqlCheck>
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*)
+        FROM (SELECT alias FROM dataset GROUP BY alias HAVING COUNT(*) &gt; 1) duplicate_aliases
+      </sqlCheck>
+    </preConditions>
+
+    <createSequence sequenceName="dataset_alias_seq"/>
+    <sql>
+      SELECT setval(
+        'dataset_alias_seq',
+        COALESCE((SELECT MAX(alias) FROM dataset), 0) + 1,
+        false
+      )
+    </sql>
+    <addDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"
+      defaultValueSequenceNext="dataset_alias_seq"/>
+    <addNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
+    <addUniqueConstraint tableName="dataset" columnNames="alias"
+      constraintName="uq_dataset_alias"/>
+
+    <rollback>
+      <dropUniqueConstraint tableName="dataset" constraintName="uq_dataset_alias"/>
+      <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
+      <dropDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"/>
+      <dropSequence sequenceName="dataset_alias_seq"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="changelog-consent-2026-08-05-add-match-dataset-id" author="kmarete">
+    <addColumn tableName="match_entity">
+      <column name="dataset_id" type="bigint"/>
+    </addColumn>
+    <addForeignKeyConstraint baseTableName="match_entity" baseColumnNames="dataset_id"
+      constraintName="fk_match_entity_dataset_id" referencedTableName="dataset"
+      referencedColumnNames="dataset_id" onDelete="NO ACTION" onUpdate="NO ACTION"/>
+    <createIndex tableName="match_entity" indexName="idx_match_entity_dataset_id">
+      <column name="dataset_id"/>
+    </createIndex>
+
+    <rollback>
+      <dropIndex tableName="match_entity" indexName="idx_match_entity_dataset_id"/>
+      <dropForeignKeyConstraint baseTableName="match_entity"
+        constraintName="fk_match_entity_dataset_id"/>
+      <dropColumn tableName="match_entity" columnName="dataset_id"/>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="changelog-consent-2026-08-05-backfill-match-dataset-id" author="kmarete">
+    <!-- Only canonical, exact, and unambiguous public identifiers are eligible for backfill. -->
+    <sql>
+      UPDATE match_entity m
+      SET dataset_id = d.dataset_id
+      FROM dataset d
+      WHERE m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+    </sql>
+    <rollback>
+      <sql>UPDATE match_entity SET dataset_id = NULL</sql>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="changelog-consent-2026-08-05-finalize-match-dataset-id" author="kmarete">
+    <preConditions onFail="HALT" onError="HALT">
+      <!-- A failure leaves the nullable column in place so unmatched rows can be isolated/resolved. -->
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*) FROM match_entity WHERE dataset_id IS NULL
+      </sqlCheck>
+      <sqlCheck expectedResult="0">
+        SELECT COUNT(*)
+        FROM (
+          SELECT purpose, dataset_id
+          FROM match_entity
+          GROUP BY purpose, dataset_id
+          HAVING COUNT(*) &gt; 1
+        ) duplicate_matches
+      </sqlCheck>
+    </preConditions>
+
+    <addNotNullConstraint tableName="match_entity" columnName="dataset_id"
+      columnDataType="bigint"/>
+    <dropUniqueConstraint tableName="match_entity" constraintName="purpose_consent"/>
+    <addUniqueConstraint tableName="match_entity" columnNames="purpose,dataset_id"
+      constraintName="uq_match_entity_purpose_dataset_id"/>
+    <dropColumn tableName="match_entity" columnName="consent"/>
+
+    <rollback>
+      <addColumn tableName="match_entity">
+        <column name="consent" type="varchar(255)"/>
+      </addColumn>
+      <sql>
+        UPDATE match_entity m
+        SET consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+        FROM dataset d
+        WHERE d.dataset_id = m.dataset_id
+      </sql>
+      <addNotNullConstraint tableName="match_entity" columnName="consent"
+        columnDataType="varchar(255)"/>
+      <dropUniqueConstraint tableName="match_entity"
+        constraintName="uq_match_entity_purpose_dataset_id"/>
+      <addUniqueConstraint tableName="match_entity" columnNames="purpose,consent"
+        constraintName="purpose_consent"/>
+      <dropNotNullConstraint tableName="match_entity" columnName="dataset_id"
+        columnDataType="bigint"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
@@ -98,10 +98,14 @@
   </changeSet>
 
   <changeSet id="changelog-consent-2026-08-05-sync-legacy-match-writes" author="kmarete">
-    <!-- Populate dataset_id for match inserts made by an older application instance. -->
+    <!-- Populate dataset_id for legacy writes that do not supply it or change consent. -->
     <sql splitStatements="false"><![CDATA[
       CREATE FUNCTION populate_match_dataset_id() RETURNS trigger AS $$
       BEGIN
+        IF TG_OP = 'INSERT' AND NEW.dataset_id IS NOT NULL THEN
+          RETURN NEW;
+        END IF;
+
         SELECT d.dataset_id INTO NEW.dataset_id
         FROM dataset d
         WHERE NEW.consent = 'DUOS-'

--- a/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-05-dataset-identity.xml
@@ -15,6 +15,7 @@
     </preConditions>
 
     <createSequence sequenceName="dataset_alias_seq"/>
+    <sql>LOCK TABLE dataset IN ACCESS EXCLUSIVE MODE</sql>
     <sql>
       SELECT setval(
         'dataset_alias_seq',
@@ -22,19 +23,33 @@
         false
       )
     </sql>
-    <addDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"
-      defaultValueSequenceNext="dataset_alias_seq"/>
+    <!--
+      Allocate from the sequence in a trigger during the compatibility release. This also overrides
+      aliases supplied by older application versions that still calculate MAX(alias) + 1.
+    -->
+    <sql splitStatements="false"><![CDATA[
+      CREATE FUNCTION allocate_dataset_alias() RETURNS trigger AS $$
+      BEGIN
+        NEW.alias := nextval('dataset_alias_seq');
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    ]]></sql>
+    <sql>
+      CREATE TRIGGER dataset_alias_sequence_trigger
+      BEFORE INSERT ON dataset
+      FOR EACH ROW EXECUTE FUNCTION allocate_dataset_alias()
+    </sql>
     <addNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
     <addUniqueConstraint tableName="dataset" columnNames="alias"
       constraintName="uq_dataset_alias"/>
 
     <rollback>
+      <sql>DROP TRIGGER dataset_alias_sequence_trigger ON dataset</sql>
+      <sql>DROP FUNCTION allocate_dataset_alias()</sql>
       <dropUniqueConstraint tableName="dataset" constraintName="uq_dataset_alias"/>
       <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
-      <dropDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"/>
       <dropSequence sequenceName="dataset_alias_seq"/>
-      <addDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"
-        defaultValueNumeric="0"/>
     </rollback>
   </changeSet>
 
@@ -44,12 +59,22 @@
     </addColumn>
     <addForeignKeyConstraint baseTableName="match_entity" baseColumnNames="dataset_id"
       constraintName="fk_match_entity_dataset_id" referencedTableName="dataset"
-      referencedColumnNames="dataset_id" onDelete="NO ACTION" onUpdate="NO ACTION"/>
+      referencedColumnNames="dataset_id" onDelete="CASCADE" onUpdate="NO ACTION"/>
     <createIndex tableName="match_entity" indexName="idx_match_entity_dataset_id">
       <column name="dataset_id"/>
     </createIndex>
+    <dropForeignKeyConstraint baseTableName="match_rationale"
+      constraintName="fk_match_failure_entity_id"/>
+    <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
+      constraintName="fk_match_failure_entity_id" referencedTableName="match_entity"
+      referencedColumnNames="match_id" onDelete="CASCADE" onUpdate="NO ACTION"/>
 
     <rollback>
+      <dropForeignKeyConstraint baseTableName="match_rationale"
+        constraintName="fk_match_failure_entity_id"/>
+      <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
+        constraintName="fk_match_failure_entity_id" referencedTableName="match_entity"
+        referencedColumnNames="match_id" onDelete="NO ACTION" onUpdate="NO ACTION"/>
       <dropIndex tableName="match_entity" indexName="idx_match_entity_dataset_id"/>
       <dropForeignKeyConstraint baseTableName="match_entity"
         constraintName="fk_match_entity_dataset_id"/>
@@ -63,14 +88,42 @@
       UPDATE match_entity m
       SET dataset_id = d.dataset_id
       FROM dataset d
-      WHERE m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+      WHERE m.consent = 'DUOS-'
+        || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+        || d.alias::text
     </sql>
     <rollback>
       <sql>UPDATE match_entity SET dataset_id = NULL</sql>
     </rollback>
   </changeSet>
 
-  <changeSet id="changelog-consent-2026-08-05-finalize-match-dataset-id" author="kmarete">
+  <changeSet id="changelog-consent-2026-08-05-sync-legacy-match-writes" author="kmarete">
+    <!-- Populate dataset_id for match inserts made by an older application instance. -->
+    <sql splitStatements="false"><![CDATA[
+      CREATE FUNCTION populate_match_dataset_id() RETURNS trigger AS $$
+      BEGIN
+        SELECT d.dataset_id INTO NEW.dataset_id
+        FROM dataset d
+        WHERE NEW.consent = 'DUOS-'
+          || REPEAT('0', GREATEST(0, 6 - LENGTH(d.alias::text)))
+          || d.alias::text;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    ]]></sql>
+    <sql>
+      CREATE TRIGGER match_dataset_id_compatibility_trigger
+      BEFORE INSERT OR UPDATE OF consent ON match_entity
+      FOR EACH ROW EXECUTE FUNCTION populate_match_dataset_id()
+    </sql>
+
+    <rollback>
+      <sql>DROP TRIGGER match_dataset_id_compatibility_trigger ON match_entity</sql>
+      <sql>DROP FUNCTION populate_match_dataset_id()</sql>
+    </rollback>
+  </changeSet>
+
+  <changeSet id="changelog-consent-2026-08-05-enforce-match-dataset-id" author="kmarete">
     <preConditions onFail="HALT" onError="HALT">
       <!-- A failure leaves the nullable column in place so unmatched rows can be isolated/resolved. -->
       <sqlCheck expectedResult="0">
@@ -89,27 +142,12 @@
 
     <addNotNullConstraint tableName="match_entity" columnName="dataset_id"
       columnDataType="bigint"/>
-    <dropUniqueConstraint tableName="match_entity" constraintName="purpose_consent"/>
     <addUniqueConstraint tableName="match_entity" columnNames="purpose,dataset_id"
       constraintName="uq_match_entity_purpose_dataset_id"/>
-    <dropColumn tableName="match_entity" columnName="consent"/>
 
     <rollback>
-      <addColumn tableName="match_entity">
-        <column name="consent" type="varchar(255)"/>
-      </addColumn>
-      <sql>
-        UPDATE match_entity m
-        SET consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
-        FROM dataset d
-        WHERE d.dataset_id = m.dataset_id
-      </sql>
-      <addNotNullConstraint tableName="match_entity" columnName="consent"
-        columnDataType="varchar(255)"/>
       <dropUniqueConstraint tableName="match_entity"
         constraintName="uq_match_entity_purpose_dataset_id"/>
-      <addUniqueConstraint tableName="match_entity" columnNames="purpose,consent"
-        constraintName="purpose_consent"/>
       <dropNotNullConstraint tableName="match_entity" columnName="dataset_id"
         columnDataType="bigint"/>
     </rollback>

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -719,13 +720,19 @@ class DatasetDAOTest extends DAOTestHelper {
 
       Set<Integer> aliases = new HashSet<>();
       for (Future<Integer> insertion : insertions) {
-        Dataset dataset = datasetDAO.findDatasetById(insertion.get());
+        Dataset dataset = datasetDAO.findDatasetById(insertion.get(30, TimeUnit.SECONDS));
         aliases.add(dataset.getAlias());
       }
 
       assertEquals(datasetCount, aliases.size());
     } finally {
-      executor.shutdownNow();
+      executor.shutdown();
+      if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+        assertTrue(
+            executor.awaitTermination(5, TimeUnit.SECONDS),
+            "Dataset insertion executor did not terminate");
+      }
     }
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -709,13 +709,16 @@ class DatasetDAOTest extends DAOTestHelper {
                   index ->
                       executor.submit(
                           () ->
-                              datasetDAO.insertDataset(
-                                  "Concurrent Dataset " + index + " " + UUID.randomUUID(),
-                                  now,
-                                  user.getUserId(),
-                                  "Concurrent Object " + index + " " + UUID.randomUUID(),
-                                  dataUse,
-                                  null)))
+                              index % 2 == 0
+                                  ? datasetDAO.insertDataset(
+                                      "Concurrent Dataset " + index + " " + UUID.randomUUID(),
+                                      now,
+                                      user.getUserId(),
+                                      "Concurrent Object " + index + " " + UUID.randomUUID(),
+                                      dataUse,
+                                      null)
+                                  : insertDatasetLikeLegacyVersion(
+                                      index, now, user.getUserId(), dataUse)))
               .toList();
 
       Set<Integer> aliases = new HashSet<>();
@@ -734,6 +737,30 @@ class DatasetDAOTest extends DAOTestHelper {
             "Dataset insertion executor did not terminate");
       }
     }
+  }
+
+  private Integer insertDatasetLikeLegacyVersion(
+      int index, Timestamp createDate, Integer userId, String dataUse) {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    """
+                    INSERT INTO dataset
+                        (name, create_date, create_user_id, update_date,
+                         update_user_id, object_id, dac_id, alias, data_use)
+                    SELECT :name, :createDate, :userId, :createDate,
+                           :userId, :objectId, NULL, COALESCE(MAX(alias), 0) + 1, :dataUse
+                    FROM dataset
+                    RETURNING dataset_id
+                    """)
+                .bind("name", "Legacy Concurrent Dataset " + index + " " + UUID.randomUUID())
+                .bind("createDate", createDate)
+                .bind("userId", userId)
+                .bind("objectId", "Legacy Concurrent Object " + index + " " + UUID.randomUUID())
+                .bind("dataUse", dataUse)
+                .mapTo(Integer.class)
+                .one());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -23,6 +23,9 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -688,6 +691,42 @@ class DatasetDAOTest extends DAOTestHelper {
     assertEquals(0, updatedDataset.getAlias());
     updatedDataset.setDatasetIdentifier();
     assertNotNull(updatedDataset.getDatasetIdentifier());
+  }
+
+  @Test
+  void testConcurrentDatasetInsertsAllocateUniqueAliases() throws Exception {
+    User user = createUser();
+    Timestamp now = new Timestamp(new Date().getTime());
+    String dataUse = new DataUseBuilder().setGeneralUse(true).build().toString();
+    int datasetCount = 12;
+    ExecutorService executor = Executors.newFixedThreadPool(6);
+
+    try {
+      List<Future<Integer>> insertions =
+          IntStream.range(0, datasetCount)
+              .mapToObj(
+                  index ->
+                      executor.submit(
+                          () ->
+                              datasetDAO.insertDataset(
+                                  "Concurrent Dataset " + index + " " + UUID.randomUUID(),
+                                  now,
+                                  user.getUserId(),
+                                  "Concurrent Object " + index + " " + UUID.randomUUID(),
+                                  dataUse,
+                                  null)))
+              .toList();
+
+      Set<Integer> aliases = new HashSet<>();
+      for (Future<Integer> insertion : insertions) {
+        Dataset dataset = datasetDAO.findDatasetById(insertion.get());
+        aliases.add(dataset.getAlias());
+      }
+
+      assertEquals(datasetCount, aliases.size());
+    } finally {
+      executor.shutdownNow();
+    }
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 
 class DatasetIdentityMigrationTest extends DAOTestHelper {
 
+  private static final String DATASET_IDENTITY_CHANGELOG =
+      "changesets/changelog-consent-2026-08-05-dataset-identity.xml";
+
   @Test
   void testRollbackRestoresLegacyIdentityAndMigrationReapplies() throws Exception {
     User user = createUser();
@@ -46,7 +49,8 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
               DatabaseFactory.getInstance()
                   .findCorrectDatabaseImplementation(new JdbcConnection(connection));
           Liquibase liquibase =
-              new Liquibase("changelog-master.xml", new ClassLoaderResourceAccessor(), database);
+              new Liquibase(
+                  DATASET_IDENTITY_CHANGELOG, new ClassLoaderResourceAccessor(), database);
           Contexts contexts = new Contexts();
           LabelExpression labels = new LabelExpression();
 

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -1,0 +1,119 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.util.UUID;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.jupiter.api.Test;
+
+class DatasetIdentityMigrationTest extends DAOTestHelper {
+
+  @Test
+  void testRollbackRestoresLegacyIdentityAndMigrationReapplies() throws Exception {
+    User user = createUser();
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    Integer datasetId =
+        datasetDAO.insertDataset(
+            "Rollback Dataset " + UUID.randomUUID(),
+            FIXED_TIMESTAMP,
+            user.getUserId(),
+            "Rollback Object " + UUID.randomUUID(),
+            dataUse.toString(),
+            null);
+    Dataset dataset = datasetDAO.findDatasetById(datasetId);
+    String purposeId = UUID.randomUUID().toString();
+    matchDAO.insertMatch(
+        datasetId, purposeId, true, false, FIXED_DATE, MatchAlgorithm.V4.getVersion(), false);
+
+    jdbi.useHandle(
+        handle -> {
+          Connection connection = handle.getConnection();
+          Database database =
+              DatabaseFactory.getInstance()
+                  .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+          Liquibase liquibase =
+              new Liquibase("changelog-master.xml", new ClassLoaderResourceAccessor(), database);
+          Contexts contexts = new Contexts();
+          LabelExpression labels = new LabelExpression();
+
+          try {
+            // DAOTestHelper clears data between tests, including Liquibase's tracking rows. Restore
+            // the tracking metadata without rerunning the already-present schema changes.
+            liquibase.changeLogSync(contexts, labels);
+            liquibase.rollback(4, contexts, labels);
+
+            assertTrue(columnExists(handle, "match_entity", "consent"));
+            assertFalse(columnExists(handle, "match_entity", "dataset_id"));
+            assertFalse(sequenceExists(handle, "dataset_alias_seq"));
+            assertEquals(
+                dataset.getDatasetIdentifier(),
+                handle
+                    .createQuery("SELECT consent FROM match_entity WHERE purpose = :purpose")
+                    .bind("purpose", purposeId)
+                    .mapTo(String.class)
+                    .one());
+          } finally {
+            liquibase.update(contexts, labels);
+          }
+
+          assertFalse(columnExists(handle, "match_entity", "consent"));
+          assertTrue(columnExists(handle, "match_entity", "dataset_id"));
+          assertTrue(sequenceExists(handle, "dataset_alias_seq"));
+          assertEquals(
+              datasetId,
+              handle
+                  .createQuery("SELECT dataset_id FROM match_entity WHERE purpose = :purpose")
+                  .bind("purpose", purposeId)
+                  .mapTo(Integer.class)
+                  .one());
+          handle.commit();
+        });
+  }
+
+  private boolean columnExists(
+      org.jdbi.v3.core.Handle handle, String tableName, String columnName) {
+    return handle
+            .createQuery(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = :tableName
+                  AND column_name = :columnName
+                """)
+            .bind("tableName", tableName)
+            .bind("columnName", columnName)
+            .mapTo(Integer.class)
+            .one()
+        == 1;
+  }
+
+  private boolean sequenceExists(org.jdbi.v3.core.Handle handle, String sequenceName) {
+    return handle
+            .createQuery(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.sequences
+                WHERE sequence_schema = current_schema()
+                  AND sequence_name = :sequenceName
+                """)
+            .bind("sequenceName", sequenceName)
+            .mapTo(Integer.class)
+            .one()
+        == 1;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -129,6 +129,35 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
                   .bind("purpose", UUID.randomUUID().toString())
                   .mapTo(Integer.class)
                   .one());
+          String explicitDatasetIdPurpose = UUID.randomUUID().toString();
+          assertEquals(
+              datasetId,
+              handle
+                  .createQuery(
+                      """
+                      INSERT INTO match_entity
+                          (dataset_id, consent, purpose, match_entity, failed)
+                      VALUES (:datasetId, 'unresolved-legacy-consent', :purpose, true, false)
+                      RETURNING dataset_id
+                      """)
+                  .bind("datasetId", datasetId)
+                  .bind("purpose", explicitDatasetIdPurpose)
+                  .mapTo(Integer.class)
+                  .one());
+          assertEquals(
+              datasetId,
+              handle
+                  .createQuery(
+                      """
+                      UPDATE match_entity
+                      SET consent = :consent, dataset_id = NULL
+                      WHERE purpose = :purpose
+                      RETURNING dataset_id
+                      """)
+                  .bind("consent", dataset.getDatasetIdentifier())
+                  .bind("purpose", explicitDatasetIdPurpose)
+                  .mapTo(Integer.class)
+                  .one());
           assertTrue(
               handle
                       .createQuery(

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -37,6 +37,12 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
             "Rollback Object " + UUID.randomUUID(),
             dataUse.toString(),
             null);
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate("UPDATE dataset SET alias = 1000000 WHERE dataset_id = :datasetId")
+                .bind("datasetId", datasetId)
+                .execute());
     Dataset dataset = datasetDAO.findDatasetById(datasetId);
     String purposeId = UUID.randomUUID().toString();
     matchDAO.insertMatch(
@@ -58,7 +64,7 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
             // DAOTestHelper clears data between tests, including Liquibase's tracking rows. Restore
             // the tracking metadata without rerunning the already-present schema changes.
             liquibase.changeLogSync(contexts, labels);
-            liquibase.rollback(4, contexts, labels);
+            liquibase.rollback(5, contexts, labels);
 
             assertTrue(columnExists(handle, "match_entity", "consent"));
             assertFalse(columnExists(handle, "match_entity", "dataset_id"));
@@ -93,7 +99,7 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
             liquibase.update(contexts, labels);
           }
 
-          assertFalse(columnExists(handle, "match_entity", "consent"));
+          assertTrue(columnExists(handle, "match_entity", "consent"));
           assertTrue(columnExists(handle, "match_entity", "dataset_id"));
           assertTrue(sequenceExists(handle, "dataset_alias_seq"));
           assertEquals(
@@ -103,6 +109,45 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
                   .bind("purpose", purposeId)
                   .mapTo(Integer.class)
                   .one());
+          assertEquals(
+              "DUOS-1000000",
+              handle
+                  .createQuery("SELECT consent FROM match_entity WHERE purpose = :purpose")
+                  .bind("purpose", purposeId)
+                  .mapTo(String.class)
+                  .one());
+          assertEquals(
+              datasetId,
+              handle
+                  .createQuery(
+                      """
+                      INSERT INTO match_entity (consent, purpose, match_entity, failed)
+                      VALUES (:consent, :purpose, true, false)
+                      RETURNING dataset_id
+                      """)
+                  .bind("consent", dataset.getDatasetIdentifier())
+                  .bind("purpose", UUID.randomUUID().toString())
+                  .mapTo(Integer.class)
+                  .one());
+          assertTrue(
+              handle
+                      .createQuery(
+                          """
+                          INSERT INTO dataset
+                              (name, create_date, create_user_id, update_date,
+                               update_user_id, object_id, data_use, alias)
+                          VALUES (:name, :createDate, :userId, :createDate,
+                                  :userId, :objectId, :dataUse, 5000000)
+                          RETURNING alias
+                          """)
+                      .bind("name", "Legacy Sequence Dataset " + UUID.randomUUID())
+                      .bind("createDate", FIXED_TIMESTAMP)
+                      .bind("userId", user.getUserId())
+                      .bind("objectId", "Legacy Sequence Object " + UUID.randomUUID())
+                      .bind("dataUse", dataUse.toString())
+                      .mapTo(Long.class)
+                      .one()
+                  < 5000000L);
           handle.commit();
         });
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -70,6 +70,25 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
                     .bind("purpose", purposeId)
                     .mapTo(String.class)
                     .one());
+            assertEquals(
+                0L,
+                handle
+                    .createQuery(
+                        """
+                        INSERT INTO dataset
+                            (name, create_date, create_user_id, update_date,
+                             update_user_id, object_id, data_use)
+                        VALUES (:name, :createDate, :userId, :createDate,
+                                :userId, :objectId, :dataUse)
+                        RETURNING alias
+                        """)
+                    .bind("name", "Legacy Default Dataset " + UUID.randomUUID())
+                    .bind("createDate", FIXED_TIMESTAMP)
+                    .bind("userId", user.getUserId())
+                    .bind("objectId", "Legacy Default Object " + UUID.randomUUID())
+                    .bind("dataUse", dataUse.toString())
+                    .mapTo(Long.class)
+                    .one());
           } finally {
             liquibase.update(contexts, labels);
           }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetIdentityMigrationTest.java
@@ -64,7 +64,7 @@ class DatasetIdentityMigrationTest extends DAOTestHelper {
             // DAOTestHelper clears data between tests, including Liquibase's tracking rows. Restore
             // the tracking metadata without rerunning the already-present schema changes.
             liquibase.changeLogSync(contexts, labels);
-            liquibase.rollback(5, contexts, labels);
+            liquibase.rollback(Integer.MAX_VALUE, contexts, labels);
 
             assertTrue(columnExists(handle, "match_entity", "consent"));
             assertFalse(columnExists(handle, "match_entity", "dataset_id"));

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,15 +36,18 @@ class MatchDAOTest extends DAOTestHelper {
     assertFalse(matches.isEmpty());
     Match found = matches.getFirst();
     assertEquals(found.getId(), m.getId());
+    assertEquals(found.getDatasetId(), m.getDatasetId());
     assertEquals(found.getPurpose(), m.getPurpose());
     assertEquals(found.getConsent(), m.getConsent());
     assertEquals(found.getFailed(), m.getFailed());
     assertEquals(found.getMatch(), m.getMatch());
   }
 
-  private Match makeMockMatch(String consentId) {
+  private Match makeMockMatch() {
+    Dataset dataset = createDataset();
     Match match = new Match();
-    match.setConsent(consentId);
+    match.setDatasetId(dataset.getDatasetId());
+    match.setConsent(dataset.getDatasetIdentifier());
     match.setPurpose(UUID.randomUUID().toString());
     match.setFailed(false);
     match.setCreateDate(FIXED_DATE);
@@ -57,7 +62,7 @@ class MatchDAOTest extends DAOTestHelper {
     Match m = createMatch();
 
     matchDAO.deleteMatchesByPurposeId(m.getPurpose());
-    List<Match> matches = matchDAO.findMatchesByPurposeId(m.getConsent());
+    List<Match> matches = matchDAO.findMatchesByPurposeId(m.getPurpose());
     assertTrue(matches.isEmpty());
   }
 
@@ -85,11 +90,11 @@ class MatchDAOTest extends DAOTestHelper {
     // Generate an unknown election to test that the query only references DataAccess elections
     Election unknownElection =
         createUnknownElection(UUID.randomUUID().toString(), dataset.getDatasetId());
-    String datasetIdentifier = dataset.getDatasetIdentifier();
+    Dataset datasetWithoutElection = createDataset();
 
     // This match represents the match record generated for the target election
     matchDAO.insertMatch(
-        datasetIdentifier,
+        dataset.getDatasetId(),
         darReferenceId,
         true,
         false,
@@ -99,7 +104,7 @@ class MatchDAOTest extends DAOTestHelper {
 
     // This match represents the match record generated for the ignored access election
     matchDAO.insertMatch(
-        datasetIdentifier,
+        dataset.getDatasetId(),
         ignoredAccessElection.getReferenceId(),
         false,
         false,
@@ -110,13 +115,23 @@ class MatchDAOTest extends DAOTestHelper {
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
-        datasetIdentifier,
+        dataset.getDatasetId(),
         unknownElection.getReferenceId(),
         false,
         false,
         FIXED_DATE,
         MatchAlgorithm.V4.getVersion(),
         true);
+
+    // A match for the same DAR but a different dataset must not join to the target election.
+    matchDAO.insertMatch(
+        datasetWithoutElection.getDatasetId(),
+        darReferenceId,
+        false,
+        false,
+        FIXED_DATE,
+        MatchAlgorithm.V4.getVersion(),
+        false);
 
     List<Match> matchResults =
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
@@ -136,11 +151,10 @@ class MatchDAOTest extends DAOTestHelper {
 
     // Generate an unknown election for test
     Election unknownElection = createUnknownElection(darReferenceId, dataset.getDatasetId());
-    String datasetIdentifier = dataset.getDatasetIdentifier();
 
     // This match represents the match record generated for the access election
     matchDAO.insertMatch(
-        datasetIdentifier,
+        dataset.getDatasetId(),
         accessElection.getReferenceId(),
         true,
         false,
@@ -151,7 +165,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
-        datasetIdentifier,
+        dataset.getDatasetId(),
         unknownElection.getReferenceId(),
         false,
         false,
@@ -170,10 +184,10 @@ class MatchDAOTest extends DAOTestHelper {
 
   @Test
   void testFindMatchById() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Match match = makeMockMatch();
     Integer matchId =
         matchDAO.insertMatch(
-            match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -182,18 +196,53 @@ class MatchDAOTest extends DAOTestHelper {
             match.getAbstain());
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
+    assertEquals(match.getDatasetId(), foundMatch.getDatasetId());
+    assertEquals(match.getConsent(), foundMatch.getConsent());
+  }
+
+  @Test
+  void testMatchUniquenessUsesPurposeAndDatasetId() {
+    Dataset firstDataset = createDataset();
+    Dataset secondDataset = createDataset();
+    String purposeId = UUID.randomUUID().toString();
+
+    matchDAO.insertMatch(
+        firstDataset.getDatasetId(),
+        purposeId,
+        true,
+        false,
+        FIXED_DATE,
+        MatchAlgorithm.V4.getVersion(),
+        false);
+    matchDAO.insertMatch(
+        secondDataset.getDatasetId(),
+        purposeId,
+        true,
+        false,
+        FIXED_DATE,
+        MatchAlgorithm.V4.getVersion(),
+        false);
+
+    Integer firstDatasetId = firstDataset.getDatasetId();
+    String algorithmVersion = MatchAlgorithm.V4.getVersion();
+
+    assertThrows(
+        UnableToExecuteStatementException.class,
+        () ->
+            matchDAO.insertMatch(
+                firstDatasetId, purposeId, false, false, FIXED_DATE, algorithmVersion, false));
   }
 
   @Test
   void testInsertFailureReason() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Match match = makeMockMatch();
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
     match.addRationale(randomAlphabetic(100));
     Integer matchId =
         matchDAO.insertMatch(
-            match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -208,14 +257,14 @@ class MatchDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteFailureReasonsByPurposeIds() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Match match = makeMockMatch();
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
     match.addRationale(randomAlphabetic(100));
     Integer matchId =
         matchDAO.insertMatch(
-            match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -235,7 +284,7 @@ class MatchDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Integer matchId =
         matchDAO.insertMatch(
-            dataset.getDatasetIdentifier(),
+            dataset.getDatasetId(),
             dar.getReferenceId(),
             randomBoolean(),
             false,

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -43,6 +43,31 @@ class MatchDAOTest extends DAOTestHelper {
     assertEquals(found.getMatch(), m.getMatch());
   }
 
+  @Test
+  void testPublicIdentifierDoesNotTruncateAliasesLongerThanSixDigits() {
+    Dataset dataset = createDataset();
+    jdbi.useHandle(
+        handle ->
+            handle
+                .createUpdate("UPDATE dataset SET alias = 1000000 WHERE dataset_id = :datasetId")
+                .bind("datasetId", dataset.getDatasetId())
+                .execute());
+    String purposeId = UUID.randomUUID().toString();
+    Integer matchId =
+        matchDAO.insertMatch(
+            dataset.getDatasetId(),
+            purposeId,
+            true,
+            false,
+            FIXED_DATE,
+            MatchAlgorithm.V4.getVersion(),
+            false);
+
+    Match match = matchDAO.findMatchById(matchId);
+
+    assertEquals("DUOS-1000000", match.getConsent());
+  }
+
   private Match makeMockMatch() {
     Dataset dataset = createDataset();
     Match match = new Match();

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -226,6 +226,19 @@ class MatchDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testInsertMatchFailsWhenDatasetDoesNotExist() {
+    Integer missingDatasetId = Integer.MAX_VALUE;
+    String purposeId = UUID.randomUUID().toString();
+    String algorithmVersion = MatchAlgorithm.V4.getVersion();
+
+    assertThrows(
+        UnableToExecuteStatementException.class,
+        () ->
+            matchDAO.insertMatch(
+                missingDatasetId, purposeId, true, false, FIXED_DATE, algorithmVersion, false));
+  }
+
+  @Test
   void testMatchUniquenessUsesPurposeAndDatasetId() {
     Dataset firstDataset = createDataset();
     Dataset secondDataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/models/MatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/MatchTest.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class MatchTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void testDatasetIdIsInternalOnly() {
+    Match match = new Match();
+    match.setDatasetId(123);
+    match.setConsent("DUOS-000123");
+
+    JsonNode json = mapper.valueToTree(match);
+
+    assertFalse(json.has("datasetId"));
+    assertEquals("DUOS-000123", json.get("consent").asText());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -94,6 +94,7 @@ class MatchServiceTest extends AbstractTestHelper {
     try {
       List<Match> matches = service.createMatchesForDataAccessRequest(dar);
       assertFalse(matches.isEmpty());
+      assertEquals(dataset.getDatasetId(), matches.getFirst().getDatasetId());
       // Each match should be false since the exception is thrown during the matching process
       matches.forEach(m -> assertFalse(m.getMatch()));
     } catch (Exception e) {
@@ -151,6 +152,7 @@ class MatchServiceTest extends AbstractTestHelper {
 
     Match match = service.singleEntitiesMatch(dataset, dar);
     assertNotNull(match);
+    assertEquals(dataset.getDatasetId(), match.getDatasetId());
     assertTrue(match.getMatch());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -30,6 +30,7 @@ import org.broadinstitute.consent.http.db.DAOTestHelper;
 import org.broadinstitute.consent.http.enumeration.AuditActions;
 import org.broadinstitute.consent.http.enumeration.DataUseTranslationType;
 import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
 import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.Dac;
@@ -82,6 +83,26 @@ class DatasetServiceDAOTest extends DAOTestHelper {
     List<DatasetAudit> audits = datasetDAO.findAuditsByDatasetId(dataset.getDatasetId());
     assertEquals(1, audits.size());
     assertEquals(AuditActions.DELETE.name(), audits.getFirst().getAction());
+  }
+
+  @Test
+  void testDeleteDatasetCascadesToMatchesAndRationales() throws Exception {
+    Dataset dataset = createDataset();
+    Integer matchId =
+        matchDAO.insertMatch(
+            dataset.getDatasetId(),
+            UUID.randomUUID().toString(),
+            true,
+            false,
+            FIXED_DATE,
+            MatchAlgorithm.V4.getVersion(),
+            false);
+    matchDAO.insertRationale(matchId, "Synthetic rationale");
+
+    serviceDAO.deleteDataset(dataset, dataset.getCreateUserId());
+
+    assertNull(datasetDAO.findDatasetById(dataset.getDatasetId()));
+    assertNull(matchDAO.findMatchById(matchId));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DatasetServiceDAOTest.java
@@ -103,6 +103,16 @@ class DatasetServiceDAOTest extends DAOTestHelper {
 
     assertNull(datasetDAO.findDatasetById(dataset.getDatasetId()));
     assertNull(matchDAO.findMatchById(matchId));
+    long rationaleCount =
+        jdbi.withHandle(
+            handle ->
+                handle
+                    .createQuery(
+                        "SELECT COUNT(*) FROM match_rationale WHERE match_entity_id = :matchId")
+                    .bind("matchId", matchId)
+                    .mapTo(Long.class)
+                    .one());
+    assertEquals(0L, rationaleCount);
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3865

### Summary

- Add `dataset_id` as the stable database identity for match persistence and relationships.
- Backfill existing matches from their legacy DUOS consent identifiers without truncating aliases longer than six digits.
- Retain and dual-write the legacy `consent` value during this compatibility release.
- Add compatibility triggers so old and new application versions can safely overlap during deployment.
- Replace `MAX(alias) + 1` allocation with a sequence-backed trigger that also supports legacy explicit alias writes.
- Cascade dataset deletion to associated matches and match rationales.
- Fail immediately when attempting to insert a match for a nonexistent dataset.
- Preserve canonical `DUOS-######` identifiers in API-facing behavior.
- Add migration, rollback, concurrency, cascade, compatibility, and DAO regression tests.

### Rollout notes

- Liquibase applies the migration automatically during application startup.
- Run the documented preflight queries before deployment.
- The migration stops if existing match identifiers cannot be resolved or would violate the new constraints.
- This is an expand/migrate compatibility release, so old and new application versions can overlap during rollout.
- No manual data migration is required when the preflight checks pass.
- A follow-up contract release is required after every environment is running the compatible application version. That release should remove the legacy `consent` column and constraint, remove the compatibility triggers, and complete the alias-allocation transition.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
