### PR TITLE
[DT-3864] Make unsupported matcher behavior explicit

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -44,6 +44,7 @@ import org.broadinstitute.consent.http.health.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV5;
 import org.broadinstitute.consent.http.matching.DataUseUtil;
 import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.dto.registration.RegistrationRequestMapper;
@@ -363,6 +364,12 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   @Singleton
   private DataUseMatcherV4 providesDataUseMatcherV4(DataUseUtil dataUseUtil) {
     return new DataUseMatcherV4(dataUseUtil);
+  }
+
+  @Provides
+  @Singleton
+  private DataUseMatcherV5 providesDataUseMatcherV5(DataUseMatcherV4 dataUseMatcherV4) {
+    return new DataUseMatcherV5(dataUseMatcherV4);
   }
 
   /**
@@ -745,8 +752,8 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   private MatchService providesMatchService(
       Jdbi jdbi,
       UseRestrictionConverter useRestrictionConverter,
-      DataUseMatcherV4 dataUseMatcherV4) {
-    return new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV4);
+      DataUseMatcherV5 dataUseMatcherV5) {
+    return new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV5);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
@@ -4,7 +4,8 @@ public enum MatchAlgorithm {
   V1("v1"),
   V2("v2"),
   V3("v3"),
-  V4("v4");
+  V4("v4"),
+  V5("v5");
 
   String version;
 

--- a/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5.java
+++ b/src/main/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.consent.http.matching;
+
+import com.google.inject.Inject;
+import java.util.List;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryCategory;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
+import org.broadinstitute.consent.http.models.matching.DataUseMatchResultType;
+
+/** Applies canonical dataset-primary policy before delegating supported cases to V4. */
+public class DataUseMatcherV5 {
+
+  public static final String MISSING_PRIMARY_RATIONALE =
+      "The dataset is missing a supported primary Data Use and requires manual review.";
+  public static final String MULTIPLE_PRIMARY_RATIONALE =
+      "The dataset has multiple primary Data Use categories and requires manual review.";
+  public static final String OTHER_PRIMARY_RATIONALE =
+      "The dataset has an Other primary Data Use and requires manual review.";
+
+  private final DataUseMatcherV4 dataUseMatcherV4;
+
+  @Inject
+  public DataUseMatcherV5(DataUseMatcherV4 dataUseMatcherV4) {
+    this.dataUseMatcherV4 = dataUseMatcherV4;
+  }
+
+  public MatchResult matchPurposeAndDatasetV5(DataUse purpose, DataUse dataset) {
+    if (dataset == null) {
+      return abstain(MISSING_PRIMARY_RATIONALE);
+    }
+
+    DataUsePrimaryClassification classification = DataUsePrimaryClassifier.classify(dataset);
+    return switch (classification.shape()) {
+      case NONE -> abstain(MISSING_PRIMARY_RATIONALE);
+      case MULTIPLE -> abstain(MULTIPLE_PRIMARY_RATIONALE);
+      case SINGLE ->
+          classification.categories().contains(DataUsePrimaryCategory.OTHER)
+              ? abstain(OTHER_PRIMARY_RATIONALE)
+              : dataUseMatcherV4.matchPurposeAndDatasetV4(purpose, dataset);
+    };
+  }
+
+  private MatchResult abstain(String rationale) {
+    return MatchResult.from(DataUseMatchResultType.ABSTAIN, List.of(rationale));
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -157,9 +157,23 @@ public class Match {
     return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V4, rationales);
   }
 
+  public static Match matchFailure(
+      String consentId, String purposeId, MatchAlgorithm algorithm, List<String> rationales) {
+    return new Match(consentId, purposeId, false, false, true, algorithm, rationales);
+  }
+
   public static Match matchSuccess(
       String consentId, String purposeId, DataUseMatchResultType match, List<String> rationales) {
+    return matchSuccess(consentId, purposeId, match, MatchAlgorithm.V4, rationales);
+  }
+
+  public static Match matchSuccess(
+      String consentId,
+      String purposeId,
+      DataUseMatchResultType match,
+      MatchAlgorithm algorithm,
+      List<String> rationales) {
     return new Match(
-        consentId, purposeId, Approve(match), Abstain(match), false, MatchAlgorithm.V4, rationales);
+        consentId, purposeId, Approve(match), Abstain(match), false, algorithm, rationales);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -23,9 +23,11 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.AutomationRuleToggleResponse;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryCategory;
 import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
 import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
 import org.broadinstitute.consent.http.rules.AuditPageResults;
@@ -161,11 +163,10 @@ public class DACAutomationRuleService implements ConsentLogger {
   @VisibleForTesting
   protected Optional<Vote> applyRule(
       DACAutomationRule rule, Dataset dataset, DataAccessRequest dar, ContainerRequest request) {
-    if (dataset.getDataUse() == null
-        || DataUsePrimaryClassifier.classify(dataset.getDataUse()).shape() != Shape.SINGLE) {
+    if (dataset.getDataUse() == null || !hasCanonicalSinglePrimaryDataUse(dataset.getDataUse())) {
       logInfo(
           String.format(
-              "Rule %s not triggered for DAC id: %s and dataset id: %s because the dataset does not have a single primary Data Use",
+              "Rule %s not triggered for DAC id: %s and dataset id: %s because the dataset does not have a canonical single primary Data Use",
               rule.ruleType(), dataset.getDacId(), dataset.getDatasetId()));
       return Optional.empty();
     }
@@ -187,6 +188,17 @@ public class DACAutomationRuleService implements ConsentLogger {
               darContainsBannedCountry));
     }
     return Optional.empty();
+  }
+
+  /**
+   * DAC automation only supports canonical single-primary Data Use shapes. {@code Shape.SINGLE}
+   * also covers an Other-only primary category, which is non-canonical and must be excluded here to
+   * match the abstention policy in {@code DataUseMatcherV5}.
+   */
+  private boolean hasCanonicalSinglePrimaryDataUse(DataUse dataUse) {
+    var classification = DataUsePrimaryClassifier.classify(dataUse);
+    return classification.shape() == Shape.SINGLE
+        && !classification.categories().contains(DataUsePrimaryCategory.OTHER);
   }
 
   @VisibleForTesting

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -26,6 +26,8 @@ import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
 import org.broadinstitute.consent.http.rules.AuditPageResults;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
@@ -159,6 +161,14 @@ public class DACAutomationRuleService implements ConsentLogger {
   @VisibleForTesting
   protected Optional<Vote> applyRule(
       DACAutomationRule rule, Dataset dataset, DataAccessRequest dar, ContainerRequest request) {
+    if (dataset.getDataUse() == null
+        || DataUsePrimaryClassifier.classify(dataset.getDataUse()).shape() != Shape.SINGLE) {
+      logInfo(
+          String.format(
+              "Rule %s not triggered for DAC id: %s and dataset id: %s because the dataset does not have a single primary Data Use",
+              rule.ruleType(), dataset.getDacId(), dataset.getDatasetId()));
+      return Optional.empty();
+    }
     RuleImplementationInterface ruleImplementation = getRuleImplementation(rule);
     boolean darContainsBannedCountry = CountryValidator.containsBannedCountry(dar);
     boolean shouldApprove = ruleImplementation.compare(dataset, dar);

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -11,7 +11,8 @@ import java.util.Objects;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
-import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV5;
 import org.broadinstitute.consent.http.matching.MatchResult;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -26,18 +27,18 @@ public class MatchService implements ConsentLogger {
   private final UseRestrictionConverter useRestrictionConverter;
   private final DataAccessRequestDAO dataAccessRequestDAO;
   private final DatasetDAO datasetDAO;
-  private final DataUseMatcherV4 dataUseMatcherV4;
+  private final DataUseMatcherV5 dataUseMatcherV5;
 
   @Inject
   public MatchService(
       Jdbi jdbi,
       UseRestrictionConverter useRestrictionConverter,
-      DataUseMatcherV4 dataUseMatcherV4) {
+      DataUseMatcherV5 dataUseMatcherV5) {
     this.matchDAO = jdbi.onDemand(MatchDAO.class);
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     this.useRestrictionConverter = useRestrictionConverter;
     this.datasetDAO = jdbi.onDemand(DatasetDAO.class);
-    this.dataUseMatcherV4 = dataUseMatcherV4;
+    this.dataUseMatcherV5 = dataUseMatcherV5;
   }
 
   public void insertMatches(List<Match> match) {
@@ -91,7 +92,10 @@ public class MatchService implements ConsentLogger {
                   logWarn(message);
                   matches.add(
                       matchFailure(
-                          dataset.getDatasetIdentifier(), dar.getReferenceId(), List.of(message)));
+                          dataset.getDatasetIdentifier(),
+                          dar.getReferenceId(),
+                          MatchAlgorithm.V5,
+                          List.of(message)));
                 }
               }
             });
