### PR TITLE
[DT-3869] Define the Study Template CSV v1 contract and fixtures

### DIFF
--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -123,9 +123,15 @@ field is absent when it has no rows; there is no encoding for an explicitly empt
 appear twice within one field.
 
 JSON in a `value` cell is therefore limited to `fileTypes` and asset payloads, which have no
-lossless flat representation. Both are optional and neither appears in a minimal template. This
-narrowing is pending confirmation with product; if hand-authored JSON is unacceptable for assets
-too, the remaining option is dropping non-file assets from v1 rather than re-encoding them.
+lossless flat representation. Both are optional and neither appears in a minimal template.
+
+Product confirmed that producers get the template by downloading it from the DUOS UI rather than
+building it from this contract. Those JSON cells are edited in place, not authored from scratch,
+which is what makes them acceptable in a user-facing template. That makes the download a v1
+dependency rather than a convenience: it must emit the header and the `templateVersion`,
+`recordType`, `recordId`, `parentRecordId`, and `field` columns for the fields being offered,
+leaving `value` empty for the producer to fill in, and it must escape leading `=`, `+`, and `@` as
+described under Spreadsheet compatibility.
 
 ## Study field mapping
 

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -29,9 +29,9 @@ platform upload limit: the shared check in `Resource#validateFileDetails` uses t
 certification documents but far too permissive for a text template.
 
 The limit is generous for the intended client. Rows average roughly 120 bytes. A study with 40
-study-level rows, 100 consent groups at about 25 rows each, and 20 asset rows is about 2,560 rows,
-or roughly 300 KB — about a tenth of the limit. A file that exceeds 5 MiB is not a study template
-that a person authored in a spreadsheet.
+study-level rows and 100 consent groups at about 25 rows each, file types included, is around 2,540
+rows, or roughly 300 KB — about a tenth of the limit. A file that exceeds 5 MiB is not a study
+template that a person authored in a spreadsheet.
 
 ### Spreadsheet compatibility
 
@@ -82,18 +82,18 @@ Each row assigns one `field` to one logical record.
 | --- | --- | --- | --- |
 | `study` | Must be `study` | Empty | One field on the single `StudyRegistrationRequest`. |
 | `consentGroup` | Unique non-empty template ID | Must be `study` | One field on a `ConsentGroupRequest`; each ID becomes one `consentGroups[]` item. |
-| `asset` | Unique non-empty template ID | Must be `study` | One supported non-file asset; `field` names the asset collection and `value` is a JSON object. |
+| `fileType` | Unique non-empty template ID | Must be a `consentGroup` `recordId` | One field on a `fileTypes[]` item belonging to that consent group. |
 
-`recordId` is template-only grouping metadata for study and consent-group records. For assets it
-also becomes the client asset identifier (`modelId`, `workspaceId`, `publicationId`,
-`presentationId`, `clinicalTrialId`, `fundingId`, or `ipId`). Numeric study and dataset IDs remain
-server-owned.
+`recordId` is template-only grouping metadata. It never reaches the wire: numeric study and dataset
+IDs remain server-owned, and `fileTypes[]` items are positional. A `fileType` record's
+`parentRecordId` must name a `consentGroup` record declared in the same file; `fileTypes` items are
+attached to that consent group in file order.
 
 Rows may appear in any order after the header. A `(recordType, recordId, field)` tuple may occur
 only once for a single-valued field; duplicate assignments are errors even if their values match.
 Scalar array fields are the one exception: they repeat the tuple once per item, as described under
-Value encoding. Unknown headers, record types, fields, and asset properties are errors and are never
-silently ignored.
+Value encoding. Unknown headers, record types, and fields are errors and are never silently
+ignored.
 
 ## Value encoding
 
@@ -105,12 +105,12 @@ silently ignored.
 | Date | ISO local date `YYYY-MM-DD`; calendar-invalid dates are rejected. |
 | URI | Absolute `http` or `https` URI. |
 | Scalar array | One row per item, repeating the same `(recordType, recordId, field)` tuple. Each `value` cell holds one plain string or enum item, encoded exactly as a single value of that kind. |
-| Object array | JSON array in one CSV cell. Used only by `fileTypes`. |
-| Object | JSON object in one CSV cell. Used only for supported asset payloads. |
 | Empty value | An empty `value` cell means absent (`null`), not an empty string or empty array. Omit optional fields; empty required values fail validation. |
 
