### PR TITLE
[DT-3937] Add researcher dashboard stats API.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -76,6 +76,7 @@ import org.broadinstitute.consent.http.resources.OAuth2Resource;
 import org.broadinstitute.consent.http.resources.OntologyResource;
 import org.broadinstitute.consent.http.resources.PassportResource;
 import org.broadinstitute.consent.http.resources.PublicFeatureFlagResource;
+import org.broadinstitute.consent.http.resources.ResearcherDashboardResource;
 import org.broadinstitute.consent.http.resources.SamResource;
 import org.broadinstitute.consent.http.resources.SigningOfficialDashboardResource;
 import org.broadinstitute.consent.http.resources.StatusResource;
@@ -189,6 +190,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(OAuth2Resource.class));
     env.jersey().register(injector.getInstance(OntologyResource.class));
     env.jersey().register(injector.getInstance(PassportResource.class));
+    env.jersey().register(injector.getInstance(ResearcherDashboardResource.class));
     env.jersey().register(injector.getInstance(SamResource.class));
     env.jersey().register(injector.getInstance(SigningOfficialDashboardResource.class));
     env.jersey().register(injector.getInstance(SwaggerResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -71,6 +71,7 @@ import org.broadinstitute.consent.http.service.MetricsService;
 import org.broadinstitute.consent.http.service.NihService;
 import org.broadinstitute.consent.http.service.OidcService;
 import org.broadinstitute.consent.http.service.OntologyService;
+import org.broadinstitute.consent.http.service.ResearcherDashboardService;
 import org.broadinstitute.consent.http.service.SigningOfficialDashboardService;
 import org.broadinstitute.consent.http.service.SupportRequestService;
 import org.broadinstitute.consent.http.service.UseRestrictionConverter;
@@ -455,6 +456,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   @Singleton
   private SamService providesSamService(SamDAO samDAO) {
     return new SamService(samDAO);
+  }
+
+  @Provides
+  @Singleton
+  private ResearcherDashboardService providesResearcherDashboardService(
+      Jdbi jdbi, ElasticSearchService elasticSearchService, ExecutorService executorService) {
+    return new ResearcherDashboardService(jdbi, elasticSearchService, executorService);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/ResearcherDashboardDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ResearcherDashboardDAO.java
@@ -1,0 +1,160 @@
+package org.broadinstitute.consent.http.db;
+
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+public interface ResearcherDashboardDAO {
+
+  /**
+   * Every database count the researcher dashboard needs, in one round trip.
+   *
+   * <p>DAR counts are scoped like {@code
+   * DarCollectionSummaryDAO#getDarCollectionSummariesForResearcher}: submitted, non-archived
+   * collections the researcher created. Approval counts are scoped like {@code
+   * DatasetDAO#getApprovedDatasets}, except that expired approvals are counted rather than filtered
+   * out - that filter is why the old Expired stat was always zero.
+   */
+  @RegisterConstructorMapper(DashboardDatabaseCounts.class)
+  @SqlQuery(
+      """
+      WITH researcher_submissions AS (
+        SELECT DISTINCT ON (dar.collection_id)
+               dar.collection_id, dar.reference_id, dar.data
+        FROM data_access_request dar
+        JOIN dar_collection c ON c.collection_id = dar.collection_id
+        WHERE dar.submission_date IS NOT NULL
+          AND c.create_user_id = :userId
+        ORDER BY dar.collection_id, dar.submission_date DESC
+      ),
+      -- Filtering before the DISTINCT ON would substitute an older submission for a collection
+      -- whose latest submission is archived, instead of dropping the collection.
+      latest_dar AS (
+        SELECT collection_id, reference_id, data
+        FROM researcher_submissions
+        WHERE data->>'status' IS NULL OR LOWER(data->>'status') != 'archived'
+      ),
+      -- Every submitted DAR, not just the latest per collection: an approval granted on an
+      -- earlier submission still governs access until it expires.
+      submitted_dars AS (
+        SELECT dar.reference_id, dar.collection_id, dar.submission_date, c.dar_code
+        FROM data_access_request dar
+        JOIN dar_collection c ON c.collection_id = dar.collection_id
+        WHERE dar.submission_date IS NOT NULL
+          AND dar.user_id = :userId
+      ),
+      final_votes AS (
+        SELECT e.reference_id, e.dataset_id, v.vote, v.vote_id, v.create_date, v.update_date
+        FROM election e
+        JOIN vote v ON v.election_id = e.election_id
+        WHERE LOWER(e.election_type) = 'dataaccess'
+          AND LOWER(v.type) IN ('final', 'radar_approve')
+          AND v.vote IS NOT NULL
+          AND (e.reference_id IN (SELECT reference_id FROM latest_dar)
+               OR e.reference_id IN (SELECT reference_id FROM submitted_dars))
+      ),
+      -- Request statuses follow the SO console: for a re-opened election the most recently edited
+      -- vote decides.
+      latest_final_votes AS (
+        SELECT reference_id, dataset_id, vote
+        FROM (
+          SELECT reference_id, dataset_id, vote,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY reference_id, dataset_id
+                   ORDER BY COALESCE(update_date, create_date) DESC, vote_id DESC
+                 ) AS recency
+          FROM final_votes
+        ) ranked
+        WHERE recency = 1
+      ),
+      -- Approvals instead follow the My Dataset Approvals page, which ranks by create_date, so the
+      -- dashboard tile and that page always show the same number. The page breaks create_date ties
+      -- arbitrarily; vote_id makes this deterministic.
+      page_final_votes AS (
+        SELECT reference_id, dataset_id, vote
+        FROM (
+          SELECT reference_id, dataset_id, vote,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY reference_id, dataset_id
+                   ORDER BY create_date DESC, vote_id DESC
+                 ) AS recency
+          FROM final_votes
+        ) ranked
+        WHERE recency = 1
+      ),
+      -- Grouped by collection_id alone so the aggregate never hashes whole DAR documents.
+      dataset_vote_counts AS (
+        SELECT ld.collection_id,
+               COUNT(DISTINCT dd.dataset_id) AS dataset_count,
+               COUNT(DISTINCT lfv.dataset_id) FILTER (WHERE lfv.vote) AS approved_dataset_count
+        FROM latest_dar ld
+        JOIN dar_dataset dd ON dd.reference_id = ld.reference_id
+        LEFT JOIN latest_final_votes lfv
+          ON lfv.reference_id = ld.reference_id AND lfv.dataset_id = dd.dataset_id
+        GROUP BY ld.collection_id
+      ),
+      researcher_dars AS (
+        SELECT ld.collection_id, ld.data, dvc.dataset_count, dvc.approved_dataset_count
+        FROM latest_dar ld
+        JOIN dataset_vote_counts dvc ON dvc.collection_id = ld.collection_id
+      ),
+      dar_counts AS (
+        SELECT COUNT(*) AS total,
+               COUNT(*) FILTER (
+                 WHERE dataset_count > 0 AND approved_dataset_count >= dataset_count
+                   AND LOWER(data->>'status') IS DISTINCT FROM 'canceled'
+               ) AS approved,
+               COUNT(*) FILTER (WHERE LOWER(data->>'status') = 'canceled') AS canceled
+        FROM researcher_dars
+      ),
+      -- One row per approved dataset per DAR, as the My Dataset Approvals page lists them.
+      -- A closed-out collection no longer grants access, so it drops out.
+      approved_datasets AS (
+        -- Grouped by dar_code and dataset because that is the key the page's row reducer uses: a
+        -- revised DAR has several submissions in one collection, and they are one approval, dated
+        -- from the latest submission that granted it.
+        SELECT sd.dar_code, dd.dataset_id,
+               MAX(sd.submission_date) + make_interval(days => :expirationDays) AS expiration_date
+        FROM submitted_dars sd
+        JOIN dar_dataset dd ON dd.reference_id = sd.reference_id
+        JOIN dataset d ON d.dataset_id = dd.dataset_id
+        JOIN dac ON dac.dac_id = d.dac_id AND dac.deleted IS NOT TRUE
+        JOIN page_final_votes pfv
+          ON pfv.reference_id = sd.reference_id AND pfv.dataset_id = dd.dataset_id
+        WHERE pfv.vote
+          AND EXISTS (SELECT 1 FROM library_card lc WHERE lc.user_id = :userId)
+          AND NOT EXISTS (
+            SELECT 1 FROM data_access_request closeout
+            WHERE closeout.collection_id = sd.collection_id
+              AND closeout.data->>'closeoutSupplement' IS NOT NULL
+          )
+        GROUP BY sd.dar_code, dd.dataset_id
+      )
+      SELECT
+        COALESCE((SELECT total FROM dar_counts), 0) AS dar_total,
+        COALESCE((SELECT approved FROM dar_counts), 0) AS dar_approved,
+        COALESCE((SELECT canceled FROM dar_counts), 0) AS dar_canceled,
+        -- Active uses the same boundary the approvals page does (submitted within the last year),
+        -- so the two never disagree by a row sitting exactly on it.
+        (SELECT COUNT(*) FROM approved_datasets WHERE expiration_date > NOW())
+          AS approvals_active,
+        (SELECT COUNT(*) FROM approved_datasets
+          WHERE expiration_date > NOW()
+            AND expiration_date <= NOW() + make_interval(days => :expiringSoonDays))
+          AS approvals_expiring_soon,
+        (SELECT COUNT(*) FROM approved_datasets WHERE expiration_date <= NOW())
+          AS approvals_expired
+      """)
+  DashboardDatabaseCounts getCounts(
+      @Bind("userId") Integer userId,
+      @Bind("expirationDays") int expirationDays,
+      @Bind("expiringSoonDays") int expiringSoonDays);
+
+  record DashboardDatabaseCounts(
+      long darTotal,
+      long darApproved,
+      long darCanceled,
+      long approvalsActive,
+      long approvalsExpiringSoon,
+      long approvalsExpired) {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/ResearcherDashboardSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ResearcherDashboardSummary.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.consent.http.models;
+
+public record ResearcherDashboardSummary(
+    DataLibrary dataLibrary,
+    DarRequests darRequests,
+    DatasetApprovals datasetApprovals,
+    DataSubmissions dataSubmissions) {
+
+  /** What the researcher can see in the Data Library, by asset tab. */
+  public record DataLibrary(long studies, long datasets, long models, long workspaces) {}
+
+  /**
+   * Mirrors the statuses on the researcher's DAR Requests page (see {@code DarCollectionStatus}).
+   * No denied count: the system records no denial, so an unapproved request stays In Process.
+   * Drafts are excluded.
+   */
+  public record DarRequests(long total, long approved, long canceled, long inProcess) {}
+
+  /**
+   * One count per approved dataset per DAR. An approval expires {@link
+   * DataAccessRequest#EXPIRATION_DURATION_MILLIS} after submission; {@code expiringSoon} is the
+   * subset of {@code active} expiring within 30 days.
+   */
+  public record DatasetApprovals(long active, long expiringSoon, long expired) {}
+
+  /** Sum of the nine My Data Submissions tab counts for records the researcher registered. */
+  public record DataSubmissions(long total) {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/ResearcherDashboardResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/ResearcherDashboardResource.java
@@ -1,0 +1,36 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.service.ResearcherDashboardService;
+
+@Path("api/researcher/dashboard-summary")
+public class ResearcherDashboardResource extends Resource {
+
+  private final ResearcherDashboardService dashboardService;
+
+  @Inject
+  public ResearcherDashboardResource(ResearcherDashboardService dashboardService) {
+    this.dashboardService = dashboardService;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed(RESEARCHER)
+  @Timed
+  public Response getDashboardSummary(@Auth DuosUser duosUser) {
+    try {
+      return Response.ok(dashboardService.getSummary(duosUser.getUser())).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
@@ -1,0 +1,259 @@
+package org.broadinstitute.consent.http.service;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.inject.Inject;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.broadinstitute.consent.http.db.ResearcherDashboardDAO;
+import org.broadinstitute.consent.http.db.ResearcherDashboardDAO.DashboardDatabaseCounts;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.DataAccessRequest;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DarRequests;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataLibrary;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataSubmissions;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DatasetApprovals;
+import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.Jdbi;
+
+public class ResearcherDashboardService {
+
+  /** Matches the "Expiring in 30 Days" stat on the My Dataset Approvals tile. */
+  private static final int EXPIRING_SOON_DAYS = 30;
+
+  private static final int EXPIRATION_DAYS =
+      (int) TimeUnit.MILLISECONDS.toDays(DataAccessRequest.EXPIRATION_DURATION_MILLIS);
+
+  /** Roles that see every study; everyone else sees only publicly visible ones, as in the UI. */
+  private static final List<UserRoles> UNRESTRICTED_VISIBILITY_ROLES =
+      List.of(
+          UserRoles.CHAIRPERSON,
+          UserRoles.DATASUBMITTER,
+          UserRoles.ADMIN,
+          UserRoles.SIGNINGOFFICIAL);
+
+  /** Asset arrays behind the Data Library's AI Models and Workspaces tiles. */
+  private static final List<String> LIBRARY_ASSET_KEYS = List.of("models", "workspaces");
+
+  /**
+   * Asset arrays behind the seven study-asset tabs on My Data Submissions. With the Studies and
+   * Datasets tabs, these are the nine tabs the Data Submissions total sums.
+   */
+  private static final List<String> SUBMISSION_ASSET_KEYS =
+      List.of(
+          "models",
+          "workspaces",
+          "clinicalTrials",
+          "biospecimens",
+          "publications",
+          "presentations",
+          "intellectualProperties");
+
+  /** Counts every dataset in scope, matching the submissions view's showAllControlled behavior. */
+  private static final String ALL_DATASETS_FILTER = "{\"match_all\": {}}";
+
+  /** Open/external datasets always count; controlled ones only once approved. */
+  private static final String APPROVED_DATASETS_FILTER =
+      """
+      {
+        "bool": {
+          "should": [
+            {"bool": {"must_not": [{"term": {"accessManagement": "controlled"}}]}},
+            {"bool": {"must": [
+              {"term": {"accessManagement": "controlled"}},
+              {"term": {"dacApproval": true}}
+            ]}}
+          ],
+          "minimum_should_match": 1
+        }
+      }
+      """;
+
+  private final ResearcherDashboardDAO dashboardDAO;
+  private final ElasticSearchService elasticSearchService;
+  private final ExecutorService executorService;
+
+  @Inject
+  public ResearcherDashboardService(
+      Jdbi jdbi, ElasticSearchService elasticSearchService, ExecutorService executorService) {
+    this.dashboardDAO = jdbi.onDemand(ResearcherDashboardDAO.class);
+    this.elasticSearchService = elasticSearchService;
+    this.executorService = executorService;
+  }
+
+  public ResearcherDashboardSummary getSummary(User user) {
+    CompletableFuture<DashboardDatabaseCounts> databaseCounts =
+        CompletableFuture.supplyAsync(
+            () -> dashboardDAO.getCounts(user.getUserId(), EXPIRATION_DAYS, EXPIRING_SOON_DAYS),
+            executorService);
+    CompletableFuture<DataLibrary> libraryCounts =
+        CompletableFuture.supplyAsync(() -> getDataLibraryCounts(user), executorService);
+    CompletableFuture<DataSubmissions> submissionCounts =
+        CompletableFuture.supplyAsync(() -> getDataSubmissionCounts(user), executorService);
+    try {
+      DashboardDatabaseCounts db = databaseCounts.join();
+      long inProcess = db.darTotal() - db.darApproved() - db.darCanceled();
+      return new ResearcherDashboardSummary(
+          libraryCounts.join(),
+          new DarRequests(db.darTotal(), db.darApproved(), db.darCanceled(), inProcess),
+          new DatasetApprovals(
+              db.approvalsActive(), db.approvalsExpiringSoon(), db.approvalsExpired()),
+          submissionCounts.join());
+    } catch (CompletionException e) {
+      if (e.getCause() instanceof RuntimeException runtimeException) throw runtimeException;
+      throw e;
+    }
+  }
+
+  /**
+   * Counts have to match the tab badges at /datalibrary, so this reuses that library's query.
+   * Models and workspaces live in each study's assets, so they are summed once per study from the
+   * same study aggregation the library's own tab counts use.
+   */
+  private DataLibrary getDataLibraryCounts(User user) {
+    String visibilityClause =
+        isRestrictedToPublicVisibility(user)
+            ? ", {\"term\": {\"study.publicVisibility\": true}}"
+            : "";
+    TabCounts counts =
+        countTabs(
+            visibilityClause,
+            APPROVED_DATASETS_FILTER,
+            LIBRARY_ASSET_KEYS,
+            "Unable to load data library statistics");
+    return new DataLibrary(
+        counts.studies(), counts.datasets(), counts.assets().get(0), counts.assets().get(1));
+  }
+
+  /**
+   * Sums what My Data Submissions lists, one tab at a time: studies, datasets, and the seven
+   * study-asset tabs. Scoped to datasets the researcher registered or is data custodian for, and
+   * counting controlled datasets whether or not they are approved, as that page does.
+   */
+  private DataSubmissions getDataSubmissionCounts(User user) {
+    if (!user.hasUserRole(UserRoles.DATASUBMITTER)) {
+      return new DataSubmissions(0);
+    }
+    String ownershipClause =
+        """
+        , {
+          "bool": {
+            "should": [
+              {"term": {"createUserId": %d}},
+              {"term": {"study.dataSubmitterId": %d}},
+              {"term": {"study.dataCustodianEmail": "%s"}}
+            ],
+            "minimum_should_match": 1
+          }
+        }
+        """
+            .formatted(user.getUserId(), user.getUserId(), escapeJson(user.getEmail()));
+    TabCounts counts =
+        countTabs(
+            ownershipClause,
+            ALL_DATASETS_FILTER,
+            SUBMISSION_ASSET_KEYS,
+            "Unable to load data submission statistics");
+    long total =
+        counts.studies()
+            + counts.datasets()
+            + counts.assets().stream().mapToLong(Long::longValue).sum();
+    return new DataSubmissions(total);
+  }
+
+  /**
+   * Runs one library-shaped search and returns the count each tab would show: distinct studies,
+   * datasets matching {@code datasetsFilter}, and the length of each requested asset array summed
+   * across studies (in the order requested).
+   */
+  private TabCounts countTabs(
+      String extraMustClauses,
+      String datasetsFilter,
+      List<String> assetKeys,
+      String failureMessage) {
+    String assetSources =
+        String.join(", ", assetKeys.stream().map("\"study.assets.%s\""::formatted).toList());
+    String query =
+        """
+        {
+          "size": 0,
+          "track_total_hits": true,
+          "query": {"bool": {"must": [{"exists": {"field": "study"}}%s]}},
+          "aggs": {
+            "total_studies": {"cardinality": {"field": "study.studyId"}},
+            "datasets_count": {"filter": %s},
+            "studies": {
+              "terms": {"field": "study.studyId", "size": 10000},
+              "aggs": {"study_details": {"top_hits": {"size": 1, "_source": [%s]}}}
+            }
+          }
+        }
+        """
+            .formatted(extraMustClauses, datasetsFilter, assetSources);
+    JsonObject aggregations = search(query, failureMessage).getAsJsonObject("aggregations");
+    List<Long> assetTotals = new ArrayList<>(Collections.nCopies(assetKeys.size(), 0L));
+    for (JsonElement bucket : aggregations.getAsJsonObject("studies").getAsJsonArray("buckets")) {
+      JsonObject assets = studyAssets(bucket.getAsJsonObject());
+      for (int i = 0; i < assetKeys.size(); i++) {
+        assetTotals.set(i, assetTotals.get(i) + assetCount(assets, assetKeys.get(i)));
+      }
+    }
+    return new TabCounts(
+        aggregations.getAsJsonObject("total_studies").get("value").getAsLong(),
+        aggregations.getAsJsonObject("datasets_count").get("doc_count").getAsLong(),
+        assetTotals);
+  }
+
+  private record TabCounts(long studies, long datasets, List<Long> assets) {}
+
+  private JsonObject search(String query, String failureMessage) {
+    try (InputStream stream = elasticSearchService.searchDatasetsStream(query);
+        InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+      return JsonParser.parseReader(reader).getAsJsonObject();
+    } catch (Exception e) {
+      throw new IllegalStateException(failureMessage, e);
+    }
+  }
+
+  private JsonObject studyAssets(JsonObject bucket) {
+    JsonArray hits =
+        bucket.getAsJsonObject("study_details").getAsJsonObject("hits").getAsJsonArray("hits");
+    if (hits.isEmpty()) {
+      return null;
+    }
+    JsonObject source = hits.get(0).getAsJsonObject().getAsJsonObject("_source");
+    if (source == null || !source.has("study")) {
+      return null;
+    }
+    JsonObject study = source.getAsJsonObject("study");
+    return study.has("assets") && study.get("assets").isJsonObject()
+        ? study.getAsJsonObject("assets")
+        : null;
+  }
+
+  private long assetCount(JsonObject assets, String assetName) {
+    if (assets == null || !assets.has(assetName) || !assets.get(assetName).isJsonArray()) {
+      return 0;
+    }
+    return assets.getAsJsonArray(assetName).size();
+  }
+
+  private boolean isRestrictedToPublicVisibility(User user) {
+    return !user.hasAnyUserRole(UNRESTRICTED_VISIBILITY_ROLES);
+  }
+
+  private String escapeJson(String value) {
+    return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
@@ -43,6 +43,9 @@ public class ResearcherDashboardService {
           UserRoles.ADMIN,
           UserRoles.SIGNINGOFFICIAL);
 
+  /** Field on each indexed study holding the asset arrays the tab counts are summed from. */
+  private static final String ASSETS_FIELD = "assets";
+
   /** Asset arrays behind the Data Library's AI Models and Workspaces tiles. */
   private static final List<String> LIBRARY_ASSET_KEYS = List.of("models", "workspaces");
 
@@ -237,8 +240,8 @@ public class ResearcherDashboardService {
       return null;
     }
     JsonObject study = source.getAsJsonObject("study");
-    return study.has("assets") && study.get("assets").isJsonObject()
-        ? study.getAsJsonObject("assets")
+    return study.has(ASSETS_FIELD) && study.get(ASSETS_FIELD).isJsonObject()
+        ? study.getAsJsonObject(ASSETS_FIELD)
         : null;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ResearcherDashboardService.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
@@ -25,6 +26,7 @@ import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataLib
 import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataSubmissions;
 import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DatasetApprovals;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.jdbi.v3.core.Jdbi;
 
 public class ResearcherDashboardService {
@@ -155,13 +157,13 @@ public class ResearcherDashboardService {
             "should": [
               {"term": {"createUserId": %d}},
               {"term": {"study.dataSubmitterId": %d}},
-              {"term": {"study.dataCustodianEmail": "%s"}}
+              {"term": {"study.dataCustodianEmail": %s}}
             ],
             "minimum_should_match": 1
           }
         }
         """
-            .formatted(user.getUserId(), user.getUserId(), escapeJson(user.getEmail()));
+            .formatted(user.getUserId(), user.getUserId(), toJsonString(user.getEmail()));
     TabCounts counts =
         countTabs(
             ownershipClause,
@@ -256,7 +258,8 @@ public class ResearcherDashboardService {
     return !user.hasAnyUserRole(UNRESTRICTED_VISIBILITY_ROLES);
   }
 
-  private String escapeJson(String value) {
-    return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+  /** Renders the value as a quoted JSON string literal, so no character can break the query. */
+  private String toJsonString(String value) {
+    return GsonUtil.getInstance().toJson(Objects.toString(value, ""));
   }
 }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -26,6 +26,8 @@ security:
       - profile
 
 paths:
+  /api/researcher/dashboard-summary:
+    $ref: './paths/researcherDashboardSummary.yaml'
   /api/signing-official/dashboard-summary:
     $ref: './paths/signingOfficialDashboardSummary.yaml'
   /api/collections/{collectionId}:
@@ -1245,6 +1247,8 @@ components:
       $ref: './schemas/DataAccessAgreement.yaml'
     DataAccessCommittee:
       $ref: './schemas/Dac.yaml'
+    ResearcherDashboardSummary:
+      $ref: './schemas/ResearcherDashboardSummary.yaml'
     SigningOfficialDashboardSummary:
       $ref: './schemas/SigningOfficialDashboardSummary.yaml'
     DacDatasetExternalizationRequest:

--- a/src/main/resources/assets/paths/researcherDashboardSummary.yaml
+++ b/src/main/resources/assets/paths/researcherDashboardSummary.yaml
@@ -1,0 +1,18 @@
+get:
+  summary: Get Researcher dashboard statistics
+  operationId: getResearcherDashboardSummary
+  tags:
+    - Researcher
+  responses:
+    200:
+      description: Researcher-scoped dashboard counts
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ResearcherDashboardSummary.yaml'
+    401:
+      description: Unauthorized
+    403:
+      description: The user does not have the Researcher role
+    500:
+      description: Unable to aggregate dashboard statistics

--- a/src/main/resources/assets/schemas/ResearcherDashboardSummary.yaml
+++ b/src/main/resources/assets/schemas/ResearcherDashboardSummary.yaml
@@ -1,0 +1,51 @@
+type: object
+required:
+  - dataLibrary
+  - darRequests
+  - datasetApprovals
+  - dataSubmissions
+properties:
+  dataLibrary:
+    type: object
+    description: >-
+      Counts of what the researcher can see in the Data Library, matching the tab badges on
+      /datalibrary. Users without a privileged role only see publicly visible studies.
+    required: [studies, datasets, models, workspaces]
+    properties:
+      studies: { type: integer, format: int64 }
+      datasets: { type: integer, format: int64 }
+      models: { type: integer, format: int64 }
+      workspaces: { type: integer, format: int64 }
+  darRequests:
+    type: object
+    description: >-
+      Counts mirroring the statuses on the researcher's DAR Requests page. `canceled` counts
+      collections the researcher withdrew; `inProcess` is everything not yet fully approved or
+      canceled. Denials are not counted because the system does not record one. Drafts are
+      excluded.
+    required: [total, approved, canceled, inProcess]
+    properties:
+      total: { type: integer, format: int64 }
+      approved: { type: integer, format: int64 }
+      canceled: { type: integer, format: int64 }
+      inProcess: { type: integer, format: int64 }
+  datasetApprovals:
+    type: object
+    description: >-
+      Dataset approvals the researcher holds, counted per approved dataset per DAR. An approval
+      expires one year after the DAR was submitted; `expiringSoon` is the subset of `active`
+      expiring within 30 days.
+    required: [active, expiringSoon, expired]
+    properties:
+      active: { type: integer, format: int64 }
+      expiringSoon: { type: integer, format: int64 }
+      expired: { type: integer, format: int64 }
+  dataSubmissions:
+    type: object
+    description: >-
+      Sum of the nine tab counts on My Data Submissions (studies, datasets, and the seven
+      study-asset tabs), scoped to records the researcher registered or is data custodian for.
+      Zero for users without the Data Submitter role.
+    required: [total]
+    properties:
+      total: { type: integer, format: int64 }

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -255,4 +255,5 @@
   <include file="changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-07-14-election-type.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-07-so-dashboard-indices.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <!--
+    Supports the Researcher dashboard summary query, which reads every DAR a researcher submitted.
+    `data_access_request.user_id` carries only a foreign key, and Postgres does not index the
+    referencing side of one, so this lookup was a sequential scan.
+
+    Built CONCURRENTLY (runInTransaction="false") to avoid the write-blocking SHARE lock; see
+    changelog-consent-2026-08-07-so-dashboard-indices.xml for recovery notes.
+  -->
+  <changeSet id="changelog-consent-2026-08-11-researcher-dashboard-indices-dar-user-id"
+    author="otchet" runInTransaction="false">
+    <sql>CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_data_access_request_user_id ON data_access_request (user_id)</sql>
+    <rollback>
+      <sql>DROP INDEX CONCURRENTLY IF EXISTS idx_data_access_request_user_id</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/broadinstitute/consent/http/db/ResearcherDashboardDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/ResearcherDashboardDAOTest.java
@@ -1,0 +1,432 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.broadinstitute.consent.http.db.ResearcherDashboardDAO.DashboardDatabaseCounts;
+import org.broadinstitute.consent.http.enumeration.ElectionStatus;
+import org.broadinstitute.consent.http.enumeration.ElectionType;
+import org.broadinstitute.consent.http.enumeration.VoteType;
+import org.broadinstitute.consent.http.models.CloseoutSupplement;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ResearcherDashboardDAOTest extends DAOTestHelper {
+
+  /** The one-year window {@code DataAccessRequest.EXPIRATION_DURATION_MILLIS} defines. */
+  private static final int EXPIRATION_DAYS = 365;
+
+  private static final int EXPIRING_SOON_DAYS = 30;
+
+  private DashboardDatabaseCounts getCounts(User user) {
+    return jdbi.onDemand(ResearcherDashboardDAO.class)
+        .getCounts(user.getUserId(), EXPIRATION_DAYS, EXPIRING_SOON_DAYS);
+  }
+
+  @Test
+  void returnsZeroCountsForResearcherWithoutData() {
+    DashboardDatabaseCounts counts =
+        jdbi.onDemand(ResearcherDashboardDAO.class)
+            .getCounts(Integer.MAX_VALUE, EXPIRATION_DAYS, EXPIRING_SOON_DAYS);
+
+    assertEquals(0, counts.darTotal());
+    assertEquals(0, counts.darApproved());
+    assertEquals(0, counts.darCanceled());
+    assertEquals(0, counts.approvalsActive());
+    assertEquals(0, counts.approvalsExpiringSoon());
+    assertEquals(0, counts.approvalsExpired());
+  }
+
+  @Test
+  void countsOnlyTheResearchersOwnRequests() {
+    User user = createUser();
+    User otherResearcher = createUser();
+    createSubmittedDar(user, createDataset(user), new DataAccessRequestData(), FIXED_DATE);
+    createSubmittedDar(
+        otherResearcher, createDataset(otherResearcher), new DataAccessRequestData(), FIXED_DATE);
+
+    assertEquals(1, getCounts(user).darTotal());
+  }
+
+  @Test
+  void countsCanceledDarAsCanceledRatherThanInProcess() {
+    User user = createUser();
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setStatus("Canceled");
+    createSubmittedDar(user, createDataset(user), data, FIXED_DATE);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    assertEquals(1, counts.darTotal());
+    assertEquals(0, counts.darApproved());
+    assertEquals(1, counts.darCanceled());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = VoteType.class,
+      names = {"FINAL", "RADAR_APPROVE"})
+  void countsDarAsApprovedWhenEveryDatasetHasPositiveFinalVote(VoteType voteType) {
+    User user = createUser();
+    Integer datasetId = createDataset(user);
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), FIXED_DATE);
+    approve(user, referenceId, datasetId, voteType, true);
+
+    assertEquals(1, getCounts(user).darApproved());
+  }
+
+  @Test
+  void countsDarVotedDownAsInProcessBecauseThereIsNoDeniedStatus() {
+    User user = createUser();
+    Integer datasetId = createDataset(user);
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), FIXED_DATE);
+    approve(user, referenceId, datasetId, VoteType.FINAL, false);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    // The DAR Requests page has no denied status: a voted-down request is neither approved nor
+    // canceled, so it stays In Process.
+    assertEquals(1, counts.darTotal());
+    assertEquals(0, counts.darApproved());
+    assertEquals(0, counts.darCanceled());
+  }
+
+  @Test
+  void excludesCollectionWhoseLatestSubmissionIsArchived() {
+    User user = createUser();
+    Integer datasetId = createDataset(user);
+    Integer collectionId = createCollection(user);
+    insertSubmittedDar(
+        user,
+        collectionId,
+        datasetId,
+        new DataAccessRequestData(),
+        Date.from(Instant.parse("2026-01-01T00:00:00Z")));
+    DataAccessRequestData archived = new DataAccessRequestData();
+    archived.setStatus("Archived");
+    insertSubmittedDar(
+        user, collectionId, datasetId, archived, Date.from(Instant.parse("2026-02-01T00:00:00Z")));
+
+    assertEquals(0, getCounts(user).darTotal());
+  }
+
+  @Test
+  void countsApprovalsOlderThanAYearAsExpiredInsteadOfDroppingThem() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer expiredDataset = createDataset(user);
+    Integer activeDataset = createDataset(user);
+    Integer expiringSoonDataset = createDataset(user);
+    approveDatasetSubmittedDaysAgo(user, expiredDataset, EXPIRATION_DAYS + 10);
+    approveDatasetSubmittedDaysAgo(user, activeDataset, 5);
+    approveDatasetSubmittedDaysAgo(user, expiringSoonDataset, EXPIRATION_DAYS - 10);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    assertEquals(1, counts.approvalsExpired());
+    // Expiring soon is a subset of active, as the tile reads it.
+    assertEquals(2, counts.approvalsActive());
+    assertEquals(1, counts.approvalsExpiringSoon());
+  }
+
+  @Test
+  void doesNotCountDatasetsWithoutAnApprovingVote() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), FIXED_DATE);
+    approve(user, referenceId, datasetId, VoteType.FINAL, false);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    assertEquals(0, counts.approvalsActive());
+    assertEquals(0, counts.approvalsExpired());
+  }
+
+  @Test
+  void doesNotCountApprovalsFromAClosedOutCollection() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setCloseoutSupplement(
+        new CloseoutSupplement(List.of("Project completed"), "Closeout notes", user.getUserId()));
+    String referenceId = createSubmittedDar(user, datasetId, data, recentDate(5));
+    approve(user, referenceId, datasetId, VoteType.FINAL, true);
+
+    assertEquals(0, getCounts(user).approvalsActive());
+  }
+
+  @Test
+  void doesNotCountApprovalsForResearcherWithoutALibraryCard() {
+    User user = createUser();
+    Integer datasetId = createDataset(user);
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), recentDate(5));
+    approve(user, referenceId, datasetId, VoteType.FINAL, true);
+
+    assertEquals(0, getCounts(user).approvalsActive());
+  }
+
+  /**
+   * The dashboard's Active count and the My Dataset Approvals page must agree, so these compare
+   * this DAO against the query that page renders from.
+   */
+  private long pageRowCount(User user) {
+    return datasetDAO.getApprovedDatasets(user.getUserId()).size();
+  }
+
+  @Test
+  void activeCountMatchesTheApprovalsPageForSeparateCollections() {
+    User user = createUser();
+    giveLibraryCard(user);
+    approveDatasetSubmittedDaysAgo(user, createDataset(user), 5);
+    approveDatasetSubmittedDaysAgo(user, createDataset(user), 30);
+
+    assertEquals(pageRowCount(user), getCounts(user).approvalsActive());
+    assertEquals(2, getCounts(user).approvalsActive());
+  }
+
+  @Test
+  void activeCountMatchesTheApprovalsPageWhenACollectionHasSeveralSubmissions() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    Integer collectionId = createCollection(user);
+    // A revised DAR: two submissions of the same collection, both approved for the same dataset.
+    // The page reduces them to one row, keyed by dar_code and dataset.
+    String first =
+        insertSubmittedDar(
+            user, collectionId, datasetId, new DataAccessRequestData(), recentDate(90));
+    approve(user, first, datasetId, VoteType.FINAL, true);
+    String second =
+        insertSubmittedDar(
+            user, collectionId, datasetId, new DataAccessRequestData(), recentDate(5));
+    approve(user, second, datasetId, VoteType.FINAL, true);
+
+    assertEquals(pageRowCount(user), getCounts(user).approvalsActive());
+    assertEquals(1, getCounts(user).approvalsActive());
+  }
+
+  @Test
+  void countsTheSameDatasetOnceForEachCollectionThatApprovedIt() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    approveDatasetSubmittedDaysAgo(user, datasetId, 5);
+    approveDatasetSubmittedDaysAgo(user, datasetId, 40);
+
+    assertEquals(pageRowCount(user), getCounts(user).approvalsActive());
+    assertEquals(2, getCounts(user).approvalsActive());
+  }
+
+  @Test
+  void datesARevisedApprovalFromItsLatestSubmission() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    Integer collectionId = createCollection(user);
+    // The first submission is already past the one-year window; the revision is not, so the
+    // approval is still active.
+    String stale =
+        insertSubmittedDar(
+            user,
+            collectionId,
+            datasetId,
+            new DataAccessRequestData(),
+            recentDate(EXPIRATION_DAYS + 10));
+    approve(user, stale, datasetId, VoteType.FINAL, true);
+    String revised =
+        insertSubmittedDar(
+            user, collectionId, datasetId, new DataAccessRequestData(), recentDate(5));
+    approve(user, revised, datasetId, VoteType.FINAL, true);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    assertEquals(1, counts.approvalsActive());
+    assertEquals(0, counts.approvalsExpired());
+    assertEquals(pageRowCount(user), counts.approvalsActive());
+  }
+
+  @Test
+  void agreesWithTheApprovalsPageWhenVoteCreateAndUpdateOrderDisagree() {
+    User user = createUser();
+    giveLibraryCard(user);
+    Integer datasetId = createDataset(user);
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), recentDate(5));
+    // A re-opened election: the vote created first was edited last. Ranking by create_date and
+    // ranking by update_date therefore pick different votes.
+    Date early = Date.from(Instant.now().minus(10, ChronoUnit.DAYS));
+    Date late = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+    Integer firstElection =
+        electionDAO.insertElection(
+            ElectionType.DATA_ACCESS.getValue(),
+            ElectionStatus.CLOSED.getValue(),
+            FIXED_DATE,
+            referenceId,
+            datasetId);
+    Integer firstVote =
+        voteDAO.insertVote(user.getUserId(), firstElection, VoteType.FINAL.getValue());
+    updateVote(false, "not approved", late, firstVote, false, firstElection, early, false);
+    Integer secondElection =
+        electionDAO.insertElection(
+            ElectionType.DATA_ACCESS.getValue(),
+            ElectionStatus.CLOSED.getValue(),
+            FIXED_DATE,
+            referenceId,
+            datasetId);
+    Integer secondVote =
+        voteDAO.insertVote(user.getUserId(), secondElection, VoteType.FINAL.getValue());
+    updateVote(true, "approved", early, secondVote, false, secondElection, late, false);
+
+    assertEquals(pageRowCount(user), getCounts(user).approvalsActive());
+  }
+
+  @Test
+  void activeCountMatchesTheApprovalsPageAcrossAMixedFixture() {
+    User user = createUser();
+    giveLibraryCard(user);
+
+    // Two straightforward approvals in separate collections.
+    approveDatasetSubmittedDaysAgo(user, createDataset(user), 5);
+    approveDatasetSubmittedDaysAgo(user, createDataset(user), 60);
+
+    // Two datasets approved on one DAR.
+    Integer sharedDarFirst = createDataset(user);
+    Integer sharedDarSecond = createDataset(user);
+    String shared =
+        createSubmittedDar(user, sharedDarFirst, new DataAccessRequestData(), recentDate(10));
+    dataAccessRequestDAO.insertDARDatasetRelation(shared, sharedDarSecond);
+    approve(user, shared, sharedDarFirst, VoteType.FINAL, true);
+    approve(user, shared, sharedDarSecond, VoteType.FINAL, true);
+
+    // A revised DAR: one approval across two submissions.
+    Integer revisedDataset = createDataset(user);
+    Integer revisedCollection = createCollection(user);
+    String firstSubmission =
+        insertSubmittedDar(
+            user, revisedCollection, revisedDataset, new DataAccessRequestData(), recentDate(80));
+    approve(user, firstSubmission, revisedDataset, VoteType.FINAL, true);
+    String revision =
+        insertSubmittedDar(
+            user, revisedCollection, revisedDataset, new DataAccessRequestData(), recentDate(3));
+    approve(user, revision, revisedDataset, VoteType.FINAL, true);
+
+    // Excluded by both: voted down, closed out, and another researcher's approval.
+    Integer deniedDataset = createDataset(user);
+    String denied =
+        createSubmittedDar(user, deniedDataset, new DataAccessRequestData(), recentDate(5));
+    approve(user, denied, deniedDataset, VoteType.FINAL, false);
+    Integer closedOutDataset = createDataset(user);
+    DataAccessRequestData closedOut = new DataAccessRequestData();
+    closedOut.setCloseoutSupplement(
+        new CloseoutSupplement(List.of("Project completed"), "Closeout notes", user.getUserId()));
+    String closedOutDar = createSubmittedDar(user, closedOutDataset, closedOut, recentDate(5));
+    approve(user, closedOutDar, closedOutDataset, VoteType.FINAL, true);
+    User otherResearcher = createUser();
+    giveLibraryCard(otherResearcher);
+    approveDatasetSubmittedDaysAgo(otherResearcher, createDataset(otherResearcher), 5);
+
+    // Counted only by the dashboard: the approvals page filters expired approvals out entirely.
+    approveDatasetSubmittedDaysAgo(user, createDataset(user), EXPIRATION_DAYS + 20);
+
+    DashboardDatabaseCounts counts = getCounts(user);
+
+    assertEquals(pageRowCount(user), counts.approvalsActive());
+    assertEquals(5, counts.approvalsActive());
+    assertEquals(1, counts.approvalsExpired());
+  }
+
+  private void approveDatasetSubmittedDaysAgo(User user, Integer datasetId, int daysAgo) {
+    String referenceId =
+        createSubmittedDar(user, datasetId, new DataAccessRequestData(), recentDate(daysAgo));
+    approve(user, referenceId, datasetId, VoteType.FINAL, true);
+  }
+
+  private void approve(
+      User user, String referenceId, Integer datasetId, VoteType voteType, boolean approved) {
+    Integer electionId =
+        electionDAO.insertElection(
+            ElectionType.DATA_ACCESS.getValue(),
+            ElectionStatus.CLOSED.getValue(),
+            FIXED_DATE,
+            referenceId,
+            datasetId);
+    Integer voteId = voteDAO.insertVote(user.getUserId(), electionId, voteType.getValue());
+    updateVote(
+        approved,
+        approved ? "approved" : "not approved",
+        FIXED_DATE,
+        voteId,
+        false,
+        electionId,
+        FIXED_DATE,
+        false);
+  }
+
+  private static Date recentDate(int daysAgo) {
+    return Date.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS));
+  }
+
+  private void giveLibraryCard(User user) {
+    libraryCardDAO.insertLibraryCard(
+        user.getUserId(), user.getDisplayName(), user.getEmail(), user.getUserId(), FIXED_DATE);
+  }
+
+  private Integer createDataset(User user) {
+    Integer dacId =
+        dacDAO.createDac(
+            "DAC " + UUID.randomUUID(),
+            randomAlphabetic(10) + "@example.org",
+            "",
+            user.getUserId());
+    return datasetDAO.insertDataset(
+        "Dashboard dataset " + UUID.randomUUID(),
+        FIXED_TIMESTAMP,
+        user.getUserId(),
+        UUID.randomUUID().toString(),
+        EMPTY_JSON_DOCUMENT,
+        dacId);
+  }
+
+  private Integer createCollection(User user) {
+    return darCollectionDAO.insertDarCollection(
+        "DAR-" + UUID.randomUUID(), user.getUserId(), FIXED_DATE);
+  }
+
+  private String createSubmittedDar(
+      User user, Integer datasetId, DataAccessRequestData data, Date submissionDate) {
+    return insertSubmittedDar(user, createCollection(user), datasetId, data, submissionDate);
+  }
+
+  private String insertSubmittedDar(
+      User user,
+      Integer collectionId,
+      Integer datasetId,
+      DataAccessRequestData data,
+      Date submissionDate) {
+    String referenceId = UUID.randomUUID().toString();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collectionId,
+        referenceId,
+        user.getUserId(),
+        FIXED_DATE, // createDate
+        submissionDate,
+        FIXED_DATE, // updateDate
+        data,
+        "era-commons-id");
+    dataAccessRequestDAO.insertDARDatasetRelation(referenceId, datasetId);
+    return referenceId;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/ResearcherDashboardResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/ResearcherDashboardResourceTest.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DarRequests;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataLibrary;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DataSubmissions;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary.DatasetApprovals;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.service.ResearcherDashboardService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResearcherDashboardResourceTest {
+
+  @Mock private ResearcherDashboardService dashboardService;
+
+  private ResearcherDashboardResource resource;
+  private DuosUser duosUser;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    resource = new ResearcherDashboardResource(dashboardService);
+    user = new User();
+    user.setEmail("researcher@example.org");
+    duosUser = new DuosUser(new AuthUser("researcher@example.org"), user);
+  }
+
+  @Test
+  void returnsSummary() {
+    ResearcherDashboardSummary summary =
+        new ResearcherDashboardSummary(
+            new DataLibrary(1, 2, 3, 4),
+            new DarRequests(5, 2, 1, 2),
+            new DatasetApprovals(6, 2, 3),
+            new DataSubmissions(7));
+    when(dashboardService.getSummary(user)).thenReturn(summary);
+
+    Response response = resource.getDashboardSummary(duosUser);
+
+    assertEquals(200, response.getStatus());
+    assertEquals(summary, response.getEntity());
+  }
+
+  @Test
+  void mapsAggregationFailureToServerError() {
+    when(dashboardService.getSummary(user)).thenThrow(new IllegalStateException("failed"));
+
+    Response response = resource.getDashboardSummary(duosUser);
+
+    assertEquals(500, response.getStatus());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherDashboardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherDashboardServiceTest.java
@@ -1,0 +1,297 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.JsonParser;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import org.broadinstitute.consent.http.db.ResearcherDashboardDAO;
+import org.broadinstitute.consent.http.db.ResearcherDashboardDAO.DashboardDatabaseCounts;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.ResearcherDashboardSummary;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResearcherDashboardServiceTest {
+
+  private static final String LIBRARY_RESPONSE =
+      """
+      {
+        "hits": {"total": {"value": 40}},
+        "aggregations": {
+          "total_studies": {"value": 7},
+          "datasets_count": {"doc_count": 12},
+          "studies": {"buckets": [
+            {"key": 1, "study_details": {"hits": {"hits": [
+              {"_source": {"study": {"assets": {"models": [{}, {}], "workspaces": [{}]}}}}
+            ]}}},
+            {"key": 2, "study_details": {"hits": {"hits": [
+              {"_source": {"study": {"assets": {"models": [{}]}}}}
+            ]}}},
+            {"key": 3, "study_details": {"hits": {"hits": [
+              {"_source": {"study": {}}}
+            ]}}}
+          ]}
+        }
+      }
+      """;
+
+  // Two studies and five datasets, plus eleven study assets spread across the seven asset tabs.
+  private static final String SUBMISSIONS_RESPONSE =
+      """
+      {
+        "hits": {"total": {"value": 5}},
+        "aggregations": {
+          "total_studies": {"value": 2},
+          "datasets_count": {"doc_count": 5},
+          "studies": {"buckets": [
+            {"key": 1, "study_details": {"hits": {"hits": [
+              {"_source": {"study": {"assets": {
+                "models": [{}, {}],
+                "workspaces": [{}],
+                "clinicalTrials": [{}],
+                "biospecimens": [{}, {}],
+                "publications": [{}],
+                "presentations": [{}],
+                "intellectualProperties": [{}]
+              }}}}
+            ]}}},
+            {"key": 2, "study_details": {"hits": {"hits": [
+              {"_source": {"study": {"assets": {"publications": [{}, {}]}}}}
+            ]}}}
+          ]}
+        }
+      }
+      """;
+
+  @Mock private Jdbi jdbi;
+  @Mock private ResearcherDashboardDAO dashboardDAO;
+  @Mock private ElasticSearchService elasticSearchService;
+
+  private ExecutorService executorService;
+  private ResearcherDashboardService service;
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    executorService = MoreExecutors.newDirectExecutorService();
+    when(jdbi.onDemand(ResearcherDashboardDAO.class)).thenReturn(dashboardDAO);
+    service = new ResearcherDashboardService(jdbi, elasticSearchService, executorService);
+    user = new User();
+    user.setUserId(10);
+    user.setEmail("researcher@example.org");
+    user.setRoles(
+        List.of(
+            new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName())));
+  }
+
+  @AfterEach
+  void tearDown() {
+    executorService.shutdownNow();
+  }
+
+  private static InputStream stream(String json) {
+    return new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void stubDatabaseCounts(DashboardDatabaseCounts counts) {
+    when(dashboardDAO.getCounts(eq(10), anyInt(), anyInt())).thenReturn(counts);
+  }
+
+  private void stubLibrarySearch() throws IOException {
+    when(elasticSearchService.searchDatasetsStream(
+            argThat(q -> q != null && q.contains("total_studies"))))
+        .thenReturn(stream(LIBRARY_RESPONSE));
+  }
+
+  private void stubSubmissionSearch() throws IOException {
+    when(elasticSearchService.searchDatasetsStream(
+            argThat(q -> q != null && q.contains("dataSubmitterId"))))
+        .thenReturn(stream(SUBMISSIONS_RESPONSE));
+  }
+
+  private void makeDataSubmitter() {
+    user.setRoles(
+        List.of(
+            new UserRole(UserRoles.RESEARCHER.getRoleId(), UserRoles.RESEARCHER.getRoleName()),
+            new UserRole(
+                UserRoles.DATASUBMITTER.getRoleId(), UserRoles.DATASUBMITTER.getRoleName())));
+  }
+
+  @Test
+  void combinesDatabaseLibraryAndSubmissionCounts() throws Exception {
+    makeDataSubmitter();
+    stubDatabaseCounts(new DashboardDatabaseCounts(8, 3, 1, 6, 2, 5));
+    stubLibrarySearch();
+    stubSubmissionSearch();
+
+    ResearcherDashboardSummary summary = service.getSummary(user);
+
+    assertEquals(7, summary.dataLibrary().studies());
+    assertEquals(12, summary.dataLibrary().datasets());
+    // Summed once per study, skipping studies with no assets.
+    assertEquals(3, summary.dataLibrary().models());
+    assertEquals(1, summary.dataLibrary().workspaces());
+    assertEquals(8, summary.darRequests().total());
+    assertEquals(3, summary.darRequests().approved());
+    assertEquals(1, summary.darRequests().canceled());
+    assertEquals(4, summary.darRequests().inProcess());
+    assertEquals(6, summary.datasetApprovals().active());
+    assertEquals(2, summary.datasetApprovals().expiringSoon());
+    assertEquals(5, summary.datasetApprovals().expired());
+    // Studies (2) + datasets (5) + the seven asset tabs (11), as the submissions page tabs count.
+    assertEquals(18, summary.dataSubmissions().total());
+  }
+
+  @Test
+  void countsExpiredApprovalsSeparatelyFromActiveOnes() throws Exception {
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 4, 1, 11));
+    stubLibrarySearch();
+
+    ResearcherDashboardSummary summary = service.getSummary(user);
+
+    assertEquals(4, summary.datasetApprovals().active());
+    assertEquals(11, summary.datasetApprovals().expired());
+  }
+
+  @Test
+  void restrictsLibraryToPublicStudiesForUnprivilegedResearcher() throws Exception {
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    stubLibrarySearch();
+
+    service.getSummary(user);
+
+    ArgumentCaptor<String> query = ArgumentCaptor.forClass(String.class);
+    verify(elasticSearchService).searchDatasetsStream(query.capture());
+    assertTrue(query.getValue().contains("study.publicVisibility"));
+  }
+
+  @Test
+  void showsAllStudiesToPrivilegedUser() throws Exception {
+    makeDataSubmitter();
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    stubLibrarySearch();
+    stubSubmissionSearch();
+
+    service.getSummary(user);
+
+    ArgumentCaptor<String> queries = ArgumentCaptor.forClass(String.class);
+    verify(elasticSearchService, times(2)).searchDatasetsStream(queries.capture());
+    assertFalse(
+        queries.getAllValues().stream().anyMatch(q -> q.contains("study.publicVisibility")));
+  }
+
+  @Test
+  void skipsSubmissionSearchForNonSubmitters() throws Exception {
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    stubLibrarySearch();
+
+    ResearcherDashboardSummary summary = service.getSummary(user);
+
+    assertEquals(0, summary.dataSubmissions().total());
+    verify(elasticSearchService, never())
+        .searchDatasetsStream(argThat(q -> q != null && q.contains("dataSubmitterId")));
+  }
+
+  @Test
+  void treatsStudiesWithMissingOrMalformedAssetsAsZero() throws Exception {
+    // Studies with no top hit, no _source, no study, a non-object assets field, and a non-array
+    // asset all have to count as nothing rather than fail the whole dashboard.
+    String response =
+        """
+        {
+          "aggregations": {
+            "total_studies": {"value": 5},
+            "datasets_count": {"doc_count": 5},
+            "studies": {"buckets": [
+              {"key": 1, "study_details": {"hits": {"hits": []}}},
+              {"key": 2, "study_details": {"hits": {"hits": [{"_source": {}}]}}},
+              {"key": 5, "study_details": {"hits": {"hits": [{}]}}},
+              {"key": 3, "study_details": {"hits": {"hits": [
+                {"_source": {"study": {"assets": "none"}}}
+              ]}}},
+              {"key": 4, "study_details": {"hits": {"hits": [
+                {"_source": {"study": {"assets": {"models": 3, "workspaces": [{}]}}}}
+              ]}}}
+            ]}
+          }
+        }
+        """;
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    when(elasticSearchService.searchDatasetsStream(anyString())).thenReturn(stream(response));
+
+    ResearcherDashboardSummary summary = service.getSummary(user);
+
+    assertEquals(0, summary.dataLibrary().models());
+    assertEquals(1, summary.dataLibrary().workspaces());
+  }
+
+  @Test
+  void keepsTheSubmissionsQueryValidWhenAnEmailNeedsEscaping() throws Exception {
+    makeDataSubmitter();
+    user.setEmail("od\"d\\name@example.org");
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    stubLibrarySearch();
+    stubSubmissionSearch();
+
+    service.getSummary(user);
+
+    ArgumentCaptor<String> queries = ArgumentCaptor.forClass(String.class);
+    verify(elasticSearchService, times(2)).searchDatasetsStream(queries.capture());
+    String submissionQuery =
+        queries.getAllValues().stream()
+            .filter(q -> q.contains("dataSubmitterId"))
+            .findFirst()
+            .orElseThrow();
+    assertDoesNotThrow(() -> JsonParser.parseString(submissionQuery));
+    assertTrue(submissionQuery.contains("od\\\"d\\\\name@example.org"));
+  }
+
+  @Test
+  void toleratesADataSubmitterWithNoEmail() throws Exception {
+    makeDataSubmitter();
+    user.setEmail(null);
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    stubLibrarySearch();
+    stubSubmissionSearch();
+
+    assertEquals(18, service.getSummary(user).dataSubmissions().total());
+  }
+
+  @Test
+  void wrapsElasticSearchFailures() throws Exception {
+    stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
+    when(elasticSearchService.searchDatasetsStream(anyString()))
+        .thenThrow(new IOException("index unavailable"));
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> service.getSummary(user));
+    assertTrue(thrown.getMessage().contains("data library statistics"));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/ResearcherDashboardServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ResearcherDashboardServiceTest.java
@@ -15,6 +15,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -255,7 +258,7 @@ class ResearcherDashboardServiceTest {
   @Test
   void keepsTheSubmissionsQueryValidWhenAnEmailNeedsEscaping() throws Exception {
     makeDataSubmitter();
-    user.setEmail("od\"d\\name@example.org");
+    user.setEmail("od\"d\\na\tme\n@example.org");
     stubDatabaseCounts(new DashboardDatabaseCounts(0, 0, 0, 0, 0, 0));
     stubLibrarySearch();
     stubSubmissionSearch();
@@ -269,8 +272,27 @@ class ResearcherDashboardServiceTest {
             .filter(q -> q.contains("dataSubmitterId"))
             .findFirst()
             .orElseThrow();
-    assertDoesNotThrow(() -> JsonParser.parseString(submissionQuery));
-    assertTrue(submissionQuery.contains("od\\\"d\\\\name@example.org"));
+    JsonObject parsed =
+        assertDoesNotThrow(() -> JsonParser.parseString(submissionQuery).getAsJsonObject());
+    assertEquals(user.getEmail(), custodianEmailTerm(parsed));
+  }
+
+  /** Reads back the email the submissions query filters on, as Elastic Search would parse it. */
+  private String custodianEmailTerm(JsonObject query) {
+    JsonArray must = query.getAsJsonObject("query").getAsJsonObject("bool").getAsJsonArray("must");
+    for (JsonElement clause : must) {
+      if (!clause.getAsJsonObject().has("bool")) {
+        continue;
+      }
+      for (JsonElement should :
+          clause.getAsJsonObject().getAsJsonObject("bool").getAsJsonArray("should")) {
+        JsonObject term = should.getAsJsonObject().getAsJsonObject("term");
+        if (term != null && term.has("study.dataCustodianEmail")) {
+          return term.get("study.dataCustodianEmail").getAsString();
+        }
+      }
+    }
+    throw new AssertionError("no dataCustodianEmail term in query");
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3937](https://broadworkbench.atlassian.net/browse/DT-3937)

### Summary

* Adds API and documentation to support the Researcher Console Dashboard statistics for the currently logged in user.


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
