### PR TITLE
[DT-3941] Preserve long dataset aliases

### DIFF
--- a/docs/plans/data-use-primary-consistency-plan.md
+++ b/docs/plans/data-use-primary-consistency-plan.md
@@ -185,12 +185,14 @@ match_usage AS (
   SELECT d.dataset_id, COUNT(*) AS match_count
   FROM match_entity m
   JOIN dataset d
-    ON m.consent = 'DUOS-' || LPAD(d.alias::text, 6, '0')
+    ON m.consent =
+      'DUOS-' || LPAD(d.alias::text, GREATEST(6, LENGTH(d.alias::text)), '0')
   GROUP BY d.dataset_id
 )
 SELECT
   d.dataset_id,
-  'DUOS-' || LPAD(d.alias::text, 6, '0') AS dataset_identifier,
+  'DUOS-' || LPAD(d.alias::text, GREATEST(6, LENGTH(d.alias::text)), '0')
+    AS dataset_identifier,
   COALESCE(am.access_management, 'missing') AS access_management,
   d.data_use,
   COALESCE(du.dar_count, 0) AS dar_count,

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DacServiceDAO.java
@@ -91,9 +91,15 @@ public class DacServiceDAO implements ConsentLogger {
             FROM (
               SELECT dd.reference_id,
                      STRING_AGG(
-                       COALESCE('DUOS-' || LPAD(d.alias::TEXT, 6, '0'), d.object_id, d.dataset_id::TEXT),
+                       COALESCE(
+                         'DUOS-' || LPAD(d.alias::TEXT, GREATEST(6, LENGTH(d.alias::TEXT)), '0'),
+                         d.object_id,
+                         d.dataset_id::TEXT),
                        ', '
-                       ORDER BY COALESCE('DUOS-' || LPAD(d.alias::TEXT, 6, '0'), d.object_id, d.dataset_id::TEXT)
+                       ORDER BY COALESCE(
+                         'DUOS-' || LPAD(d.alias::TEXT, GREATEST(6, LENGTH(d.alias::TEXT)), '0'),
+                         d.object_id,
+                         d.dataset_id::TEXT)
                      ) AS removed_dataset_identifiers
               FROM dar_dataset dd
               INNER JOIN dataset d ON d.dataset_id = dd.dataset_id

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -105,6 +105,13 @@ class DatasetTests {
   }
 
   @Test
+  void testParseAliasToIdentifierPadsToMinimumWidthWithoutTruncating() {
+    assertEquals("DUOS-000042", Dataset.parseAliasToIdentifier(42));
+    assertEquals("DUOS-123456", Dataset.parseAliasToIdentifier(123456));
+    assertEquals("DUOS-1234567", Dataset.parseAliasToIdentifier(1234567));
+  }
+
+  @Test
   void testIsDatasetMatchName() {
     String name = RandomStringUtils.randomAlphanumeric(20);
 

--- a/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DatasetTests.java
@@ -112,6 +112,19 @@ class DatasetTests {
   }
 
   @Test
+  void testParseAliasToIdentifierAtSixDigitBoundary() {
+    assertEquals("DUOS-099999", Dataset.parseAliasToIdentifier(99999));
+    assertEquals("DUOS-999999", Dataset.parseAliasToIdentifier(999999));
+    assertEquals("DUOS-1000000", Dataset.parseAliasToIdentifier(1000000));
+  }
+
+  @Test
+  void testParseIdentifierToAliasAtSixDigitBoundary() {
+    assertEquals(999999, (int) Dataset.parseIdentifierToAlias("DUOS-999999"));
+    assertEquals(1000000, (int) Dataset.parseIdentifierToAlias("DUOS-1000000"));
+  }
+
+  @Test
   void testIsDatasetMatchName() {
     String name = RandomStringUtils.randomAlphanumeric(20);
 

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -283,6 +283,11 @@ class DacServiceDAOTest extends DAOTestHelper {
 
   private ExternalizationTestFixture buildExternalizationFixture(
       Boolean shouldConvertOpenAccessDatasets) {
+    return buildExternalizationFixture(shouldConvertOpenAccessDatasets, null);
+  }
+
+  private ExternalizationTestFixture buildExternalizationFixture(
+      Boolean shouldConvertOpenAccessDatasets, Integer controlledDatasetAlias) {
     User admin = createUser();
     User darOwner = createUser();
     User openDarOwner = createUser();
@@ -312,6 +317,15 @@ class DacServiceDAOTest extends DAOTestHelper {
             openDatasetObjectId,
             new DataUseBuilder().setGeneralUse(true).build().toString(),
             dacId);
+    if (controlledDatasetAlias != null) {
+      jdbi.useHandle(
+          handle ->
+              handle
+                  .createUpdate("UPDATE dataset SET alias = :alias WHERE dataset_id = :datasetId")
+                  .bind("alias", controlledDatasetAlias)
+                  .bind("datasetId", datasetId)
+                  .execute());
+    }
     jdbi.useHandle(
         handle ->
             handle
@@ -537,6 +551,23 @@ class DacServiceDAOTest extends DAOTestHelper {
     assertTrue(
         controlledDarAdminNotes.contains(
             "the following datasets were removed administratively from this request because the responsible Data Access Committee no longer manages access using DUOS."));
+  }
+
+  @Test
+  void testConvertDacDatasetsToExternal_preservesAliasLongerThanSixDigits() {
+    ExternalizationTestFixture f = buildExternalizationFixture(null, 1234567);
+
+    String controlledDarAdminNotes =
+        jdbi.withHandle(
+            handle ->
+                handle
+                    .createQuery(
+                        "SELECT admin_dar_notes FROM data_access_request WHERE reference_id = :referenceId")
+                    .bind("referenceId", f.referenceId())
+                    .mapTo(String.class)
+                    .one());
+
+    assertTrue(controlledDarAdminNotes.contains("DUOS-1234567"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DacServiceDAOTest.java
@@ -34,6 +34,8 @@ import org.broadinstitute.consent.http.rules.RuleState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -553,9 +555,16 @@ class DacServiceDAOTest extends DAOTestHelper {
             "the following datasets were removed administratively from this request because the responsible Data Access Committee no longer manages access using DUOS."));
   }
 
-  @Test
-  void testConvertDacDatasetsToExternal_preservesAliasLongerThanSixDigits() {
-    ExternalizationTestFixture f = buildExternalizationFixture(null, 1234567);
+  @ParameterizedTest
+  @CsvSource({
+    "99999, DUOS-099999",
+    "999999, DUOS-999999",
+    "1000000, DUOS-1000000",
+    "1234567, DUOS-1234567"
+  })
+  void testConvertDacDatasetsToExternal_preservesAliasLongerThanSixDigits(
+      Integer alias, String expectedIdentifier) {
+    ExternalizationTestFixture f = buildExternalizationFixture(null, alias);
 
     String controlledDarAdminNotes =
         jdbi.withHandle(
@@ -567,7 +576,10 @@ class DacServiceDAOTest extends DAOTestHelper {
                     .mapTo(String.class)
                     .one());
 
-    assertTrue(controlledDarAdminNotes.contains("DUOS-1234567"));
+    assertTrue(
+        controlledDarAdminNotes.contains(expectedIdentifier),
+        "Admin notes should contain %s but were: %s"
+            .formatted(expectedIdentifier, controlledDarAdminNotes));
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3941

## Summary

- Preserve dataset aliases longer than six digits when formatting public identifiers.
- Continue padding shorter aliases to six digits.
- Add regression coverage for two-, six-, and seven-digit aliases.
- Update related SQL documentation.

## Root cause

PostgreSQL `LPAD` used a fixed width of six characters, which truncated aliases containing more than six digits.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