-Every array-typed field is a scalar array except `fileTypes`, which is an object array. So the wire
-value `["Genomic","Phenotypic"]` is two rows, and neither cell needs quoting:
+Every `value` cell is a single scalar. **v1 has no JSON encoding at all**: structured wire values
+are expressed as rows, not as embedded documents. Arrays of scalars repeat their row, and the one
+array of objects, `fileTypes`, is its own record type. So the wire value `["Genomic","Phenotypic"]`
+is two rows, and neither cell needs quoting:
 
 ```csv
 1,study,study,,dataTypes,Genomic
@@ -122,16 +122,16 @@ field is absent when it has no rows; there is no encoding for an explicitly empt
 `value` cell on a repeated row is an error, not a skipped item, and the same item value may not
 appear twice within one field.
 
-JSON in a `value` cell is therefore limited to `fileTypes` and asset payloads, which have no
-lossless flat representation. Both are optional and neither appears in a minimal template.
+Product asked for a template with no JSON in it, which is what set the v1 boundary: the wire
+properties that cannot be expressed as scalar rows without inventing new encodings are excluded from
+v1 rather than embedded as JSON. That is why non-file assets are not in this contract.
 
-Product confirmed that producers get the template by downloading it from the DUOS UI rather than
-building it from this contract. Those JSON cells are edited in place, not authored from scratch,
-which is what makes them acceptable in a user-facing template. That makes the download a v1
-dependency rather than a convenience: it must emit the header and the `templateVersion`,
-`recordType`, `recordId`, `parentRecordId`, and `field` columns for the fields being offered,
-leaving `value` empty for the producer to fill in, and it must escape leading `=`, `+`, and `@` as
-described under Spreadsheet compatibility.
+Product also confirmed that producers get the template by downloading it from the DUOS UI rather
+than building it from this contract. The download is therefore a v1 dependency rather than a
+convenience: it must emit the header and the `templateVersion`, `recordType`, `recordId`,
+`parentRecordId`, and `field` columns for the fields being offered, leaving `value` empty for the
+producer to fill in, and it must escape leading `=`, `+`, and `@` as described under Spreadsheet
+compatibility.
 
 ## Study field mapping
 
@@ -173,7 +173,7 @@ The following wire properties are deliberately not direct template fields:
 | Wire property | Reason |
 | --- | --- |
 | `consentGroups` | Constructed from `consentGroup` records. |
-| `assets` | Constructed from `asset` records. |
+| `assets` | Non-file assets are out of scope for v1. See below. |
 | All `alternativeDataSharingPlan*` properties | The alternative sharing plan is file-backed and its file cannot be uploaded through the template. See below. |
 | `data` | Opaque client metadata is not part of the stable v1 contract. |
 | `externalIdentifier`, `externalIdentifierType` | Integration-owned identifiers are outside this user-authored template. |
@@ -184,7 +184,17 @@ the template cannot carry, so importing them would populate a draft that still c
 without returning to the form for the file. A user who needs an alternative sharing plan fills that
 section in on the populated draft, where the file upload lives, and the group is a candidate for a
 later template version once file-bearing imports are supported. (Confirmed as the intended v1 scope
-with @otchet-broad; pending confirmation from @jlaw-codes.)
+with @otchet-broad and @jlaw-codes.)
+
+Non-file assets — models, workspaces, publications, presentations, clinical trials, funding, and
+intellectual properties — are excluded from v1 for a different reason. Their payloads nest: a
+publication carries an `authors` array of `Author` objects, a presentation carries a `presenter`
+object, and a model carries a `maintainer` object. Expressing those without JSON needs encodings
+this contract otherwise has no use for, such as dotted field paths or a second level of child
+records, which is a poor trade in a template meant to be filled in by hand. Assets are optional,
+additive metadata: excluding them leaves nothing blocked, since a user can add them on the populated
+draft the same way they do today. They are the first candidate for v2, where they can be designed as
+records rather than retrofitted. (Product preference for no JSON confirmed by @jlaw-codes.)
 
 NIH institutional certification files are also excluded. They are not fields on the canonical wire
 request and must be uploaded on the populated draft form.
@@ -217,32 +227,32 @@ Wire paths are relative to one `consentGroups[]` item.
 | `url` | `url` | URI | Optional absolute HTTP(S) data URL. |
 | `requestLocation` | `requestLocation` | URI | Optional absolute HTTP(S) external-request URL. |
 | `numberOfParticipants` | `numberOfParticipants` | Integer | Required. |
-| `fileTypes` | `fileTypes` | Object array | Optional; each item has exact `fileType` and optional `functionalEquivalence`. These describe data formats, not uploads. |
+| `fileTypes` | `fileTypes` | Object array | Optional; supplied as `fileType` records, not as a field on this record. See below. |
 
 Primary data-use rules are unchanged: `open` requires no primary data use; `controlled` and
 `external` require exactly one of general research use, HMB, disease-specific use, POA, or other.
 `datasetId` is server-assigned, and the opaque consent-group `data` property is unsupported.
 
-## Non-file asset mapping
+## File-type mapping
 
-An asset record contains exactly one row. Its `field` is one collection name below and its `value`
-is a JSON object using existing duos-ui property names. It maps to
-`StudyRegistrationRequest.assets.<field>[]`.
+`fileTypes` is the only array of objects in v1, so it is a record type rather than a field. Each
+`fileType` record contributes one `fileTypes[]` item to the consent group named by its
+`parentRecordId`. These describe data formats; they are not uploads.
 
-| Asset `field` | `recordId` maps to | Required JSON properties | Optional JSON properties |
+| CSV `field` | Wire target | Type | Requirement / existing rule |
 | --- | --- | --- | --- |
-| `models` | `modelId` | `name`, `url`, `format`, `license`, `maintainer` (`name`, `email`) | `description`, `cloud`, `trainedOnDatasets`, `tags` |
-| `workspaces` | `workspaceId` | `name`, `platform`, `url`, `description` | `cloud`, `tools`, `access`, `tags` |
-| `publications` | `publicationId` | `title`, `publishedDate`, `authors`, `datasetCitation`, `citation`, `journal`, `doi` | `pubmedId`, `bibliographicCitation`, `url`, `access`, `tags` |
-| `presentations` | `presentationId` | `title`, `date`, `citation` | `url`, `authors`, `datasetCitation`, `presenter`, `event`, `location`, `format`, `access`, `tags` |
-| `clinicalTrials` | `clinicalTrialId` | `title`, `registry`, `identifier`, `status`, `sponsor`, `startDate`, `interventionType`, `description`, `phase`, `url` | `endDate`, `tags` |
-| `funding` | `fundingId` | `funderName`, `funderProgram`, `grantNumber`, `projectTitle`, `url` | `startDate`, `endDate`, `tags` |
-| `intellectualProperties` | `ipId` | `type`, `title`, `assignee`, `patentNumber`, `filingDate`, `status`, `url`, `contact` | `tags` |
+| `fileType` | `fileType` | Enum | Required; exact `FileType` wire value. |
+| `functionalEquivalence` | `functionalEquivalence` | String | Optional. |
 
-Asset objects must not contain their ID property or `studyId`; the importer supplies the ID from
-`recordId`, and draft/study processing supplies `studyId`. Biospecimens are excluded because the
-current study form does not allow users to add them. No file-storage object or file-content asset is
-supported.
+```csv
+1,consentGroup,dataset-controlled,study,consentGroupName,Synthetic Controlled Dataset
+1,fileType,ft-genome,dataset-controlled,fileType,Genome
+1,fileType,ft-genome,dataset-controlled,functionalEquivalence,Synthetic reference build
+```
+
+A `fileType` record whose `parentRecordId` does not name a `consentGroup` record in the same file is
+an orphan and is rejected. Biospecimens are excluded because the current study form does not allow
+users to add them, and no file-storage object or file-content asset is supported.
 
 ## Invalid-input behavior
 
@@ -265,11 +275,11 @@ preserving aggregation across otherwise independent fields.
 | Missing, unknown, reordered, or duplicate header | Reject. |
 | Non-comma delimiter detected in the header | Reject, naming the detected character and asking for a comma-delimited re-export. |
 | Missing, unsupported, or mixed version | Reject affected rows; only major version `1` is supported. |
-| Unknown record type, field, asset collection, or asset property | Reject the row. |
+| Unknown record type or field | Reject the row. |
 | Duplicate `(recordType, recordId, field)` on a single-valued field | Reject the later assignment. |
 | Repeated item value within one scalar array field | Reject the later row. |
 | Missing parent, multiple study records, or orphan record | Reject the affected record. |
-| Empty required value, empty scalar array item, or invalid scalar/JSON | Reject with row and column context. |
+| Empty required value, empty scalar array item, or invalid scalar | Reject with row and column context. |
 | Existing registration-rule violation | Reject with the existing validator message; row and column may be absent. |
 
 Errors and general logs must not echo raw rows or sensitive free-text values.
@@ -286,6 +296,7 @@ Fixtures live under `src/test/resources/fixtures/study-template/v1`:
 - `invalid/duplicate-field.csv`
 - `invalid/semicolon-delimited.csv` — a European-locale Excel export
 - `invalid/duplicate-array-item.csv`
+- `invalid/orphan-file-type.csv`
 - `invalid/unknown-field.csv`
 - `invalid/unsupported-version.csv`
 - `invalid/field-values.csv`
@@ -330,13 +341,13 @@ On success, route with the exact returned draft UUID and require
 `draftType === 'StudyDatasetSubmissionV1'`. The loaded document has the
 `StudyRegistrationRequest` wire shape described by this contract. Hydration must:
 
-- populate supported study fields, consent groups, and non-file assets;
-- leave file upload controls empty;
+- populate supported study fields, consent groups, and their file types;
+- leave file upload controls empty and asset sections untouched;
 - allow review and edits through the existing study registration form; and
 - submit through the existing study-creation path.
 
-The CSV contract's `recordId` values are template grouping keys. Consent converts asset record IDs
-to the corresponding client asset ID. Numeric study and dataset IDs remain server-owned.
+The CSV contract's `recordId` values are template grouping keys and do not reach the wire. Numeric
+study and dataset IDs remain server-owned.
 
 ## Approval gate
 

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -61,8 +61,8 @@ fields, and asset properties are errors and are never silently ignored.
 | Integer | Base-10 digits with an optional leading minus sign; no decimal point or separator. Domain validation may reject negative values. |
 | Date | ISO local date `YYYY-MM-DD`; calendar-invalid dates are rejected. |
 | URI | Absolute `http` or `https` URI. |
-| Array | Compact JSON array in one CSV cell, such as `["Genomic","Phenotypic"]`. CSV escaping still applies. |
-| Object | Compact JSON object in one CSV cell, used only for supported asset payloads and `fileTypes` entries. |
+| Array | JSON array in one CSV cell, such as `["Genomic","Phenotypic"]`. CSV escaping still applies. |
+| Object | JSON object in one CSV cell, used only for supported asset payloads and `fileTypes` entries. |
 | Empty value | An empty `value` cell means absent (`null`), not an empty string or empty array. Omit optional fields; empty required values fail validation. |
 
 For example, `["Genomic","Phenotypic"]` is represented as this CSV cell:

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -1,0 +1,278 @@
+# Study Template CSV Contract v1
+
+Jira: [DT-3869](https://broadworkbench.atlassian.net/browse/DT-3869)
+
+Status: **product and Consent API owner approval required before dependent parser or endpoint work
+merges**
+
+This is the canonical v1 contract for importing one study and its datasets into a DUOS study
+registration draft. It maps template fields to Consent's `StudyRegistrationRequest` wire contract;
+it does not define a new registration API or replace existing registration validation.
+
+Canonical synthetic fixtures live in `src/test/resources/fixtures/study-template/v1`, where Consent
+parser tests can load them directly. DT-3869 itself does not implement parsing or UI behavior.
+
+## File contract
+
+- File extension: `.csv`.
+- Maximum size: 5 MiB (5,242,880 bytes), including a UTF-8 BOM when present.
+- Encoding: UTF-8. A UTF-8 BOM is accepted only at the beginning of the file.
+- Dialect: RFC 4180-style comma-separated values. Double quotes enclose values; a literal quote is
+  escaped as `""`. CRLF and LF record separators are accepted.
+- One file represents exactly one study.
+- The case-sensitive header is required exactly once and in this order:
+
+```text
+templateVersion,recordType,recordId,parentRecordId,field,value
+```
+
+- `templateVersion` is required on every data row and must be major version `1`. Mixed or
+  unsupported versions are errors.
+- Blank physical lines may be ignored. A zero-byte, BOM-only, header-only, or otherwise record-free
+  file is invalid.
+- Leading and trailing whitespace is significant in string values. Producers should not add
+  whitespace around unquoted values.
+
+## Record model
+
+Each row assigns one `field` to one logical record.
+
+| `recordType` | `recordId` | `parentRecordId` | Meaning |
+| --- | --- | --- | --- |
+| `study` | Must be `study` | Empty | One field on the single `StudyRegistrationRequest`. |
+| `consentGroup` | Unique non-empty template ID | Must be `study` | One field on a `ConsentGroupRequest`; each ID becomes one `consentGroups[]` item. |
+| `asset` | Unique non-empty template ID | Must be `study` | One supported non-file asset; `field` names the asset collection and `value` is a JSON object. |
+
+`recordId` is template-only grouping metadata for study and consent-group records. For assets it
+also becomes the client asset identifier (`modelId`, `workspaceId`, `publicationId`,
+`presentationId`, `clinicalTrialId`, `fundingId`, or `ipId`). Numeric study and dataset IDs remain
+server-owned.
+
+Rows may appear in any order after the header. A `(recordType, recordId, field)` tuple may occur only
+once; duplicate assignments are errors even if their values match. Unknown headers, record types,
+fields, and asset properties are errors and are never silently ignored.
+
+## Value encoding
+
+| Kind | Encoding |
+| --- | --- |
+| String or enum | Exact wire value; enum matching is case-sensitive. Use normal CSV quoting for commas, quotes, or line breaks. |
+| Boolean | Exactly lowercase `true` or `false`. |
+| Integer | Base-10 digits with an optional leading minus sign; no decimal point or separator. Domain validation may reject negative values. |
+| Date | ISO local date `YYYY-MM-DD`; calendar-invalid dates are rejected. |
+| URI | Absolute `http` or `https` URI. |
+| Array | Compact JSON array in one CSV cell, such as `["Genomic","Phenotypic"]`. CSV escaping still applies. |
+| Object | Compact JSON object in one CSV cell, used only for supported asset payloads and `fileTypes` entries. |
+| Empty value | An empty `value` cell means absent (`null`), not an empty string or empty array. Omit optional fields; empty required values fail validation. |
+
+For example, `["Genomic","Phenotypic"]` is represented as this CSV cell:
+
+```csv
+"[""Genomic"",""Phenotypic""]"
+```
+
+## Study field mapping
+
+Wire paths are relative to `StudyRegistrationRequest`. Conditional requirements reuse Consent's
+existing `StudyRegistrationRequestValidator` rules.
+
+| CSV `field` | Wire target | Type | Requirement / existing rule |
+| --- | --- | --- | --- |
+| `studyName` | `studyName` | String | Required and non-blank. |
+| `studyType` | `studyType` | Enum | Optional; exact `StudyType` wire value. |
+| `studyDescription` | `studyDescription` | String | Required and non-blank. |
+| `dataTypes` | `dataTypes` | String array | Required and non-empty. |
+| `phenotypeIndication` | `phenotypeIndication` | String | Optional. |
+| `species` | `species` | String | Optional. |
+| `piName` | `piName` | String | Required and non-blank. |
+| `piEmail` | `piEmail` | String | Optional; must be a valid email when present. |
+| `dataCustodianEmail` | `dataCustodianEmail` | String array | Optional; every non-empty item must be a valid email. |
+| `publicVisibility` | `publicVisibility` | Boolean | Required. |
+| `throughBioId` | `throughBioId` | String | Optional. |
+| `nihAnvilUse` | `nihAnvilUse` | Enum | Required; exact `NihAnvilUse` wire value. |
+| `submittingToAnvil` | `submittingToAnvil` | Boolean | Optional. |
+| `dbGaPPhsID` | `dbGaPPhsID` | String | Required when `nihAnvilUse` states that an existing dbGaP PHS ID is available. |
+| `dbGaPStudyRegistrationName` | `dbGaPStudyRegistrationName` | String | Optional. |
+| `embargoReleaseDate` | `embargoReleaseDate` | Date | Optional; valid ISO local date when present. |
+| `sequencingCenter` | `sequencingCenter` | String | Optional. |
+| `piInstitution` | `piInstitution` | Integer | Required for NHGRI-funded or AnVIL-seeking `nihAnvilUse` choices; an existing DUOS institution ID. |
+| `nihGrantContractNumber` | `nihGrantContractNumber` | String | Required for NHGRI-funded or AnVIL-seeking `nihAnvilUse` choices. |
+| `nihICsSupportingStudy` | `nihICsSupportingStudy` | Enum array | Optional; exact NIH institute/center abbreviations. |
+| `nihProgramOfficerName` | `nihProgramOfficerName` | String | Optional. |
+| `nihInstitutionCenterSubmission` | `nihInstitutionCenterSubmission` | Enum | Optional; exact NIH institute/center abbreviation. |
+| `nihGenomicProgramAdministratorName` | `nihGenomicProgramAdministratorName` | String | Optional. |
+| `multiCenterStudy` | `multiCenterStudy` | Boolean | Optional. |
+| `collaboratingSites` | `collaboratingSites` | String array | Optional. |
+| `controlledAccessRequiredForGenomicSummaryResultsGSR` | Same name | Boolean | Optional. |
+| `controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation` | Same name | String | Required when controlled GSR access is `true`. |
+| `alternativeDataSharingPlan` | `alternativeDataSharingPlan` | Boolean | Optional. |
+| `alternativeDataSharingPlanReasons` | `alternativeDataSharingPlanReasons` | Enum array | Required and non-empty when an alternative plan is `true`. |
+| `alternativeDataSharingPlanExplanation` | `alternativeDataSharingPlanExplanation` | String | Required when an alternative plan is `true`. |
+| `alternativeDataSharingPlanDataSubmitted` | Same name | Enum | Optional; exact wire value. |
+| `alternativeDataSharingPlanDataReleased` | Same name | Boolean | Optional. |
+| `alternativeDataSharingPlanTargetDeliveryDate` | Same name | Date | Optional; valid ISO local date when present. |
+| `alternativeDataSharingPlanTargetPublicReleaseDate` | Same name | Date | Optional; valid ISO local date when present. |
+| `alternativeDataSharingPlanAccessManagement` | Same name | Enum | Optional; exact wire value. |
+
+The following wire properties are deliberately not direct template fields:
+
+| Wire property | Reason |
+| --- | --- |
+| `consentGroups` | Constructed from `consentGroup` records. |
+| `assets` | Constructed from `asset` records. |
+| `alternativeDataSharingPlanFileName` | File-backed and filename-only fields are unsupported. Add the actual file on the populated draft form. |
+| `data` | Opaque client metadata is not part of the stable v1 contract. |
+| `externalIdentifier`, `externalIdentifierType` | Integration-owned identifiers are outside this user-authored template. |
+
+NIH institutional certification files are also excluded. They are not fields on the canonical wire
+request and must be uploaded on the populated draft form.
+
+## Consent-group field mapping
+
+Wire paths are relative to one `consentGroups[]` item.
+
+| CSV `field` | Wire target | Type | Requirement / existing rule |
+| --- | --- | --- | --- |
+| `consentGroupName` | `consentGroupName` | String | Required and non-blank; displayed as the dataset name. |
+| `accessManagement` | `accessManagement` | Enum | Required by this template contract: `open`, `controlled`, or `external`. |
+| `generalResearchUse` | `generalResearchUse` | Boolean | Primary data-use option. |
+| `hmb` | `hmb` | Boolean | Primary data-use option. |
+| `diseaseSpecificUse` | `diseaseSpecificUse` | String array | Primary data-use option; selected when non-empty. |
+| `poa` | `poa` | Boolean | Primary data-use option. |
+| `otherPrimary` | `otherPrimary` | String | Primary data-use option; selected when non-blank. |
+| `nmds` | `nmds` | Boolean | Optional secondary restriction. |
+| `gso` | `gso` | Boolean | Optional secondary restriction. |
+| `pub` | `pub` | Boolean | Optional secondary restriction. |
+| `col` | `col` | Boolean | Optional secondary restriction. |
+| `irb` | `irb` | Boolean | Optional secondary restriction. |
+| `gs` | `gs` | String | Optional geographic restriction. |
+| `mor` | `mor` | Boolean | Optional publication-moratorium flag. |
+| `morDate` | `morDate` | Date | Optional; valid ISO local date when present. |
+| `npu` | `npu` | Boolean | Optional non-profit-use restriction. |
+| `otherSecondary` | `otherSecondary` | String | Optional secondary restriction. |
+| `dataAccessCommitteeId` | `dataAccessCommitteeId` | Integer | Required for `controlled`; an existing DUOS DAC ID. Not required for `open` or `external`. |
+| `dataLocation` | `dataLocation` | Enum | Optional; exact `DataLocation` wire value. |
+| `url` | `url` | URI | Optional absolute HTTP(S) data URL. |
+| `requestLocation` | `requestLocation` | URI | Optional absolute HTTP(S) external-request URL. |
+| `numberOfParticipants` | `numberOfParticipants` | Integer | Required. |
+| `fileTypes` | `fileTypes` | Object array | Optional; each item has exact `fileType` and optional `functionalEquivalence`. These describe data formats, not uploads. |
+
+Primary data-use rules are unchanged: `open` requires no primary data use; `controlled` and
+`external` require exactly one of general research use, HMB, disease-specific use, POA, or other.
+`datasetId` is server-assigned, and the opaque consent-group `data` property is unsupported.
+
+## Non-file asset mapping
+
+An asset record contains exactly one row. Its `field` is one collection name below and its `value`
+is a JSON object using existing duos-ui property names. It maps to
+`StudyRegistrationRequest.assets.<field>[]`.
+
+| Asset `field` | `recordId` maps to | Required JSON properties | Optional JSON properties |
+| --- | --- | --- | --- |
+| `models` | `modelId` | `name`, `url`, `format`, `license`, `maintainer` (`name`, `email`) | `description`, `cloud`, `trainedOnDatasets`, `tags` |
+| `workspaces` | `workspaceId` | `name`, `platform`, `url`, `description` | `cloud`, `tools`, `access`, `tags` |
+| `publications` | `publicationId` | `title`, `publishedDate`, `authors`, `datasetCitation`, `citation`, `journal`, `doi` | `pubmedId`, `bibliographicCitation`, `url`, `access`, `tags` |
+| `presentations` | `presentationId` | `title`, `date`, `citation` | `url`, `authors`, `datasetCitation`, `presenter`, `event`, `location`, `format`, `access`, `tags` |
+| `clinicalTrials` | `clinicalTrialId` | `title`, `registry`, `identifier`, `status`, `sponsor`, `startDate`, `interventionType`, `description`, `phase`, `url` | `endDate`, `tags` |
+| `funding` | `fundingId` | `funderName`, `funderProgram`, `grantNumber`, `projectTitle`, `url` | `startDate`, `endDate`, `tags` |
+| `intellectualProperties` | `ipId` | `type`, `title`, `assignee`, `patentNumber`, `filingDate`, `status`, `url`, `contact` | `tags` |
+
+Asset objects must not contain their ID property or `studyId`; the importer supplies the ID from
+`recordId`, and draft/study processing supplies `studyId`. Biospecimens are excluded because the
+current study form does not allow users to add them. No file-storage object or file-content asset is
+supported.
+
+## Invalid-input behavior
+
+Validation collects independently actionable errors in deterministic order: file/structure errors,
+then row conversion errors in file order, then existing DTO/domain violations in validator order.
+Return at most 100 errors and report explicitly if additional errors were omitted.
+
+File and structural errors stop validation before DTO construction because the record model is not
+trustworthy. Once structure is valid, conversion and DTO/domain validation may both report errors.
+A field with a conversion error is omitted from the DTO, but its derivative required or conditional
+DTO violation is suppressed; the conversion error is the actionable error for that field. Independent
+DTO/domain violations are still reported. This prevents duplicate or misleading errors while
+preserving aggregation across otherwise independent fields.
+
+| Condition | Behavior |
+| --- | --- |
+| Empty or record-free file | Reject; no draft is created. |
+| File larger than 5 MiB | Reject before parsing; no draft is created. |
+| Malformed CSV or invalid UTF-8 | Reject with location when known. |
+| Missing, unknown, reordered, or duplicate header | Reject. |
+| Missing, unsupported, or mixed version | Reject affected rows; only major version `1` is supported. |
+| Unknown record type, field, asset collection, or asset property | Reject the row. |
+| Duplicate `(recordType, recordId, field)` | Reject the later assignment. |
+| Missing parent, multiple study records, or orphan record | Reject the affected record. |
+| Empty required value or invalid scalar/JSON | Reject with row and column context. |
+| Existing registration-rule violation | Reject with the existing validator message; row and column may be absent. |
+
+Errors and general logs must not echo raw rows or sensitive free-text values.
+
+## Canonical fixtures
+
+Fixtures live under `src/test/resources/fixtures/study-template/v1`:
+
+- `valid/minimal-valid.csv`
+- `valid/multi-consent-group-valid.csv`
+- `invalid/empty-file.csv`
+- `invalid/duplicate-header.csv`
+- `invalid/duplicate-field.csv`
+- `invalid/unknown-field.csv`
+- `invalid/unsupported-version.csv`
+- `invalid/field-values.csv`
+
+Every invalid CSV has a sibling `.errors.json` file containing the expected structured errors. All
+values are synthetic and contain no production study, participant, user, institution, or DAC data.
+
+## Validation error contract
+
+Expected CSV and registration errors are returned as a completed validation result, not as thrown
+request failures:
+
+```ts
+interface TemplateValidationError {
+  row?: number
+  column?: string
+  message: string
+}
+
+type TemplateValidationResponse =
+  | { valid: false, errors: TemplateValidationError[] }
+  | {
+      valid: true
+      errors: []
+      draft: {
+        id: string
+        draftType: 'StudyDatasetSubmissionV1'
+      }
+    }
+```
+
+`row` is one-based and counts the CSV header as row 1. Parser and conversion errors include row and
+column when known. Violations from the existing registration validator may contain only a message;
+the UI must not infer locations by parsing that message.
+
+Authentication, authorization, multipart, size-limit, network, and unexpected server failures are
+request failures and must be rendered separately from `valid: false` results.
+
+## Draft hydration boundary
+
+On success, route with the exact returned draft UUID and require
+`draftType === 'StudyDatasetSubmissionV1'`. The loaded document has the
+`StudyRegistrationRequest` wire shape described by this contract. Hydration must:
+
+- populate supported study fields, consent groups, and non-file assets;
+- leave file upload controls empty;
+- allow review and edits through the existing study registration form; and
+- submit through the existing study-creation path.
+
+The CSV contract's `recordId` values are template grouping keys. Consent converts asset record IDs
+to the corresponding client asset ID. Numeric study and dataset IDs remain server-owned.
+
+## Approval gate
+
+Product and Consent API owners must approve the canonical contract before dependent parser and
+endpoint work merges. Approval is tracked in DT-3869 and its pull requests, not in this consumer
+summary.

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -20,6 +20,47 @@ parser tests can load them directly. DT-3869 itself does not implement parsing o
 - Dialect: RFC 4180-style comma-separated values. Double quotes enclose values; a literal quote is
   escaped as `""`. CRLF and LF record separators are accepted.
 - One file represents exactly one study.
+
+### Size limit rationale
+
+5 MiB is a template-specific limit that the import endpoint must enforce itself. It is not the
+platform upload limit: the shared check in `Resource#validateFileDetails` uses the OWASP
+`FileValidator` default of 500,000,000 bytes (500 MB), which is appropriate for institutional
+certification documents but far too permissive for a text template.
+
+The limit is generous for the intended client. Rows average roughly 120 bytes. A study with 40
+study-level rows, 100 consent groups at about 25 rows each, and 20 asset rows is about 2,560 rows,
+or roughly 300 KB — about a tenth of the limit. A file that exceeds 5 MiB is not a study template
+that a person authored in a spreadsheet.
+
+### Spreadsheet compatibility
+
+Producers are expected to author templates in Excel or Google Sheets, so v1 accepts what those tools
+emit by default:
+
+| Producer behavior | v1 handling |
+| --- | --- |
+| CRLF record separators (Excel default) | Accepted; LF is also accepted. |
+| UTF-8 BOM (Excel "CSV UTF-8 (Comma delimited)") | Accepted at the beginning of the file only. |
+| Quoting only cells that need it | Accepted; quoting is per RFC 4180 and never required for cells without commas, quotes, or line breaks. |
+| Trailing blank lines at end of file | Ignored. |
+| Google Sheets "Download → Comma-separated values" | Accepted; it is comma-delimited UTF-8 without a BOM. |
+
+Excel is not strictly RFC 4180-conformant, and two of its deviations are rejected rather than
+guessed at:
+
+- **Locale list separator.** Excel writes the Windows list separator, which is a semicolon in many
+  European locales. v1 is comma-delimited only. When the header row parses as a single cell that
+  contains a semicolon or a tab, reject with an actionable message naming the detected character and
+  telling the producer to re-export as comma-delimited, rather than reporting a missing header. An
+  optional producer-supplied delimiter is a deferred v2 item, not a v1 requirement.
+- **Value auto-formatting.** Excel may coerce cells that look like dates or long numbers, so a
+  `value` cell can arrive as `15-Jan-2026` or in scientific notation. v1 does not reverse this. Such
+  values fail their field's normal type rule with the usual row and column context.
+
+The importer treats every cell as literal text and never evaluates a leading `=`, `+`, or `@` as a
+formula. Any template Consent generates for download must escape those prefixes so the exported file
+is not a CSV-injection vector in the producer's spreadsheet application.
 - The case-sensitive header is required exactly once and in this order:
 
 ```text
@@ -48,9 +89,11 @@ also becomes the client asset identifier (`modelId`, `workspaceId`, `publication
 `presentationId`, `clinicalTrialId`, `fundingId`, or `ipId`). Numeric study and dataset IDs remain
 server-owned.
 