@@ -114,11 +118,12 @@ public class MatchService implements ConsentLogger {
           "Data Use for the provided Data Access Request cannot be null");
     }
     MatchResult matchResult =
-        dataUseMatcherV4.matchPurposeAndDatasetV4(darDataUse, dataset.getDataUse());
+        dataUseMatcherV5.matchPurposeAndDatasetV5(darDataUse, dataset.getDataUse());
     return matchSuccess(
         dataset.getDatasetIdentifier(),
         dar.getReferenceId(),
         matchResult.getMatchResultType(),
+        MatchAlgorithm.V5,
         matchResult.getMessage());
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentModuleTest.java
@@ -49,6 +49,7 @@ import org.broadinstitute.consent.http.health.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.mail.SendGridAPI;
 import org.broadinstitute.consent.http.mail.freemarker.FreeMarkerTemplateHelper;
 import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV5;
 import org.broadinstitute.consent.http.matching.DataUseUtil;
 import org.broadinstitute.consent.http.matching.TranslationUtil;
 import org.broadinstitute.consent.http.models.support.TicketFactory;
@@ -297,6 +298,8 @@ class ConsentModuleTest extends AbstractTestHelper {
     assertSame(injector.getInstance(DataUseUtil.class), injector.getInstance(DataUseUtil.class));
     assertSame(
         injector.getInstance(DataUseMatcherV4.class), injector.getInstance(DataUseMatcherV4.class));
+    assertSame(
+        injector.getInstance(DataUseMatcherV5.class), injector.getInstance(DataUseMatcherV5.class));
     assertSame(
         injector.getInstance(CountryValidator.class), injector.getInstance(CountryValidator.class));
     assertSame(

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5Test.java
@@ -40,7 +40,7 @@ class DataUseMatcherV5Test {
 
     assertEquals(ABSTAIN, result.getMatchResultType());
     assertEquals(List.of(expectedRationale), result.getMessage());
-    assertFalse(result.getMessage().contains(SENSITIVE_OTHER_TEXT));
+    assertOtherTextIsNotExposed(result);
     verifyNoInteractions(dataUseMatcherV4);
   }
 
@@ -80,7 +80,13 @@ class DataUseMatcherV5Test {
 
     assertEquals(ABSTAIN, result.getMatchResultType());
     assertEquals(List.of(DataUseMatcherV5.MULTIPLE_PRIMARY_RATIONALE), result.getMessage());
-    assertFalse(result.getMessage().contains(SENSITIVE_OTHER_TEXT));
+    assertOtherTextIsNotExposed(result);
+  }
+
+  private static void assertOtherTextIsNotExposed(MatchResult result) {
+    assertFalse(
+        result.getMessage().stream()
+            .anyMatch(rationale -> rationale.contains(SENSITIVE_OTHER_TEXT)));
   }
 
   private static Stream<Arguments> unsupportedDatasetPurposeMatrix() {

--- a/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5Test.java
+++ b/src/test/java/org/broadinstitute/consent/http/matching/DataUseMatcherV5Test.java
@@ -1,0 +1,160 @@
+package org.broadinstitute.consent.http.matching;
+
+import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.ABSTAIN;
+import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.APPROVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataUseMatcherV5Test {
+
+  private static final String DISEASE = "http://example.org/disease/1";
+  private static final String SENSITIVE_OTHER_TEXT = "sensitive free text";
+
+  @Mock private DataUseMatcherV4 dataUseMatcherV4;
+
+  @ParameterizedTest
+  @MethodSource("unsupportedDatasetPurposeMatrix")
+  void unsupportedDatasetShapesAbstain(DataUse dataset, DataUse purpose, String expectedRationale) {
+    DataUseMatcherV5 matcher = new DataUseMatcherV5(dataUseMatcherV4);
+
+    MatchResult result = matcher.matchPurposeAndDatasetV5(purpose, dataset);
+
+    assertEquals(ABSTAIN, result.getMatchResultType());
+    assertEquals(List.of(expectedRationale), result.getMessage());
+    assertFalse(result.getMessage().contains(SENSITIVE_OTHER_TEXT));
+    verifyNoInteractions(dataUseMatcherV4);
+  }
+
+  @ParameterizedTest
+  @MethodSource("canonicalPrimaryDatasets")
+  void supportedSinglePrimaryDatasetsDelegateUnchanged(DataUse dataset) {
+    DataUse purpose = new DataUseBuilder().setHmbResearch(true).build();
+    MatchResult v4Result = MatchResult.from(APPROVE, List.of("unchanged V4 rationale"));
+    when(dataUseMatcherV4.matchPurposeAndDatasetV4(purpose, dataset)).thenReturn(v4Result);
+
+    MatchResult result =
+        new DataUseMatcherV5(dataUseMatcherV4).matchPurposeAndDatasetV5(purpose, dataset);
+
+    assertSame(v4Result, result);
+  }
+
+  @ParameterizedTest
+  @MethodSource("allMultiplePrimaryDatasets")
+  void everyMultiplePrimaryCombinationAbstains(DataUse dataset) {
+    MatchResult result =
+        new DataUseMatcherV5(dataUseMatcherV4)
+            .matchPurposeAndDatasetV5(new DataUseBuilder().setHmbResearch(true).build(), dataset);
+
+    assertEquals(ABSTAIN, result.getMatchResultType());
+    assertEquals(List.of(DataUseMatcherV5.MULTIPLE_PRIMARY_RATIONALE), result.getMessage());
+    verifyNoInteractions(dataUseMatcherV4);
+  }
+
+  @Test
+  void observedLegacyHmbOtherCombinationAbstainsWithoutExposingOtherText() {
+    DataUse dataset =
+        new DataUseBuilder().setHmbResearch(true).setOther(SENSITIVE_OTHER_TEXT).build();
+
+    MatchResult result =
+        new DataUseMatcherV5(dataUseMatcherV4)
+            .matchPurposeAndDatasetV5(new DataUseBuilder().setHmbResearch(true).build(), dataset);
+
+    assertEquals(ABSTAIN, result.getMatchResultType());
+    assertEquals(List.of(DataUseMatcherV5.MULTIPLE_PRIMARY_RATIONALE), result.getMessage());
+    assertFalse(result.getMessage().contains(SENSITIVE_OTHER_TEXT));
+  }
+
+  private static Stream<Arguments> unsupportedDatasetPurposeMatrix() {
+    List<Arguments> datasetCases =
+        List.of(
+            Arguments.of(null, DataUseMatcherV5.MISSING_PRIMARY_RATIONALE),
+            Arguments.of(new DataUseBuilder().build(), DataUseMatcherV5.MISSING_PRIMARY_RATIONALE),
+            Arguments.of(
+                new DataUseBuilder().setSecondaryOther(SENSITIVE_OTHER_TEXT).build(),
+                DataUseMatcherV5.MISSING_PRIMARY_RATIONALE),
+            Arguments.of(
+                new DataUseBuilder().setOther(SENSITIVE_OTHER_TEXT).build(),
+                DataUseMatcherV5.OTHER_PRIMARY_RATIONALE),
+            Arguments.of(
+                new DataUseBuilder().setGeneralUse(true).setHmbResearch(true).build(),
+                DataUseMatcherV5.MULTIPLE_PRIMARY_RATIONALE),
+            Arguments.of(
+                new DataUseBuilder().setHmbResearch(true).setOther(SENSITIVE_OTHER_TEXT).build(),
+                DataUseMatcherV5.MULTIPLE_PRIMARY_RATIONALE));
+
+    return datasetCases.stream()
+        .flatMap(
+            datasetCase ->
+                researchPurposes()
+                    .map(
+                        purpose ->
+                            Arguments.of(datasetCase.get()[0], purpose, datasetCase.get()[1])));
+  }
+
+  private static Stream<DataUse> researchPurposes() {
+    return Stream.of(
+        new DataUseBuilder().setGeneralUse(true).build(),
+        new DataUseBuilder().setHmbResearch(true).build(),
+        new DataUseBuilder().setPopulationOriginsAncestry(true).build(),
+        new DataUseBuilder().setDiseaseRestrictions(List.of(DISEASE)).build(),
+        new DataUseBuilder().setMethodsResearch(true).build());
+  }
+
+  private static Stream<DataUse> canonicalPrimaryDatasets() {
+    return Stream.of(
+        new DataUseBuilder().setGeneralUse(true).build(),
+        new DataUseBuilder().setHmbResearch(true).build(),
+        new DataUseBuilder().setPopulationOriginsAncestry(true).build(),
+        new DataUseBuilder().setDiseaseRestrictions(List.of(DISEASE)).build());
+  }
+
+  private static Stream<DataUse> allMultiplePrimaryDatasets() {
+    DataUsePrimaryCategory[] categories = DataUsePrimaryCategory.values();
+    return IntStream.range(0, 1 << categories.length)
+        .filter(mask -> Integer.bitCount(mask) > 1)
+        .mapToObj(
+            mask -> {
+              List<DataUsePrimaryCategory> selected = new ArrayList<>();
+              for (int index = 0; index < categories.length; index++) {
+                if ((mask & (1 << index)) != 0) {
+                  selected.add(categories[index]);
+                }
+              }
+              return dataUseWithPrimaryCategories(selected);
+            });
+  }
+
+  private static DataUse dataUseWithPrimaryCategories(List<DataUsePrimaryCategory> categories) {
+    DataUse dataUse = new DataUse();
+    categories.forEach(
+        category -> {
+          switch (category) {
+            case GRU -> dataUse.setGeneralUse(true);
+            case HMB -> dataUse.setHmbResearch(true);
+            case POA -> dataUse.setPopulationOriginsAncestry(true);
+            case DS -> dataUse.setDiseaseRestrictions(List.of(DISEASE));
+            case OTHER -> dataUse.setOther(SENSITIVE_OTHER_TEXT);
+          }
+        });
+    return dataUse;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -98,6 +98,18 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
         "admin@example.com");
   }
 
+  private static DACAutomationRule makeDacAutomationRuleHMB() {
+    return new DACAutomationRule(
+        2,
+        DACAutomationRuleType.HMB_V1,
+        "Test HMB Rule",
+        RuleState.AVAILABLE,
+        FIXED_TIMESTAMP,
+        1,
+        "admin",
+        "admin@example.com");
+  }
+
   private static User makeResearcher() {
     User researcher = new User();
     researcher.setUserId(1);
@@ -649,6 +661,34 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
             any(DataAccessRequest.class),
             any(Dataset.class),
             any(ContainerRequest.class));
+  }
+
+  @Test
+  void testApplyRuleDoesNotApproveDatasetWithMultiplePrimaryDataUses() {
+    Dataset dataset = makeDataset();
+    dataset.getDataUse().setHmbResearch(true);
+    DataAccessRequest dar = makeDAR();
+
+    DACAutomationRuleService serviceSpy = spy(service);
+    List.of(makeDacAutomationRuleGRU(), makeDacAutomationRuleHMB())
+        .forEach(rule -> assertTrue(serviceSpy.applyRule(rule, dataset, dar, request).isEmpty()));
+    verify(serviceSpy, never()).openElectionAndApprove(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void testApplyRuleDoesNotApproveObservedHmbOtherDatasetShape() {
+    DACAutomationRule rule = makeDacAutomationRuleHMB();
+    Dataset dataset = makeDataset();
+    dataset.getDataUse().setGeneralUse(false);
+    dataset.getDataUse().setHmbResearch(true);
+    dataset.getDataUse().setOther("sensitive free text");
+    DataAccessRequest dar = makeDAR();
+
+    DACAutomationRuleService serviceSpy = spy(service);
+    Optional<Vote> appliedVote = serviceSpy.applyRule(rule, dataset, dar, request);
+
+    assertTrue(appliedVote.isEmpty());
+    verify(serviceSpy, never()).openElectionAndApprove(any(), any(), any(), any(), any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -676,6 +676,21 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testApplyRuleDoesNotApproveOtherOnlyPrimaryDatasetShape() {
+    DACAutomationRule rule = makeDacAutomationRuleHMB();
+    Dataset dataset = makeDataset();
+    dataset.getDataUse().setGeneralUse(false);
+    dataset.getDataUse().setOther("sensitive free text");
+    DataAccessRequest dar = makeDAR();
+
+    DACAutomationRuleService serviceSpy = spy(service);
+    Optional<Vote> appliedVote = serviceSpy.applyRule(rule, dataset, dar, request);
+
+    assertTrue(appliedVote.isEmpty());
+    verify(serviceSpy, never()).openElectionAndApprove(any(), any(), any(), any(), any());
+  }
+
+  @Test
   void testApplyRuleDoesNotApproveObservedHmbOtherDatasetShape() {
     DACAutomationRule rule = makeDacAutomationRuleHMB();
     Dataset dataset = makeDataset();

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
 import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
 import org.broadinstitute.consent.http.matching.DataUseMatcherV4;
+import org.broadinstitute.consent.http.matching.DataUseMatcherV5;
 import org.broadinstitute.consent.http.matching.DataUseUtil;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
@@ -46,7 +48,6 @@ class MatchServiceTest extends AbstractTestHelper {
   @Mock private UseRestrictionConverter useRestrictionConverter;
   @Mock private OntologyService ontologyService;
 
-  private DataUseMatcherV4 dataUseMatcherV4;
   private MatchService service;
 
   @BeforeEach
@@ -54,8 +55,9 @@ class MatchServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(MatchDAO.class)).thenReturn(matchDAO);
     when(jdbi.onDemand(DataAccessRequestDAO.class)).thenReturn(dataAccessRequestDAO);
     when(jdbi.onDemand(DatasetDAO.class)).thenReturn(datasetDAO);
-    dataUseMatcherV4 = new DataUseMatcherV4(new DataUseUtil(ontologyService));
-    service = new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV4);
+    DataUseMatcherV4 dataUseMatcherV4 = new DataUseMatcherV4(new DataUseUtil(ontologyService));
+    DataUseMatcherV5 dataUseMatcherV5 = new DataUseMatcherV5(dataUseMatcherV4);
+    service = new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV5);
   }
 
   @Test
@@ -152,6 +154,7 @@ class MatchServiceTest extends AbstractTestHelper {
     Match match = service.singleEntitiesMatch(dataset, dar);
     assertNotNull(match);
     assertTrue(match.getMatch());
+    assertEquals(MatchAlgorithm.V5.getVersion(), match.getAlgorithmVersion());
   }
 
   @Test
@@ -184,7 +187,8 @@ class MatchServiceTest extends AbstractTestHelper {
     service.reprocessMatchesForPurpose(dar.getReferenceId());
     verify(matchDAO).deleteRationalesByPurposeIds(List.of(dar.getReferenceId()));
     verify(matchDAO).deleteMatchesByPurposeId(dar.getReferenceId());
-    verify(matchDAO).insertMatch(any(), any(), any(), any(), any(), any(), any());
+    verify(matchDAO)
+        .insertMatch(any(), any(), any(), any(), any(), eq(MatchAlgorithm.V5.getVersion()), any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3864

### Summary

Adds a V5 matcher that preserves V4 behavior for supported single-primary datasets and abstains for missing, Other-only, and multi-primary Data Use. Also records matches as V5 and prevents DAC automation from approving noncanonical dataset shapes. Includes comprehensive matcher and automation regression tests.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