-Rows may appear in any order after the header. A `(recordType, recordId, field)` tuple may occur only
-once; duplicate assignments are errors even if their values match. Unknown headers, record types,
-fields, and asset properties are errors and are never silently ignored.
+Rows may appear in any order after the header. A `(recordType, recordId, field)` tuple may occur
+only once for a single-valued field; duplicate assignments are errors even if their values match.
+Scalar array fields are the one exception: they repeat the tuple once per item, as described under
+Value encoding. Unknown headers, record types, fields, and asset properties are errors and are never
+silently ignored.
 
 ## Value encoding
 
@@ -61,15 +104,28 @@ fields, and asset properties are errors and are never silently ignored.
 | Integer | Base-10 digits with an optional leading minus sign; no decimal point or separator. Domain validation may reject negative values. |
 | Date | ISO local date `YYYY-MM-DD`; calendar-invalid dates are rejected. |
 | URI | Absolute `http` or `https` URI. |
-| Array | JSON array in one CSV cell, such as `["Genomic","Phenotypic"]`. CSV escaping still applies. |
-| Object | JSON object in one CSV cell, used only for supported asset payloads and `fileTypes` entries. |
+| Scalar array | One row per item, repeating the same `(recordType, recordId, field)` tuple. Each `value` cell holds one plain string or enum item, encoded exactly as a single value of that kind. |
+| Object array | JSON array in one CSV cell. Used only by `fileTypes`. |
+| Object | JSON object in one CSV cell. Used only for supported asset payloads. |
 | Empty value | An empty `value` cell means absent (`null`), not an empty string or empty array. Omit optional fields; empty required values fail validation. |
 
-For example, `["Genomic","Phenotypic"]` is represented as this CSV cell:
+Every array-typed field is a scalar array except `fileTypes`, which is an object array. So the wire
+value `["Genomic","Phenotypic"]` is two rows, and neither cell needs quoting:
 
 ```csv
-"[""Genomic"",""Phenotypic""]"
+1,study,study,,dataTypes,Genomic
+1,study,study,,dataTypes,Phenotypic
 ```
+
+Repeated rows are collected in file order and that order is preserved on the wire. A scalar array
+field is absent when it has no rows; there is no encoding for an explicitly empty array. An empty
+`value` cell on a repeated row is an error, not a skipped item, and the same item value may not
+appear twice within one field.
+
+JSON in a `value` cell is therefore limited to `fileTypes` and asset payloads, which have no
+lossless flat representation. Both are optional and neither appears in a minimal template. This
+narrowing is pending confirmation with product; if hand-authored JSON is unacceptable for assets
+too, the remaining option is dropping non-file assets from v1 rather than re-encoding them.
 
 ## Study field mapping
 
@@ -86,7 +142,7 @@ existing `StudyRegistrationRequestValidator` rules.
 | `species` | `species` | String | Optional. |
 | `piName` | `piName` | String | Required and non-blank. |
 | `piEmail` | `piEmail` | String | Optional; must be a valid email when present. |
-| `dataCustodianEmail` | `dataCustodianEmail` | String array | Optional; every non-empty item must be a valid email. |
+| `dataCustodianEmail` | `dataCustodianEmail` | String array | Optional; every item must be a valid email. |
 | `publicVisibility` | `publicVisibility` | Boolean | Required. |
 | `throughBioId` | `throughBioId` | String | Optional. |
 | `nihAnvilUse` | `nihAnvilUse` | Enum | Required; exact `NihAnvilUse` wire value. |
@@ -105,14 +161,6 @@ existing `StudyRegistrationRequestValidator` rules.
 | `collaboratingSites` | `collaboratingSites` | String array | Optional. |
 | `controlledAccessRequiredForGenomicSummaryResultsGSR` | Same name | Boolean | Optional. |
 | `controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation` | Same name | String | Required when controlled GSR access is `true`. |
-| `alternativeDataSharingPlan` | `alternativeDataSharingPlan` | Boolean | Optional. |
-| `alternativeDataSharingPlanReasons` | `alternativeDataSharingPlanReasons` | Enum array | Required and non-empty when an alternative plan is `true`. |
-| `alternativeDataSharingPlanExplanation` | `alternativeDataSharingPlanExplanation` | String | Required when an alternative plan is `true`. |
-| `alternativeDataSharingPlanDataSubmitted` | Same name | Enum | Optional; exact wire value. |
-| `alternativeDataSharingPlanDataReleased` | Same name | Boolean | Optional. |
-| `alternativeDataSharingPlanTargetDeliveryDate` | Same name | Date | Optional; valid ISO local date when present. |
-| `alternativeDataSharingPlanTargetPublicReleaseDate` | Same name | Date | Optional; valid ISO local date when present. |
-| `alternativeDataSharingPlanAccessManagement` | Same name | Enum | Optional; exact wire value. |
 
 The following wire properties are deliberately not direct template fields:
 
@@ -120,9 +168,17 @@ The following wire properties are deliberately not direct template fields:
 | --- | --- |
 | `consentGroups` | Constructed from `consentGroup` records. |
 | `assets` | Constructed from `asset` records. |
-| `alternativeDataSharingPlanFileName` | File-backed and filename-only fields are unsupported. Add the actual file on the populated draft form. |
+| All `alternativeDataSharingPlan*` properties | The alternative sharing plan is file-backed and its file cannot be uploaded through the template. See below. |
 | `data` | Opaque client metadata is not part of the stable v1 contract. |
 | `externalIdentifier`, `externalIdentifierType` | Integration-owned identifiers are outside this user-authored template. |
+
+The whole `alternativeDataSharingPlan*` group is excluded, not just
+`alternativeDataSharingPlanFileName`. The remaining properties only describe a plan whose document
+the template cannot carry, so importing them would populate a draft that still cannot be completed
+without returning to the form for the file. A user who needs an alternative sharing plan fills that
+section in on the populated draft, where the file upload lives, and the group is a candidate for a
+later template version once file-bearing imports are supported. (Confirmed as the intended v1 scope
+with @otchet-broad; pending confirmation from @jlaw-codes.)
 
 NIH institutional certification files are also excluded. They are not fields on the canonical wire
 request and must be uploaded on the populated draft form.
@@ -201,11 +257,13 @@ preserving aggregation across otherwise independent fields.
 | File larger than 5 MiB | Reject before parsing; no draft is created. |
 | Malformed CSV or invalid UTF-8 | Reject with location when known. |
 | Missing, unknown, reordered, or duplicate header | Reject. |
+| Non-comma delimiter detected in the header | Reject, naming the detected character and asking for a comma-delimited re-export. |
 | Missing, unsupported, or mixed version | Reject affected rows; only major version `1` is supported. |
 | Unknown record type, field, asset collection, or asset property | Reject the row. |
-| Duplicate `(recordType, recordId, field)` | Reject the later assignment. |
+| Duplicate `(recordType, recordId, field)` on a single-valued field | Reject the later assignment. |
+| Repeated item value within one scalar array field | Reject the later row. |
 | Missing parent, multiple study records, or orphan record | Reject the affected record. |
-| Empty required value or invalid scalar/JSON | Reject with row and column context. |
+| Empty required value, empty scalar array item, or invalid scalar/JSON | Reject with row and column context. |
 | Existing registration-rule violation | Reject with the existing validator message; row and column may be absent. |
 
 Errors and general logs must not echo raw rows or sensitive free-text values.
@@ -216,9 +274,12 @@ Fixtures live under `src/test/resources/fixtures/study-template/v1`:
 
 - `valid/minimal-valid.csv`
 - `valid/multi-consent-group-valid.csv`
+- `valid/excel-export-valid.csv` — the minimal study as Excel "CSV UTF-8" writes it: BOM and CRLF
 - `invalid/empty-file.csv`
 - `invalid/duplicate-header.csv`
 - `invalid/duplicate-field.csv`
+- `invalid/semicolon-delimited.csv` — a European-locale Excel export
+- `invalid/duplicate-array-item.csv`
 - `invalid/unknown-field.csv`
 - `invalid/unsupported-version.csv`
 - `invalid/field-values.csv`

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -12,6 +12,11 @@ it does not define a new registration API or replace existing registration valid
 Canonical synthetic fixtures live in `src/test/resources/fixtures/study-template/v1`, where Consent
 parser tests can load them directly. DT-3869 itself does not implement parsing or UI behavior.
 
+DT-3869 is Ticket 1 of the workflow planned in duos-ui at
+`docs/plans/study-template-validation-workflow.md` (DT-1855). That plan defers to this document for
+the layout and records how the decisions taken here change the later tickets — in particular that
+the UI must offer a blank-template download, since v1 expresses every structured value as a row.
+
 ## File contract
 
 - File extension: `.csv`.
@@ -20,6 +25,18 @@ parser tests can load them directly. DT-3869 itself does not implement parsing o
 - Dialect: RFC 4180-style comma-separated values. Double quotes enclose values; a literal quote is
   escaped as `""`. CRLF and LF record separators are accepted.
 - One file represents exactly one study.
+- The case-sensitive header is required exactly once and in this order:
+
+```text
+templateVersion,recordType,recordId,parentRecordId,field,value
+```
+
+- `templateVersion` is required on every data row and must be major version `1`. Mixed or
+  unsupported versions are errors.
+- Blank physical lines may be ignored. A zero-byte, BOM-only, header-only, or otherwise record-free
+  file is invalid.
+- Leading and trailing whitespace is significant in string values. Producers should not add
+  whitespace around unquoted values.
 
 ### Size limit rationale
 
@@ -61,18 +78,6 @@ guessed at:
 The importer treats every cell as literal text and never evaluates a leading `=`, `+`, or `@` as a
 formula. Any template Consent generates for download must escape those prefixes so the exported file
 is not a CSV-injection vector in the producer's spreadsheet application.
-- The case-sensitive header is required exactly once and in this order:
-
-```text
-templateVersion,recordType,recordId,parentRecordId,field,value
-```
-
-- `templateVersion` is required on every data row and must be major version `1`. Mixed or
-  unsupported versions are errors.
-- Blank physical lines may be ignored. A zero-byte, BOM-only, header-only, or otherwise record-free
-  file is invalid.
-- Leading and trailing whitespace is significant in string values. Producers should not add
-  whitespace around unquoted values.
 
 ## Record model
 
@@ -108,9 +113,9 @@ ignored.
 | Empty value | An empty `value` cell means absent (`null`), not an empty string or empty array. Omit optional fields; empty required values fail validation. |
 
 Every `value` cell is a single scalar. **v1 has no JSON encoding at all**: structured wire values
-are expressed as rows, not as embedded documents. Arrays of scalars repeat their row, and the one
-array of objects, `fileTypes`, is its own record type. So the wire value `["Genomic","Phenotypic"]`
-is two rows, and neither cell needs quoting:
+are expressed as rows, not as embedded documents. Arrays of scalars repeat their row, and the only
+wire array of objects, `fileTypes`, is a record type rather than a cell. So the wire value
+`["Genomic","Phenotypic"]` is two rows, and neither cell needs quoting:
 
 ```csv
 1,study,study,,dataTypes,Genomic
@@ -127,11 +132,17 @@ properties that cannot be expressed as scalar rows without inventing new encodin
 v1 rather than embedded as JSON. That is why non-file assets are not in this contract.
 
 Product also confirmed that producers get the template by downloading it from the DUOS UI rather
-than building it from this contract. The download is therefore a v1 dependency rather than a
-convenience: it must emit the header and the `templateVersion`, `recordType`, `recordId`,
-`parentRecordId`, and `field` columns for the fields being offered, leaving `value` empty for the
-producer to fill in, and it must escape leading `=`, `+`, and `@` as described under Spreadsheet
-compatibility.
+than building it from this contract. The download must emit the header and the `templateVersion`,
+`recordType`, `recordId`, `parentRecordId`, and `field` columns for the fields being offered,
+leaving `value` empty for the producer to fill in, and it must escape leading `=`, `+`, and `@` as
+described under Spreadsheet compatibility.
+
+That download is a v1 dependency rather than a convenience, and it is **not currently tracked by any
+ticket**. It was a convenience while asset payloads were JSON; removing JSON made every structured
+value a row, so a hand-built file means keeping `recordType`, `recordId`, and `parentRecordId`
+consistent across dozens of rows. The work belongs to duos-ui rather than Consent, so it needs a
+ticket in that repo's scope before the import path is considered usable — DT-3869 covers this
+contract only.
 
 ## Study field mapping
 
@@ -227,7 +238,7 @@ Wire paths are relative to one `consentGroups[]` item.
 | `url` | `url` | URI | Optional absolute HTTP(S) data URL. |
 | `requestLocation` | `requestLocation` | URI | Optional absolute HTTP(S) external-request URL. |
 | `numberOfParticipants` | `numberOfParticipants` | Integer | Required. |
-| `fileTypes` | `fileTypes` | Object array | Optional; supplied as `fileType` records, not as a field on this record. See below. |
+| `fileTypes` | `fileTypes` | Records, not a field | Optional. Never appears as a `field` on a `consentGroup` row; supplied as `fileType` records that name this consent group as their parent. A `fileTypes` row on a `consentGroup` record is an unknown field and is rejected. See below. |
 
 Primary data-use rules are unchanged: `open` requires no primary data use; `controlled` and
 `external` require exactly one of general research use, HMB, disease-specific use, POA, or other.
@@ -235,7 +246,8 @@ Primary data-use rules are unchanged: `open` requires no primary data use; `cont
 
 ## File-type mapping
 
-`fileTypes` is the only array of objects in v1, so it is a record type rather than a field. Each
+`fileTypes` is the only array of objects on the wire, so v1 expresses it as a record type rather
+than as a JSON cell. Each
 `fileType` record contributes one `fileTypes[]` item to the consent group named by its
 `parentRecordId`. These describe data formats; they are not uploads.
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <swagger.ui.version>5.32.11</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <wiremock.version>3.13.2</wiremock.version>
+    <commons.csv.version>1.14.1</commons.csv.version>
     <junit.version>6.1.2</junit.version>
     <mockito.version>5.23.0</mockito.version>
     <sonar.plugin.version>5.7.0.6970</sonar.plugin.version>
@@ -756,6 +757,13 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
       <version>${dropwizard.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>${commons.csv.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
@@ -46,7 +46,8 @@ class StudyTemplateV1FixturesTest {
   /**
    * Array-typed fields that the contract encodes as one row per item, so the same (recordType,
    * recordId, field) tuple may legitimately repeat. Every other field is single-valued. {@code
-   * fileTypes} is an object array and stays a single JSON cell.
+   * fileTypes} is absent here because it is not a field at all: it is the {@code fileType} record
+   * type, parented to a consent group.
    */
   private static final Set<String> SCALAR_ARRAY_FIELDS =
       Set.of(

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
@@ -1,0 +1,168 @@
+package org.broadinstitute.consent.http.models.dto.registration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.jupiter.api.Test;
+
+class StudyTemplateV1FixturesTest {
+
+  private static final String FIXTURE_ROOT = "fixtures/study-template/v1/";
+  private static final int MAX_BYTES = 5 * 1024 * 1024;
+  private static final List<String> HEADERS =
+      List.of("templateVersion", "recordType", "recordId", "parentRecordId", "field", "value");
+  private static final List<String> VALID_FIXTURES =
+      List.of("minimal-valid.csv", "multi-consent-group-valid.csv");
+  private static final List<String> INVALID_FIXTURES =
+      List.of(
+          "duplicate-field.csv",
+          "duplicate-header.csv",
+          "empty-file.csv",
+          "field-values.csv",
+          "unknown-field.csv",
+          "unsupported-version.csv");
+
+  private static final CSVFormat CSV_FORMAT =
+      CSVFormat.RFC4180.builder().setIgnoreEmptyLines(true).get();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  void validFixturesAreParseableAndVersioned() throws Exception {
+    for (String name : VALID_FIXTURES) {
+      byte[] bytes = readResource("valid/" + name);
+      List<CSVRecord> records = parse(bytes);
+
+      assertEquals(HEADERS, records.getFirst().toList(), name);
+      assertTrue(records.size() > 1, name);
+
+      Set<String> fieldKeys = new HashSet<>();
+      for (CSVRecord csvRecord : records.subList(1, records.size())) {
+        assertEquals(HEADERS.size(), csvRecord.size(), name + " row " + csvRecord.getRecordNumber());
+        assertEquals("1", csvRecord.get(0), name + " row " + csvRecord.getRecordNumber());
+
+        String fieldKey = csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + csvRecord.get(4);
+        assertTrue(fieldKeys.add(fieldKey), name + " duplicates " + fieldKey);
+
+        String value = csvRecord.get(5);
+        if (value.startsWith("[") || value.startsWith("{")) {
+          assertDoesNotThrow(
+              () -> OBJECT_MAPPER.readTree(value), name + " row " + csvRecord.getRecordNumber());
+        }
+      }
+    }
+  }
+
+  @Test
+  void invalidFixturesAreParseableAndHaveStructuredErrors() throws Exception {
+    for (String name : INVALID_FIXTURES) {
+      byte[] bytes = readResource("invalid/" + name);
+      List<CSVRecord> records = bytes.length == 0 ? List.of() : parse(bytes);
+      if (!name.equals("empty-file.csv")) {
+        assertTrue(records.size() > 1, name);
+      }
+
+      String manifestName = name.replace(".csv", ".errors.json");
+      JsonNode errors = OBJECT_MAPPER.readTree(decodeUtf8(readResource("invalid/" + manifestName)));
+      assertTrue(errors.isArray(), manifestName);
+      assertFalse(errors.isEmpty(), manifestName);
+
+      for (JsonNode error : errors) {
+        JsonNode message = error.get("message");
+        assertNotNull(message, manifestName);
+        assertTrue(message.isTextual() && !message.asText().isBlank(), manifestName);
+
+        if (error.has("row")) {
+          int row = error.get("row").asInt();
+          assertTrue(row > 0 && row <= records.size(), manifestName);
+        }
+        if (error.has("column")) {
+          assertTrue(HEADERS.contains(error.get("column").asText()), manifestName);
+        }
+      }
+    }
+  }
+
+  @Test
+  void structuralInvaliditiesRemainIntentional() throws Exception {
+    List<CSVRecord> duplicateHeader = parse(readResource("invalid/duplicate-header.csv"));
+    List<String> duplicateHeaderValues = duplicateHeader.getFirst().toList();
+    assertTrue(
+        new HashSet<>(duplicateHeaderValues).size() < duplicateHeaderValues.size(),
+        "duplicate-header.csv");
+
+    List<CSVRecord> duplicateField = parse(readResource("invalid/duplicate-field.csv"));
+    Set<String> fieldKeys = new HashSet<>();
+    assertFalse(
+        duplicateField.subList(1, duplicateField.size()).stream()
+            .map(csvRecord -> csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + csvRecord.get(4))
+            .allMatch(fieldKeys::add),
+        "duplicate-field.csv");
+
+    List<CSVRecord> unsupportedVersion = parse(readResource("invalid/unsupported-version.csv"));
+    assertTrue(
+        unsupportedVersion.subList(1, unsupportedVersion.size()).stream()
+            .noneMatch(csvRecord -> csvRecord.get(0).equals("1")),
+        "unsupported-version.csv");
+
+    assertEquals(0, readResource("invalid/empty-file.csv").length, "empty-file.csv");
+  }
+
+  @Test
+  void utf8BomIsAcceptedAtTheBeginning() throws Exception {
+    byte[] fixture = readResource("valid/minimal-valid.csv");
+    byte[] withBom = new byte[fixture.length + 3];
+    withBom[0] = (byte) 0xEF;
+    withBom[1] = (byte) 0xBB;
+    withBom[2] = (byte) 0xBF;
+    System.arraycopy(fixture, 0, withBom, 3, fixture.length);
+
+    assertEquals(HEADERS, parse(withBom).getFirst().toList());
+  }
+
+  private static byte[] readResource(String relativePath) throws IOException {
+    String resourcePath = FIXTURE_ROOT + relativePath;
+    try (InputStream input =
+        StudyTemplateV1FixturesTest.class.getClassLoader().getResourceAsStream(resourcePath)) {
+      assertNotNull(input, resourcePath);
+      byte[] bytes = input.readAllBytes();
+      assertTrue(bytes.length <= MAX_BYTES, resourcePath);
+      return bytes;
+    }
+  }
+
+  private static List<CSVRecord> parse(byte[] bytes) throws IOException {
+    String csv = decodeUtf8(bytes);
+    if (csv.startsWith("\uFEFF")) {
+      csv = csv.substring(1);
+    }
+    try (CSVParser parser = CSVParser.parse(csv, CSV_FORMAT)) {
+      return parser.getRecords();
+    }
+  }
+
+  private static String decodeUtf8(byte[] bytes) throws CharacterCodingException {
+    return StandardCharsets.UTF_8
+        .newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+        .decode(ByteBuffer.wrap(bytes))
+        .toString();
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.consent.http.models.dto.registration;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -18,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -38,6 +38,7 @@ class StudyTemplateV1FixturesTest {
           "duplicate-header.csv",
           "empty-file.csv",
           "field-values.csv",
+          "orphan-file-type.csv",
           "semicolon-delimited.csv",
           "unknown-field.csv",
           "unsupported-version.csv");
@@ -77,16 +78,9 @@ class StudyTemplateV1FixturesTest {
         String value = csvRecord.get(5);
         assertTrue(fieldKeys.add(fieldKey(csvRecord)), name + " duplicates " + fieldKey(csvRecord));
         assertFalse(value.isEmpty(), name + " row " + csvRecord.getRecordNumber());
-
-        if (SCALAR_ARRAY_FIELDS.contains(csvRecord.get(4))) {
-          assertFalse(
-              value.startsWith("[") || value.startsWith("{"),
-              name + " row " + csvRecord.getRecordNumber() + " encodes an array as JSON");
-        }
-        if (value.startsWith("[") || value.startsWith("{")) {
-          assertDoesNotThrow(
-              () -> OBJECT_MAPPER.readTree(value), name + " row " + csvRecord.getRecordNumber());
-        }
+        assertFalse(
+            value.startsWith("[") || value.startsWith("{"),
+            name + " row " + csvRecord.getRecordNumber() + " encodes a value as JSON");
       }
     }
   }
@@ -201,6 +195,65 @@ class StudyTemplateV1FixturesTest {
     assertEquals(1, header.size(), "semicolon-delimited.csv");
     assertTrue(header.getFirst().contains(";"), "semicolon-delimited.csv");
     assertNotEquals(HEADERS, header, "semicolon-delimited.csv");
+  }
+
+  @Test
+  void noFixtureEncodesAValueAsJson() throws Exception {
+    // v1 expresses structured wire values as rows, never as an embedded document. fileTypes, the
+    // one array of objects, is its own record type.
+    for (String name : VALID_FIXTURES) {
+      assertNoJsonValues("valid/" + name);
+    }
+    for (String name : INVALID_FIXTURES) {
+      assertNoJsonValues("invalid/" + name);
+    }
+  }
+
+  @Test
+  void fileTypeRecordsReferenceADeclaredConsentGroup() throws Exception {
+    for (String name : VALID_FIXTURES) {
+      List<CSVRecord> records = parse(readResource("valid/" + name));
+      Set<String> consentGroupIds = recordIdsOfType(records, "consentGroup");
+
+      records.stream()
+          .filter(csvRecord -> csvRecord.get(1).equals("fileType"))
+          .forEach(
+              csvRecord ->
+                  assertTrue(
+                      consentGroupIds.contains(csvRecord.get(3)),
+                      name + " row " + csvRecord.getRecordNumber() + " has an orphan parent"));
+    }
+
+    List<CSVRecord> orphan = parse(readResource("invalid/orphan-file-type.csv"));
+    Set<String> consentGroupIds = recordIdsOfType(orphan, "consentGroup");
+    assertTrue(
+        orphan.stream()
+            .filter(csvRecord -> csvRecord.get(1).equals("fileType"))
+            .anyMatch(csvRecord -> !consentGroupIds.contains(csvRecord.get(3))),
+        "orphan-file-type.csv");
+  }
+
+  private static void assertNoJsonValues(String relativePath) throws IOException {
+    byte[] bytes = readResource(relativePath);
+    if (bytes.length == 0) {
+      return;
+    }
+    for (CSVRecord csvRecord : parse(bytes)) {
+      if (csvRecord.size() < HEADERS.size()) {
+        continue;
+      }
+      String value = csvRecord.get(5);
+      assertFalse(
+          value.startsWith("[") || value.startsWith("{"),
+          relativePath + " row " + csvRecord.getRecordNumber() + " encodes a value as JSON");
+    }
+  }
+
+  private static Set<String> recordIdsOfType(List<CSVRecord> records, String recordType) {
+    return records.stream()
+        .filter(csvRecord -> csvRecord.get(1).equals(recordType))
+        .map(csvRecord -> csvRecord.get(2))
+        .collect(Collectors.toSet());
   }
 
   private static String fieldKey(CSVRecord csvRecord) {

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
@@ -54,7 +54,8 @@ class StudyTemplateV1FixturesTest {
 
       Set<String> fieldKeys = new HashSet<>();
       for (CSVRecord csvRecord : records.subList(1, records.size())) {
-        assertEquals(HEADERS.size(), csvRecord.size(), name + " row " + csvRecord.getRecordNumber());
+        assertEquals(
+            HEADERS.size(), csvRecord.size(), name + " row " + csvRecord.getRecordNumber());
         assertEquals("1", csvRecord.get(0), name + " row " + csvRecord.getRecordNumber());
 
         String fieldKey = csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + csvRecord.get(4);

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/StudyTemplateV1FixturesTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models.dto.registration;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,15 +30,30 @@ class StudyTemplateV1FixturesTest {
   private static final List<String> HEADERS =
       List.of("templateVersion", "recordType", "recordId", "parentRecordId", "field", "value");
   private static final List<String> VALID_FIXTURES =
-      List.of("minimal-valid.csv", "multi-consent-group-valid.csv");
+      List.of("minimal-valid.csv", "multi-consent-group-valid.csv", "excel-export-valid.csv");
   private static final List<String> INVALID_FIXTURES =
       List.of(
+          "duplicate-array-item.csv",
           "duplicate-field.csv",
           "duplicate-header.csv",
           "empty-file.csv",
           "field-values.csv",
+          "semicolon-delimited.csv",
           "unknown-field.csv",
           "unsupported-version.csv");
+
+  /**
+   * Array-typed fields that the contract encodes as one row per item, so the same (recordType,
+   * recordId, field) tuple may legitimately repeat. Every other field is single-valued. {@code
+   * fileTypes} is an object array and stays a single JSON cell.
+   */
+  private static final Set<String> SCALAR_ARRAY_FIELDS =
+      Set.of(
+          "dataTypes",
+          "dataCustodianEmail",
+          "collaboratingSites",
+          "nihICsSupportingStudy",
+          "diseaseSpecificUse");
 
   private static final CSVFormat CSV_FORMAT =
       CSVFormat.RFC4180.builder().setIgnoreEmptyLines(true).get();
@@ -58,10 +74,15 @@ class StudyTemplateV1FixturesTest {
             HEADERS.size(), csvRecord.size(), name + " row " + csvRecord.getRecordNumber());
         assertEquals("1", csvRecord.get(0), name + " row " + csvRecord.getRecordNumber());
 
-        String fieldKey = csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + csvRecord.get(4);
-        assertTrue(fieldKeys.add(fieldKey), name + " duplicates " + fieldKey);
-
         String value = csvRecord.get(5);
+        assertTrue(fieldKeys.add(fieldKey(csvRecord)), name + " duplicates " + fieldKey(csvRecord));
+        assertFalse(value.isEmpty(), name + " row " + csvRecord.getRecordNumber());
+
+        if (SCALAR_ARRAY_FIELDS.contains(csvRecord.get(4))) {
+          assertFalse(
+              value.startsWith("[") || value.startsWith("{"),
+              name + " row " + csvRecord.getRecordNumber() + " encodes an array as JSON");
+        }
         if (value.startsWith("[") || value.startsWith("{")) {
           assertDoesNotThrow(
               () -> OBJECT_MAPPER.readTree(value), name + " row " + csvRecord.getRecordNumber());
@@ -112,9 +133,23 @@ class StudyTemplateV1FixturesTest {
     Set<String> fieldKeys = new HashSet<>();
     assertFalse(
         duplicateField.subList(1, duplicateField.size()).stream()
-            .map(csvRecord -> csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + csvRecord.get(4))
+            .map(StudyTemplateV1FixturesTest::fieldKey)
             .allMatch(fieldKeys::add),
         "duplicate-field.csv");
+
+    // A repeated scalar-array field is only invalid because the item value repeats, so the key that
+    // catches it has to include the value.
+    List<CSVRecord> duplicateItem = parse(readResource("invalid/duplicate-array-item.csv"));
+    Set<String> itemKeys = new HashSet<>();
+    assertFalse(
+        duplicateItem.subList(1, duplicateItem.size()).stream()
+            .map(StudyTemplateV1FixturesTest::fieldKey)
+            .allMatch(itemKeys::add),
+        "duplicate-array-item.csv");
+    assertTrue(
+        duplicateItem.subList(1, duplicateItem.size()).stream()
+            .anyMatch(csvRecord -> csvRecord.get(5).isEmpty()),
+        "duplicate-array-item.csv should also cover an empty item");
 
     List<CSVRecord> unsupportedVersion = parse(readResource("invalid/unsupported-version.csv"));
     assertTrue(
@@ -135,6 +170,43 @@ class StudyTemplateV1FixturesTest {
     System.arraycopy(fixture, 0, withBom, 3, fixture.length);
 
     assertEquals(HEADERS, parse(withBom).getFirst().toList());
+  }
+
+  @Test
+  void excelStyleExportIsAccepted() throws Exception {
+    byte[] excelExport = readResource("valid/excel-export-valid.csv");
+
+    assertEquals(
+        (byte) 0xEF, excelExport[0], "excel-export-valid.csv should start with a UTF-8 BOM");
+    assertEquals((byte) 0xBB, excelExport[1]);
+    assertEquals((byte) 0xBF, excelExport[2]);
+    assertTrue(
+        decodeUtf8(excelExport).contains("\r\n"),
+        "excel-export-valid.csv should use CRLF record separators");
+
+    // BOM and CRLF are the only differences from the plain minimal fixture.
+    List<List<String>> excelRows = parse(excelExport).stream().map(CSVRecord::toList).toList();
+    List<List<String>> minimalRows =
+        parse(readResource("valid/minimal-valid.csv")).stream().map(CSVRecord::toList).toList();
+    assertEquals(minimalRows, excelRows);
+  }
+
+  @Test
+  void semicolonDelimitedExportIsDetectableAsSuch() throws Exception {
+    List<CSVRecord> records = parse(readResource("invalid/semicolon-delimited.csv"));
+
+    // Read as comma-separated values, a European-locale export collapses to one column per row.
+    // That is the signal the parser uses to report the delimiter instead of a missing header.
+    List<String> header = records.getFirst().toList();
+    assertEquals(1, header.size(), "semicolon-delimited.csv");
+    assertTrue(header.getFirst().contains(";"), "semicolon-delimited.csv");
+    assertNotEquals(HEADERS, header, "semicolon-delimited.csv");
+  }
+
+  private static String fieldKey(CSVRecord csvRecord) {
+    String field = csvRecord.get(4);
+    String key = csvRecord.get(1) + '\0' + csvRecord.get(2) + '\0' + field;
+    return SCALAR_ARRAY_FIELDS.contains(field) ? key + '\0' + csvRecord.get(5) : key;
   }
 
   private static byte[] readResource(String relativePath) throws IOException {

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-array-item.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-array-item.csv
@@ -1,0 +1,5 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Repeated Item Study
+1,study,study,,dataTypes,Genomic
+1,study,study,,dataTypes,Genomic
+1,study,study,,collaboratingSites,

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-array-item.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-array-item.errors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "row": 4,
+    "column": "value",
+    "message": "Duplicate item 'Genomic' for study field 'dataTypes'"
+  },
+  {
+    "row": 5,
+    "column": "value",
+    "message": "Empty item for study field 'collaboratingSites'"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-field.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-field.csv
@@ -1,0 +1,3 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Study One
+1,study,study,,studyName,Synthetic Study Two

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-field.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-field.errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "row": 3,
+    "column": "field",
+    "message": "Duplicate field 'studyName' for study record 'study'"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-header.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-header.csv
@@ -1,0 +1,2 @@
+templateVersion,recordType,recordId,parentRecordId,field,value,field
+1,study,study,,studyName,Synthetic Study,duplicate

--- a/src/test/resources/fixtures/study-template/v1/invalid/duplicate-header.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/duplicate-header.errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "row": 1,
+    "column": "field",
+    "message": "Duplicate header: field"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/empty-file.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/empty-file.errors.json
@@ -1,0 +1,5 @@
+[
+  {
+    "message": "Template file is empty"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/field-values.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/field-values.csv
@@ -1,0 +1,13 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,
+1,study,study,,studyDescription,Synthetic invalid field example.
+1,study,study,,dataTypes,"[""Genomic""]"
+1,study,study,,publicVisibility,yes
+1,study,study,,nihAnvilUse,Unknown AnVIL choice
+1,study,study,,piName,Synthetic Investigator
+1,study,study,,piEmail,not-an-email
+1,study,study,,embargoReleaseDate,2026-02-30
+1,consentGroup,dataset-controlled,study,consentGroupName,Synthetic Invalid Dataset
+1,consentGroup,dataset-controlled,study,accessManagement,controlled
+1,consentGroup,dataset-controlled,study,generalResearchUse,true
+1,consentGroup,dataset-controlled,study,numberOfParticipants,12

--- a/src/test/resources/fixtures/study-template/v1/invalid/field-values.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/field-values.csv
@@ -1,7 +1,7 @@
 templateVersion,recordType,recordId,parentRecordId,field,value
 1,study,study,,studyName,
 1,study,study,,studyDescription,Synthetic invalid field example.
-1,study,study,,dataTypes,"[""Genomic""]"
+1,study,study,,dataTypes,Genomic
 1,study,study,,publicVisibility,yes
 1,study,study,,nihAnvilUse,Unknown AnVIL choice
 1,study,study,,piName,Synthetic Investigator

--- a/src/test/resources/fixtures/study-template/v1/invalid/field-values.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/field-values.errors.json
@@ -1,0 +1,30 @@
+[
+  {
+    "row": 2,
+    "column": "value",
+    "message": "Study Name is required"
+  },
+  {
+    "row": 5,
+    "column": "value",
+    "message": "publicVisibility must be true or false"
+  },
+  {
+    "row": 6,
+    "column": "value",
+    "message": "Unknown nihAnvilUse value: Unknown AnVIL choice"
+  },
+  {
+    "row": 8,
+    "column": "value",
+    "message": "PI Email is not a valid email address"
+  },
+  {
+    "row": 9,
+    "column": "value",
+    "message": "Embargo Release Date is not a valid date"
+  },
+  {
+    "message": "Data Access Committee is required unless Access Management is open or external"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/orphan-file-type.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/orphan-file-type.csv
@@ -1,0 +1,4 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Orphan File Type Study
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,fileType,ft-genome,dataset-missing,fileType,Genome

--- a/src/test/resources/fixtures/study-template/v1/invalid/orphan-file-type.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/orphan-file-type.errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "row": 4,
+    "column": "parentRecordId",
+    "message": "Unknown consent group 'dataset-missing' for fileType record 'ft-genome'"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/semicolon-delimited.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/semicolon-delimited.csv
@@ -1,0 +1,3 @@
+templateVersion;recordType;recordId;parentRecordId;field;value
+1;study;study;;studyName;Synthetic Semicolon Study
+1;study;study;;publicVisibility;true

--- a/src/test/resources/fixtures/study-template/v1/invalid/semicolon-delimited.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/semicolon-delimited.errors.json
@@ -1,0 +1,6 @@
+[
+  {
+    "row": 1,
+    "message": "Template must be comma-delimited. Detected ';' as the column separator. Re-export the file as comma-separated values."
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/unknown-field.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/unknown-field.csv
@@ -1,0 +1,2 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyColour,ultraviolet

--- a/src/test/resources/fixtures/study-template/v1/invalid/unknown-field.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/unknown-field.errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "row": 2,
+    "column": "field",
+    "message": "Unknown study field: studyColour"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/invalid/unsupported-version.csv
+++ b/src/test/resources/fixtures/study-template/v1/invalid/unsupported-version.csv
@@ -1,0 +1,2 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+2,study,study,,studyName,Synthetic Future Study

--- a/src/test/resources/fixtures/study-template/v1/invalid/unsupported-version.errors.json
+++ b/src/test/resources/fixtures/study-template/v1/invalid/unsupported-version.errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "row": 2,
+    "column": "templateVersion",
+    "message": "Unsupported template version: 2"
+  }
+]

--- a/src/test/resources/fixtures/study-template/v1/valid/excel-export-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/excel-export-valid.csv
@@ -1,0 +1,10 @@
+﻿templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Minimal Study
+1,study,study,,studyDescription,A synthetic study used only for contract tests.
+1,study,study,,dataTypes,Genomic
+1,study,study,,publicVisibility,true
+1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
+1,study,study,,piName,Synthetic Investigator
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,consentGroup,dataset-open,study,accessManagement,open
+1,consentGroup,dataset-open,study,numberOfParticipants,10

--- a/src/test/resources/fixtures/study-template/v1/valid/minimal-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/minimal-valid.csv
@@ -1,0 +1,10 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Minimal Study
+1,study,study,,studyDescription,A synthetic study used only for contract tests.
+1,study,study,,dataTypes,"[""Genomic""]"
+1,study,study,,publicVisibility,true
+1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
+1,study,study,,piName,Synthetic Investigator
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,consentGroup,dataset-open,study,accessManagement,open
+1,consentGroup,dataset-open,study,numberOfParticipants,10

--- a/src/test/resources/fixtures/study-template/v1/valid/minimal-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/minimal-valid.csv
@@ -1,7 +1,7 @@
 templateVersion,recordType,recordId,parentRecordId,field,value
 1,study,study,,studyName,Synthetic Minimal Study
 1,study,study,,studyDescription,A synthetic study used only for contract tests.
-1,study,study,,dataTypes,"[""Genomic""]"
+1,study,study,,dataTypes,Genomic
 1,study,study,,publicVisibility,true
 1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
 1,study,study,,piName,Synthetic Investigator

--- a/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
@@ -1,0 +1,31 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Multi-Dataset Study
+1,study,study,,studyType,Observational
+1,study,study,,studyDescription,"A synthetic study with multiple datasets, quoted values, and non-file assets."
+1,study,study,,dataTypes,"[""Genomic"",""Phenotypic""]"
+1,study,study,,phenotypeIndication,Synthetic condition
+1,study,study,,species,Homo sapiens
+1,study,study,,piName,Synthetic Investigator
+1,study,study,,piEmail,investigator@example.org
+1,study,study,,dataCustodianEmail,"[""custodian.one@example.org"",""custodian.two@example.org""]"
+1,study,study,,publicVisibility,false
+1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
+1,study,study,,submittingToAnvil,false
+1,study,study,,multiCenterStudy,true
+1,study,study,,collaboratingSites,"[""Synthetic Site One"",""Synthetic Site Two""]"
+1,study,study,,controlledAccessRequiredForGenomicSummaryResultsGSR,false
+1,study,study,,alternativeDataSharingPlan,false
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,consentGroup,dataset-open,study,accessManagement,open
+1,consentGroup,dataset-open,study,numberOfParticipants,20
+1,consentGroup,dataset-open,study,dataLocation,Terra Workspace
+1,consentGroup,dataset-open,study,url,https://example.org/data/synthetic-open
+1,consentGroup,dataset-controlled,study,consentGroupName,Synthetic Controlled Dataset
+1,consentGroup,dataset-controlled,study,accessManagement,controlled
+1,consentGroup,dataset-controlled,study,generalResearchUse,true
+1,consentGroup,dataset-controlled,study,npu,true
+1,consentGroup,dataset-controlled,study,dataAccessCommitteeId,1
+1,consentGroup,dataset-controlled,study,numberOfParticipants,30
+1,consentGroup,dataset-controlled,study,fileTypes,"[{""fileType"":""Genome"",""functionalEquivalence"":""Synthetic reference build""}]"
+1,asset,workspace-synthetic,study,workspaces,"{""name"":""Synthetic Analysis Workspace"",""platform"":""Terra"",""url"":""https://example.org/workspaces/synthetic"",""description"":""Synthetic workspace for fixture tests"",""cloud"": [""GCP""],""tools"": [""Notebook""],""access"":""controlled"",""tags"": [""synthetic""]}"
+1,asset,publication-synthetic,study,publications,"{""title"":""Synthetic Study Results"",""publishedDate"":""2026-01-15"",""authors"": [{""name"":""Synthetic Author"",""orcId"":""0000-0000-0000-0000""}],""datasetCitation"":""Synthetic Open Dataset"",""citation"":true,""journal"":""Journal of Synthetic Examples"",""doi"":""10.0000/example.synthetic"",""url"":""https://example.org/publications/synthetic"",""tags"": [""synthetic""]}"

--- a/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
@@ -2,19 +2,21 @@ templateVersion,recordType,recordId,parentRecordId,field,value
 1,study,study,,studyName,Synthetic Multi-Dataset Study
 1,study,study,,studyType,Observational
 1,study,study,,studyDescription,"A synthetic study with multiple datasets, quoted values, and non-file assets."
-1,study,study,,dataTypes,"[""Genomic"",""Phenotypic""]"
+1,study,study,,dataTypes,Genomic
+1,study,study,,dataTypes,Phenotypic
 1,study,study,,phenotypeIndication,Synthetic condition
 1,study,study,,species,Homo sapiens
 1,study,study,,piName,Synthetic Investigator
 1,study,study,,piEmail,investigator@example.org
-1,study,study,,dataCustodianEmail,"[""custodian.one@example.org"",""custodian.two@example.org""]"
+1,study,study,,dataCustodianEmail,custodian.one@example.org
+1,study,study,,dataCustodianEmail,custodian.two@example.org
 1,study,study,,publicVisibility,false
 1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
 1,study,study,,submittingToAnvil,false
 1,study,study,,multiCenterStudy,true
-1,study,study,,collaboratingSites,"[""Synthetic Site One"",""Synthetic Site Two""]"
+1,study,study,,collaboratingSites,Synthetic Site One
+1,study,study,,collaboratingSites,Synthetic Site Two
 1,study,study,,controlledAccessRequiredForGenomicSummaryResultsGSR,false
-1,study,study,,alternativeDataSharingPlan,false
 1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
 1,consentGroup,dataset-open,study,accessManagement,open
 1,consentGroup,dataset-open,study,numberOfParticipants,20
@@ -27,5 +29,5 @@ templateVersion,recordType,recordId,parentRecordId,field,value
 1,consentGroup,dataset-controlled,study,dataAccessCommitteeId,1
 1,consentGroup,dataset-controlled,study,numberOfParticipants,30
 1,consentGroup,dataset-controlled,study,fileTypes,"[{""fileType"":""Genome"",""functionalEquivalence"":""Synthetic reference build""}]"
-1,asset,workspace-synthetic,study,workspaces,"{""name"":""Synthetic Analysis Workspace"",""platform"":""Terra"",""url"":""https://example.org/workspaces/synthetic"",""description"":""Synthetic workspace for fixture tests"",""cloud"": [""GCP""],""tools"": [""Notebook""],""access"":""controlled"",""tags"": [""synthetic""]}"
-1,asset,publication-synthetic,study,publications,"{""title"":""Synthetic Study Results"",""publishedDate"":""2026-01-15"",""authors"": [{""name"":""Synthetic Author"",""orcId"":""0000-0000-0000-0000""}],""datasetCitation"":""Synthetic Open Dataset"",""citation"":true,""journal"":""Journal of Synthetic Examples"",""doi"":""10.0000/example.synthetic"",""url"":""https://example.org/publications/synthetic"",""tags"": [""synthetic""]}"
+1,asset,workspace-synthetic,study,workspaces,"{""name"":""Synthetic Analysis Workspace"",""platform"":""Terra"",""url"":""https://example.org/workspaces/synthetic"",""description"":""Synthetic workspace for fixture tests"",""cloud"":[""GCP""],""tools"":[""Notebook""],""access"":""controlled"",""tags"":[""synthetic""]}"
+1,asset,publication-synthetic,study,publications,"{""title"":""Synthetic Study Results"",""publishedDate"":""2026-01-15"",""authors"":[{""name"":""Synthetic Author"",""orcId"":""0000-0000-0000-0000""}],""datasetCitation"":""Synthetic Open Dataset"",""citation"":true,""journal"":""Journal of Synthetic Examples"",""doi"":""10.0000/example.synthetic"",""url"":""https://example.org/publications/synthetic"",""tags"":[""synthetic""]}"

--- a/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
+++ b/src/test/resources/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
@@ -28,6 +28,6 @@ templateVersion,recordType,recordId,parentRecordId,field,value
 1,consentGroup,dataset-controlled,study,npu,true
 1,consentGroup,dataset-controlled,study,dataAccessCommitteeId,1
 1,consentGroup,dataset-controlled,study,numberOfParticipants,30
-1,consentGroup,dataset-controlled,study,fileTypes,"[{""fileType"":""Genome"",""functionalEquivalence"":""Synthetic reference build""}]"
-1,asset,workspace-synthetic,study,workspaces,"{""name"":""Synthetic Analysis Workspace"",""platform"":""Terra"",""url"":""https://example.org/workspaces/synthetic"",""description"":""Synthetic workspace for fixture tests"",""cloud"":[""GCP""],""tools"":[""Notebook""],""access"":""controlled"",""tags"":[""synthetic""]}"
-1,asset,publication-synthetic,study,publications,"{""title"":""Synthetic Study Results"",""publishedDate"":""2026-01-15"",""authors"":[{""name"":""Synthetic Author"",""orcId"":""0000-0000-0000-0000""}],""datasetCitation"":""Synthetic Open Dataset"",""citation"":true,""journal"":""Journal of Synthetic Examples"",""doi"":""10.0000/example.synthetic"",""url"":""https://example.org/publications/synthetic"",""tags"":[""synthetic""]}"
+1,fileType,ft-genome,dataset-controlled,fileType,Genome
+1,fileType,ft-genome,dataset-controlled,functionalEquivalence,Synthetic reference build
+1,fileType,ft-phenotype,dataset-controlled,fileType,Phenotype


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3869

### Summary

- Defines the canonical Study Template CSV v1 contract.
- Adds synthetic valid and invalid fixture files for future parser tests.
- Adds fixture integrity tests covering CSV structure, UTF-8, BOM handling, versioning, duplicate fields, and structured errors.
- Adds Apache Commons CSV as a test-only dependency.
- No parser, endpoint, or API behavior is introduced.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
