### PR TITLE
[DT-3888] Surface SO authorization model on indexed datasets

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -658,8 +658,10 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
       Jdbi jdbi,
       VoteServiceDAO voteServiceDAO,
       VoteService voteService,
-      ElasticSearchService elasticSearchService) {
-    return new DACAutomationRuleService(jdbi, voteServiceDAO, voteService, elasticSearchService);
+      ElasticSearchService elasticSearchService,
+      ExecutorService executorService) {
+    return new DACAutomationRuleService(
+        jdbi, voteServiceDAO, voteService, elasticSearchService, executorService);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -655,8 +655,11 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   @Provides
   @Singleton
   private DACAutomationRuleService providesRuleService(
-      Jdbi jdbi, VoteServiceDAO voteServiceDAO, VoteService voteService) {
-    return new DACAutomationRuleService(jdbi, voteServiceDAO, voteService);
+      Jdbi jdbi,
+      VoteServiceDAO voteServiceDAO,
+      VoteService voteService,
+      ElasticSearchService elasticSearchService) {
+    return new DACAutomationRuleService(jdbi, voteServiceDAO, voteService, elasticSearchService);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -158,8 +158,9 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
   List<DACAutomationRule> findAllDACAutomationRulesByDACId(@Bind("dacId") int dacId);
 
   /**
-   * Ids of every DAC that currently has the given rule enabled. A rule is enabled for a DAC when a
-   * dac_rule_settings row exists for that pairing.
+   * Ids of every DAC that currently has the given rule enabled. A rule counts as enabled for a DAC
+   * when a dac_rule_settings row exists for that pairing and the rule itself is still AVAILABLE, so
+   * a retired rule is not reported as enabled — matching findAllDACAutomationRulesByDACId.
    *
    * <p>Deliberately keyed by DAC rather than by dataset — unlike {@code
    * DatasetDAO.filterDatasetIdsByAutomationRuleType}, which takes a dataset id list. Indexing walks

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -171,7 +171,7 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       SELECT DISTINCT settings.dac_id
       FROM dac_rule_settings settings
       INNER JOIN dac_automation_rules rules ON rules.id = settings.rule_id
-      WHERE rules.rule::text = :ruleType AND rules.state = 'AVAILABLE'
+      WHERE rules.rule = :ruleType::dac_rule_type AND rules.state = 'AVAILABLE'
       """)
   Set<Integer> findDacIdsWithRuleEnabled(@Bind("ruleType") DACAutomationRuleType ruleType);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -2,12 +2,12 @@ package org.broadinstitute.consent.http.db;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Set;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleAuditMapper;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleMapper;
+import org.broadinstitute.consent.http.db.mapper.DACRuleAssignmentMapper;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
-import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
+import org.broadinstitute.consent.http.rules.DACRuleAssignment;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -158,23 +158,27 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
   List<DACAutomationRule> findAllDACAutomationRulesByDACId(@Bind("dacId") int dacId);
 
   /**
-   * Ids of every DAC that currently has the given rule enabled. A rule counts as enabled for a DAC
-   * when a dac_rule_settings row exists for that pairing and the rule itself is still AVAILABLE, so
-   * a retired rule is not reported as enabled — matching findAllDACAutomationRulesByDACId.
+   * Every DAC-to-rule pairing that is currently enabled. A rule counts as enabled for a DAC when a
+   * dac_rule_settings row exists for that pairing and the rule itself is still AVAILABLE, so a
+   * retired rule is not reported as enabled — matching findAllDACAutomationRulesByDACId.
    *
    * <p>Deliberately keyed by DAC rather than by dataset — unlike {@code
    * DatasetDAO.filterDatasetIdsByAutomationRuleType}, which takes a dataset id list. Indexing walks
    * the entire dataset corpus, so a dataset-keyed query would mean an unbounded IN list; the result
    * here is bounded by the number of DACs no matter how many datasets are being indexed.
+   *
+   * <p>Returns all rule types in one pass rather than taking a rule type argument, so indexing
+   * resolves every rule it decorates datasets with in a single query.
    */
+  @RegisterRowMapper(DACRuleAssignmentMapper.class)
   @SqlQuery(
       """
-      SELECT DISTINCT settings.dac_id
+      SELECT DISTINCT settings.dac_id, rules.rule
       FROM dac_rule_settings settings
       INNER JOIN dac_automation_rules rules ON rules.id = settings.rule_id
-      WHERE rules.rule = :ruleType::dac_rule_type AND rules.state = 'AVAILABLE'
+      WHERE rules.state = 'AVAILABLE'
       """)
-  Set<Integer> findDacIdsWithRuleEnabled(@Bind("ruleType") DACAutomationRuleType ruleType);
+  List<DACRuleAssignment> findEnabledRuleAssignments();
 
   @RegisterRowMapper(DACAutomationRuleAuditMapper.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -2,10 +2,12 @@ package org.broadinstitute.consent.http.db;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleAuditMapper;
 import org.broadinstitute.consent.http.db.mapper.DACAutomationRuleMapper;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
+import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -154,6 +156,24 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       ORDER BY rules.id ASC
       """)
   List<DACAutomationRule> findAllDACAutomationRulesByDACId(@Bind("dacId") int dacId);
+
+  /**
+   * Ids of every DAC that currently has the given rule enabled. A rule is enabled for a DAC when a
+   * dac_rule_settings row exists for that pairing.
+   *
+   * <p>Deliberately keyed by DAC rather than by dataset — unlike {@code
+   * DatasetDAO.filterDatasetIdsByAutomationRuleType}, which takes a dataset id list. Indexing walks
+   * the entire dataset corpus, so a dataset-keyed query would mean an unbounded IN list; the result
+   * here is bounded by the number of DACs no matter how many datasets are being indexed.
+   */
+  @SqlQuery(
+      """
+      SELECT DISTINCT settings.dac_id
+      FROM dac_rule_settings settings
+      INNER JOIN dac_automation_rules rules ON rules.id = settings.rule_id
+      WHERE rules.rule::text = :ruleType AND rules.state = 'AVAILABLE'
+      """)
+  Set<Integer> findDacIdsWithRuleEnabled(@Bind("ruleType") DACAutomationRuleType ruleType);
 
   @RegisterRowMapper(DACAutomationRuleAuditMapper.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -161,6 +161,9 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
    * Every enabled DAC-to-rule pairing, in one pass. Keyed by DAC rather than by dataset — unlike
    * {@code DatasetDAO.filterDatasetIdsByAutomationRuleType} — so indexing the whole corpus does not
    * need an unbounded IN list.
+   *
+   * <p>Both columns are nullable, so both are checked: a settings row naming no user is what
+   * findAllDACAutomationRulesByDACId reports as disabled, and a null dac_id has no pairing to key.
    */
   @RegisterRowMapper(DACRuleAssignmentMapper.class)
   @SqlQuery(
@@ -169,6 +172,8 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
       FROM dac_rule_settings settings
       INNER JOIN dac_automation_rules rules ON rules.id = settings.rule_id
       WHERE rules.state = 'AVAILABLE'
+        AND settings.dac_id IS NOT NULL
+        AND settings.user_id IS NOT NULL
       """)
   List<DACRuleAssignment> findEnabledRuleAssignments();
 

--- a/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAO.java
@@ -158,17 +158,9 @@ public interface DACAutomationRuleDAO extends Transactional<DACAutomationRuleDAO
   List<DACAutomationRule> findAllDACAutomationRulesByDACId(@Bind("dacId") int dacId);
 
   /**
-   * Every DAC-to-rule pairing that is currently enabled. A rule counts as enabled for a DAC when a
-   * dac_rule_settings row exists for that pairing and the rule itself is still AVAILABLE, so a
-   * retired rule is not reported as enabled — matching findAllDACAutomationRulesByDACId.
-   *
-   * <p>Deliberately keyed by DAC rather than by dataset — unlike {@code
-   * DatasetDAO.filterDatasetIdsByAutomationRuleType}, which takes a dataset id list. Indexing walks
-   * the entire dataset corpus, so a dataset-keyed query would mean an unbounded IN list; the result
-   * here is bounded by the number of DACs no matter how many datasets are being indexed.
-   *
-   * <p>Returns all rule types in one pass rather than taking a rule type argument, so indexing
-   * resolves every rule it decorates datasets with in a single query.
+   * Every enabled DAC-to-rule pairing, in one pass. Keyed by DAC rather than by dataset — unlike
+   * {@code DatasetDAO.filterDatasetIdsByAutomationRuleType} — so indexing the whole corpus does not
+   * need an unbounded IN list.
    */
   @RegisterRowMapper(DACRuleAssignmentMapper.class)
   @SqlQuery(

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/DACRuleAssignmentMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/DACRuleAssignmentMapper.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
+import org.broadinstitute.consent.http.rules.DACRuleAssignment;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class DACRuleAssignmentMapper implements RowMapper<DACRuleAssignment> {
+
+  @Override
+  public DACRuleAssignment map(ResultSet rs, StatementContext ctx) throws SQLException {
+    return new DACRuleAssignment(
+        rs.getInt("dac_id"), DACAutomationRuleType.valueOf(rs.getString("rule")));
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
@@ -1,0 +1,47 @@
+package org.broadinstitute.consent.http.enumeration;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Which Signing Official authorization model applies to a dataset, derived from whether the
+ * dataset's DAC has the REQUIRE_SO_DAR_APPROVAL automation rule enabled. Surfaced on indexed
+ * datasets so clients do not have to resolve DAC rules themselves.
+ */
+public enum SoApprovalModel {
+  /** The SO named in each DAR must approve that request before the DAC reviews it. */
+  @SerializedName("PER_DAR")
+  PER_DAR("PER_DAR"),
+
+  /** The SO authorizes researchers in advance; no per-request SO approval is needed. */
+  @SerializedName("PRE_AUTHORIZED")
+  PRE_AUTHORIZED("PRE_AUTHORIZED");
+
+  private final String value;
+
+  public static List<String> getValues() {
+    return Stream.of(SoApprovalModel.values())
+        .map(SoApprovalModel::getValue)
+        .collect(Collectors.toList());
+  }
+
+  SoApprovalModel(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static SoApprovalModel fromValue(String value) {
+    Optional<SoApprovalModel> model =
+        EnumSet.allOf(SoApprovalModel.class).stream()
+            .filter(m -> m.getValue().equalsIgnoreCase(value))
+            .findFirst();
+    return model.orElse(null);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
@@ -11,9 +11,9 @@ import com.google.gson.annotations.SerializedName;
  * change the published contract.
  */
 public enum SoApprovalModel {
-  /** The SO named in each DAR must approve that request before the DAC reviews it. */
-  @SerializedName("PER_DAR")
-  PER_DAR,
+  /** The SO named in each access request must approve that request before the DAC reviews it. */
+  @SerializedName("PER_REQUEST")
+  PER_REQUEST,
 
   /** The SO authorizes researchers in advance; no per-request SO approval is needed. */
   @SerializedName("PRE_AUTHORIZED")

--- a/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/SoApprovalModel.java
@@ -1,47 +1,21 @@
 package org.broadinstitute.consent.http.enumeration;
 
 import com.google.gson.annotations.SerializedName;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Which Signing Official authorization model applies to a dataset, derived from whether the
  * dataset's DAC has the REQUIRE_SO_DAR_APPROVAL automation rule enabled. Surfaced on indexed
  * datasets so clients do not have to resolve DAC rules themselves.
+ *
+ * <p>The wire values are pinned with {@link SerializedName} so renaming a constant cannot silently
+ * change the published contract.
  */
 public enum SoApprovalModel {
   /** The SO named in each DAR must approve that request before the DAC reviews it. */
   @SerializedName("PER_DAR")
-  PER_DAR("PER_DAR"),
+  PER_DAR,
 
   /** The SO authorizes researchers in advance; no per-request SO approval is needed. */
   @SerializedName("PRE_AUTHORIZED")
-  PRE_AUTHORIZED("PRE_AUTHORIZED");
-
-  private final String value;
-
-  public static List<String> getValues() {
-    return Stream.of(SoApprovalModel.values())
-        .map(SoApprovalModel::getValue)
-        .collect(Collectors.toList());
-  }
-
-  SoApprovalModel(String value) {
-    this.value = value;
-  }
-
-  public String getValue() {
-    return value;
-  }
-
-  public static SoApprovalModel fromValue(String value) {
-    Optional<SoApprovalModel> model =
-        EnumSet.allOf(SoApprovalModel.class).stream()
-            .filter(m -> m.getValue().equalsIgnoreCase(value))
-            .findFirst();
-    return model.orElse(null);
-  }
+  PRE_AUTHORIZED
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
@@ -11,12 +11,9 @@ public final class DataUsePrimaryClassifier {
 
   /**
    * Whether a Data Use has the single-primary shape DAC automation supports. {@code Shape.SINGLE}
-   * also covers an Other-only primary category, which is non-canonical and must be excluded here to
-   * match the abstention policy in {@code DataUseMatcherV5}.
-   *
-   * <p>Both the approval engine and dataset indexing gate on this before consulting a rule, so it
-   * lives here rather than in either caller — the two must not be able to disagree about which
-   * datasets automation can act on.
+   * also covers an Other-only primary category, which is non-canonical and excluded here to match
+   * the abstention policy in {@code DataUseMatcherV5}. Shared by the approval engine and dataset
+   * indexing, which both gate on it before consulting a rule.
    */
   public static boolean hasCanonicalSinglePrimary(DataUse dataUse) {
     if (dataUse == null) {

--- a/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/datause/DataUsePrimaryClassifier.java
@@ -9,6 +9,24 @@ public final class DataUsePrimaryClassifier {
 
   private DataUsePrimaryClassifier() {}
 
+  /**
+   * Whether a Data Use has the single-primary shape DAC automation supports. {@code Shape.SINGLE}
+   * also covers an Other-only primary category, which is non-canonical and must be excluded here to
+   * match the abstention policy in {@code DataUseMatcherV5}.
+   *
+   * <p>Both the approval engine and dataset indexing gate on this before consulting a rule, so it
+   * lives here rather than in either caller — the two must not be able to disagree about which
+   * datasets automation can act on.
+   */
+  public static boolean hasCanonicalSinglePrimary(DataUse dataUse) {
+    if (dataUse == null) {
+      return false;
+    }
+    DataUsePrimaryClassification classification = classify(dataUse);
+    return classification.shape() == DataUsePrimaryClassification.Shape.SINGLE
+        && !classification.categories().contains(DataUsePrimaryCategory.OTHER);
+  }
+
   public static DataUsePrimaryClassification classify(DataUse dataUse) {
     return classify(
         dataUse.getGeneralUse(),

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.models.elastic_search;
 
 import java.util.Map;
+import org.broadinstitute.consent.http.enumeration.SoApprovalModel;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 
 public class DatasetTerm {
@@ -24,6 +25,7 @@ public class DatasetTerm {
   private UserTerm submitter;
   private UserTerm updateUser;
   private DacTerm dac;
+  private SoApprovalModel soApprovalModel;
   private Boolean hasInstitutionCertification;
   private Map<String, Object> data;
 
@@ -169,6 +171,14 @@ public class DatasetTerm {
 
   public void setDac(DacTerm dac) {
     this.dac = dac;
+  }
+
+  public SoApprovalModel getSoApprovalModel() {
+    return soApprovalModel;
+  }
+
+  public void setSoApprovalModel(SoApprovalModel soApprovalModel) {
+    this.soApprovalModel = soApprovalModel;
   }
 
   public Boolean getHasInstitutionCertification() {

--- a/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/elastic_search/DatasetTerm.java
@@ -26,6 +26,7 @@ public class DatasetTerm {
   private UserTerm updateUser;
   private DacTerm dac;
   private SoApprovalModel soApprovalModel;
+  private Boolean instantApprovalEligible;
   private Boolean hasInstitutionCertification;
   private Map<String, Object> data;
 
@@ -179,6 +180,14 @@ public class DatasetTerm {
 
   public void setSoApprovalModel(SoApprovalModel soApprovalModel) {
     this.soApprovalModel = soApprovalModel;
+  }
+
+  public Boolean getInstantApprovalEligible() {
+    return instantApprovalEligible;
+  }
+
+  public void setInstantApprovalEligible(Boolean instantApprovalEligible) {
+    this.instantApprovalEligible = instantApprovalEligible;
   }
 
   public Boolean getHasInstitutionCertification() {

--- a/src/main/java/org/broadinstitute/consent/http/rules/DACRuleAssignment.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/DACRuleAssignment.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.consent.http.rules;
+
+/** A single DAC-to-rule pairing: this DAC currently has this automation rule enabled. */
+public record DACRuleAssignment(Integer dacId, DACAutomationRuleType ruleType) {}

--- a/src/main/java/org/broadinstitute/consent/http/rules/GeneralResearchUseV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/GeneralResearchUseV1.java
@@ -6,9 +6,12 @@ import org.broadinstitute.consent.http.models.Dataset;
 public class GeneralResearchUseV1 implements RuleImplementationInterface {
 
   public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
-    return Boolean.TRUE.equals(dataset.getDataUse().getGeneralUse())
-        && hasNoModifiers(dataset.getDataUse())
-        && requestIsOnlyHMB(dataAccessRequest.getData());
+    return datasetQualifies(dataset) && requestIsOnlyHMB(dataAccessRequest.getData());
+  }
+
+  @Override
+  public boolean datasetQualifies(Dataset dataset) {
+    return datasetIsUnmodifiedGeneralUse(dataset);
   }
 
   public DACAutomationRuleType getRuleType() {

--- a/src/main/java/org/broadinstitute/consent/http/rules/GeneralResearchUseWithDiseaseSpecificV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/GeneralResearchUseWithDiseaseSpecificV1.java
@@ -12,8 +12,11 @@ public class GeneralResearchUseWithDiseaseSpecificV1 implements RuleImplementati
 
   @Override
   public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
-    return Boolean.TRUE.equals(dataset.getDataUse().getGeneralUse())
-        && hasNoModifiers(dataset.getDataUse())
-        && requestHasDiseases(dataAccessRequest.getData());
+    return datasetQualifies(dataset) && requestHasDiseases(dataAccessRequest.getData());
+  }
+
+  @Override
+  public boolean datasetQualifies(Dataset dataset) {
+    return datasetIsUnmodifiedGeneralUse(dataset);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/rules/HealthMedicalBioMedicalV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/HealthMedicalBioMedicalV1.java
@@ -12,8 +12,11 @@ public class HealthMedicalBioMedicalV1 implements RuleImplementationInterface {
 
   @Override
   public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
-    return Boolean.TRUE.equals(dataset.getDataUse().getHmbResearch())
-        && hasNoModifiers(dataset.getDataUse())
-        && requestIsOnlyHMB(dataAccessRequest.getData());
+    return datasetQualifies(dataset) && requestIsOnlyHMB(dataAccessRequest.getData());
+  }
+
+  @Override
+  public boolean datasetQualifies(Dataset dataset) {
+    return datasetIsUnmodifiedHmbResearch(dataset);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/rules/HealthMedicalBioMedicalWithDiseaseSpecificV1.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/HealthMedicalBioMedicalWithDiseaseSpecificV1.java
@@ -12,8 +12,11 @@ public class HealthMedicalBioMedicalWithDiseaseSpecificV1 implements RuleImpleme
 
   @Override
   public boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest) {
-    return Boolean.TRUE.equals(dataset.getDataUse().getHmbResearch())
-        && hasNoModifiers(dataset.getDataUse())
-        && requestHasDiseases(dataAccessRequest.getData());
+    return datasetQualifies(dataset) && requestHasDiseases(dataAccessRequest.getData());
+  }
+
+  @Override
+  public boolean datasetQualifies(Dataset dataset) {
+    return datasetIsUnmodifiedHmbResearch(dataset);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/rules/RuleImplementationInterface.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/RuleImplementationInterface.java
@@ -14,20 +14,14 @@ public interface RuleImplementationInterface {
 
   /**
    * Whether the dataset's own data use qualifies it for automatic approval under this rule,
-   * independent of any request. {@link #compare} layers the request-side conditions on top.
-   *
-   * <p>Split out so dataset indexing can report auto-approval eligibility with the same predicate
-   * the approval engine applies, rather than a client-side re-derivation that can drift from it.
-   * Rules that never auto-approve return false, matching their {@code compare}.
+   * independent of any request. {@link #compare} layers the request-side conditions on top, and
+   * dataset indexing applies this half alone. Rules that never auto-approve return false.
    */
   default boolean datasetQualifies(Dataset dataset) {
     return false;
   }
 
-  /**
-   * Unlike {@code compare}, this is reached during indexing for datasets that may carry no data use
-   * at all, so the absence of one is a non-match rather than a failure.
-   */
+  /** Reached during indexing for datasets that may carry no data use, so absence is a non-match. */
   default boolean datasetIsUnmodifiedGeneralUse(Dataset dataset) {
     DataUse dataUse = dataset.getDataUse();
     return dataUse != null

--- a/src/main/java/org/broadinstitute/consent/http/rules/RuleImplementationInterface.java
+++ b/src/main/java/org/broadinstitute/consent/http/rules/RuleImplementationInterface.java
@@ -12,6 +12,39 @@ public interface RuleImplementationInterface {
 
   boolean compare(Dataset dataset, DataAccessRequest dataAccessRequest);
 
+  /**
+   * Whether the dataset's own data use qualifies it for automatic approval under this rule,
+   * independent of any request. {@link #compare} layers the request-side conditions on top.
+   *
+   * <p>Split out so dataset indexing can report auto-approval eligibility with the same predicate
+   * the approval engine applies, rather than a client-side re-derivation that can drift from it.
+   * Rules that never auto-approve return false, matching their {@code compare}.
+   */
+  default boolean datasetQualifies(Dataset dataset) {
+    return false;
+  }
+
+  /**
+   * Unlike {@code compare}, this is reached during indexing for datasets that may carry no data use
+   * at all, so the absence of one is a non-match rather than a failure.
+   */
+  default boolean datasetIsUnmodifiedGeneralUse(Dataset dataset) {
+    DataUse dataUse = dataset.getDataUse();
+    return dataUse != null
+        && Boolean.TRUE.equals(dataUse.getGeneralUse())
+        && hasNoModifiers(dataUse);
+  }
+
+  /**
+   * @see #datasetIsUnmodifiedGeneralUse
+   */
+  default boolean datasetIsUnmodifiedHmbResearch(Dataset dataset) {
+    DataUse dataUse = dataset.getDataUse();
+    return dataUse != null
+        && Boolean.TRUE.equals(dataUse.getHmbResearch())
+        && hasNoModifiers(dataUse);
+  }
+
   default boolean hasNoModifiers(DataUse data) {
     if (Boolean.TRUE.equals(data.getCollaboratorRequired())) {
       return false;

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -52,10 +53,15 @@ public class DACAutomationRuleService implements ConsentLogger {
   private final VoteDAO voteDAO;
   private final VoteService voteService;
   private final VoteServiceDAO voteServiceDAO;
+  private final ElasticSearchService elasticSearchService;
 
   @Inject
   public DACAutomationRuleService(
-      Jdbi jdbi, VoteServiceDAO voteServiceDAO, VoteService voteService) {
+      Jdbi jdbi,
+      VoteServiceDAO voteServiceDAO,
+      VoteService voteService,
+      ElasticSearchService elasticSearchService) {
+    this.elasticSearchService = elasticSearchService;
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     this.datasetDAO = jdbi.onDemand(DatasetDAO.class);
     this.ruleDAO = jdbi.onDemand(DACAutomationRuleDAO.class);
@@ -89,24 +95,48 @@ public class DACAutomationRuleService implements ConsentLogger {
   public AutomationRuleToggleResponse toggleRule(Integer dacId, Integer ruleId, User user)
       throws ConsentConflictException, UnprocessableEntityException {
     List<DACAutomationRule> dacRules = ruleDAO.findAllDACAutomationRulesByDACId(dacId);
-    Optional<DACAutomationRule> matchingRule =
+    DACAutomationRule ruleBeingToggled =
         dacRules.stream()
-            .filter(r -> Objects.equals(r.id(), ruleId) && !isNull(r.enabledByUserId()))
-            .findFirst();
-    if (matchingRule.isPresent()) {
+            .filter(r -> Objects.equals(r.id(), ruleId))
+            .findFirst()
+            .orElseThrow(() -> new UnprocessableEntityException("Rule ID not found."));
+    if (!isNull(ruleBeingToggled.enabledByUserId())) {
       ruleDAO.auditedDeleteDACRuleSetting(dacId, ruleId, user.getUserId());
+      reindexDatasetsForSoApprovalChange(dacId, ruleBeingToggled);
       return new AutomationRuleToggleResponse(ruleId, false, -1, null, null);
-    } else {
-      Optional<DACAutomationRule> optionalRuleBeingUpdated =
-          dacRules.stream().filter(r -> Objects.equals(r.id(), ruleId)).findFirst();
-      if (optionalRuleBeingUpdated.isEmpty()) {
-        throw new UnprocessableEntityException("Rule ID not found.");
-      }
     }
     Instant insertTime = Instant.now();
     ruleDAO.auditedInsertDACRuleSetting(dacId, ruleId, user.getUserId(), insertTime);
+    reindexDatasetsForSoApprovalChange(dacId, ruleBeingToggled);
     return new AutomationRuleToggleResponse(
         ruleId, true, insertTime.toEpochMilli(), user.getDisplayName(), user.getEmail());
+  }
+
+  /**
+   * Indexed datasets carry their DAC's Signing Official authorization model, so toggling
+   * REQUIRE_SO_DAR_APPROVAL leaves those documents stale. Reindex failures are logged rather than
+   * raised: the toggle itself is already committed and audited, and the next reindex corrects the
+   * documents.
+   */
+  private void reindexDatasetsForSoApprovalChange(Integer dacId, DACAutomationRule rule) {
+    if (!DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL.equals(rule.ruleType())) {
+      return;
+    }
+    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDacIds(List.of(dacId));
+    if (datasetIds.isEmpty()) {
+      return;
+    }
+    try (Response response = elasticSearchService.indexDatasets(datasetIds)) {
+      if (response.getStatus() >= 400) {
+        logWarn(
+            "Error reindexing datasets after SO approval rule toggle for DAC %d: status %d"
+                .formatted(dacId, response.getStatus()));
+      }
+    } catch (Exception e) {
+      logException(
+          "Unable to reindex datasets after SO approval rule toggle for DAC %d".formatted(dacId),
+          e);
+    }
   }
 
   public Integer removeChairpersonFromDAC(Integer dacId, Integer userId, Integer auditUserId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -8,9 +8,12 @@ import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -54,11 +57,13 @@ public class DACAutomationRuleService implements ConsentLogger {
   private final ElasticSearchService elasticSearchService;
   private final ExecutorService executorService;
 
-  /** Guards both reindex flags; see {@link #reindexDatasetsForRuleChange}. */
+  /** Guards the queue and the running flag; see {@link #reindexDatasetsForRuleChange}. */
   private final Object reindexLock = new Object();
 
+  /** DACs awaiting a reindex, in toggle order. A Set so a DAC queued twice is reindexed once. */
+  private final Set<Integer> pendingDacIds = new LinkedHashSet<>();
+
   private boolean reindexRunning = false;
-  private boolean reindexPending = false;
 
   @Inject
   public DACAutomationRuleService(
@@ -109,28 +114,28 @@ public class DACAutomationRuleService implements ConsentLogger {
             .orElseThrow(() -> new UnprocessableEntityException("Rule ID not found."));
     if (!isNull(ruleBeingToggled.enabledByUserId())) {
       ruleDAO.auditedDeleteDACRuleSetting(dacId, ruleId, user.getUserId());
-      reindexDatasetsForRuleChange();
+      reindexDatasetsForRuleChange(dacId);
       return new AutomationRuleToggleResponse(ruleId, false, -1, null, null);
     }
     Instant insertTime = Instant.now();
     ruleDAO.auditedInsertDACRuleSetting(dacId, ruleId, user.getUserId(), insertTime);
-    reindexDatasetsForRuleChange();
+    reindexDatasetsForRuleChange(dacId);
     return new AutomationRuleToggleResponse(
         ruleId, true, insertTime.toEpochMilli(), user.getDisplayName(), user.getEmail());
   }
 
   /**
-   * Indexed datasets carry state derived from their DAC's automation rules, so a toggle leaves
-   * those documents stale. Reindexes the whole corpus, matching {@code POST /api/dataset/index},
-   * off the request thread so toggle latency does not track corpus size.
+   * Indexed datasets carry state derived from their DAC's automation rules, so a toggle leaves that
+   * DAC's documents stale. Only they are reindexed — most of the corpus is external entries with no
+   * DAC, which no rule change can affect. It runs off the request thread so toggle latency does not
+   * track DAC size.
    *
-   * <p>A toggle arriving mid-pass marks another pass pending rather than starting a second one, so
-   * concurrent toggles cannot stack two whole-corpus reindexes. Coalesced rather than dropped: the
-   * toggle that arrives last carries the newest state.
+   * <p>Queued FIFO, so DACs are reindexed in the order they were toggled. A DAC already queued is
+   * not queued twice: the pending pass has not started and will read the newest state when it does.
    */
-  private void reindexDatasetsForRuleChange() {
+  private void reindexDatasetsForRuleChange(Integer dacId) {
     synchronized (reindexLock) {
-      reindexPending = true;
+      pendingDacIds.add(dacId);
       if (reindexRunning) {
         return;
       }
@@ -139,8 +144,8 @@ public class DACAutomationRuleService implements ConsentLogger {
     try {
       executorService.submit(this::drainPendingReindexes);
     } catch (RuntimeException e) {
-      // Released so a rejected submission does not leave every later toggle coalescing into a
-      // pass that never runs. reindexPending stays true, so the next toggle picks this one up.
+      // Released so a rejected submission does not leave every later toggle queueing behind a drain
+      // that never runs. The queue keeps its entries, so the next toggle picks this one up.
       synchronized (reindexLock) {
         reindexRunning = false;
       }
@@ -149,26 +154,30 @@ public class DACAutomationRuleService implements ConsentLogger {
   }
 
   /**
-   * Runs reindex passes until none is pending. Both flags are read and written under {@code
-   * reindexLock}, so a toggle cannot have its request dropped by clearing {@code reindexRunning}.
+   * Reindexes queued DACs until the queue is empty. The queue and {@code reindexRunning} are read
+   * and written under {@code reindexLock}, so a toggle cannot have its DAC dropped by clearing it.
    */
   private void drainPendingReindexes() {
     boolean released = false;
     try {
       while (true) {
+        Integer dacId;
         synchronized (reindexLock) {
-          if (!reindexPending) {
+          Iterator<Integer> queued = pendingDacIds.iterator();
+          if (!queued.hasNext()) {
             reindexRunning = false;
             released = true;
             return;
           }
-          reindexPending = false;
+          dacId = queued.next();
+          queued.remove();
         }
-        reindexAllDatasets();
+        reindexDatasetsForDac(dacId);
       }
     } finally {
-      // Reached only when an Error escapes reindexAllDatasets, which catches every Exception. The
-      // guard must still be released; the flag is local because another drain may own it by now.
+      // Reached only when an Error escapes reindexDatasetsForDac, which catches every Exception.
+      // The guard must still be released; the flag is local because another drain may own it by
+      // now.
       if (!released) {
         synchronized (reindexLock) {
           reindexRunning = false;
@@ -182,21 +191,26 @@ public class DACAutomationRuleService implements ConsentLogger {
    * Failures are logged rather than raised: the toggle that triggered this is already committed and
    * audited, so nothing here may fail it, and the next reindex corrects the documents either way.
    */
-  private void reindexAllDatasets() {
+  private void reindexDatasetsForDac(Integer dacId) {
     try {
-      List<Integer> datasetIds = datasetDAO.findAllDatasetIds();
+      // Covers datasets carrying the DAC as a property as well as those assigned to it directly
+      List<Integer> datasetIds =
+          datasetDAO.findDatasetsAssociatedWithDac(dacId).stream()
+              .map(Dataset::getDatasetId)
+              .distinct()
+              .toList();
       if (datasetIds.isEmpty()) {
         return;
       }
       try (Response response = elasticSearchService.indexDatasets(datasetIds)) {
         if (response.getStatus() >= 400) {
           logWarn(
-              "Error reindexing datasets after DAC rule toggle: status %d"
-                  .formatted(response.getStatus()));
+              "Error reindexing datasets for DAC %d after rule toggle: status %d"
+                  .formatted(dacId, response.getStatus()));
         }
       }
     } catch (Exception e) {
-      logException("Unable to reindex datasets after DAC rule toggle", e);
+      logException("Unable to reindex datasets for DAC %d after rule toggle".formatted(dacId), e);
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -142,7 +142,17 @@ public class DACAutomationRuleService implements ConsentLogger {
       }
       reindexRunning = true;
     }
-    executorService.submit(this::drainPendingReindexes);
+    try {
+      executorService.submit(this::drainPendingReindexes);
+    } catch (RuntimeException e) {
+      // Rejected submission (an executor shutting down) would otherwise leave reindexRunning set
+      // with nothing draining it, so every later toggle would coalesce into a pass that never runs.
+      // reindexPending stays true, so the next toggle that does schedule picks this one up.
+      synchronized (reindexLock) {
+        reindexRunning = false;
+      }
+      logException("Unable to schedule dataset reindex after DAC rule toggle", e);
+    }
   }
 
   /**

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -153,24 +153,28 @@ public class DACAutomationRuleService implements ConsentLogger {
    * reindexLock}, so a toggle cannot have its request dropped by clearing {@code reindexRunning}.
    */
   private void drainPendingReindexes() {
+    boolean released = false;
     try {
       while (true) {
         synchronized (reindexLock) {
           if (!reindexPending) {
             reindexRunning = false;
+            released = true;
             return;
           }
           reindexPending = false;
         }
         reindexAllDatasets();
       }
-    } catch (Throwable t) {
-      // An Error escaping the inner catch would otherwise leave reindexRunning stuck set
-      synchronized (reindexLock) {
-        reindexRunning = false;
+    } finally {
+      // Reached only when an Error escapes reindexAllDatasets, which catches every Exception. The
+      // guard must still be released; the flag is local because another drain may own it by now.
+      if (!released) {
+        synchronized (reindexLock) {
+          reindexRunning = false;
+        }
+        logWarn("Dataset reindex after DAC rule toggle terminated unexpectedly");
       }
-      logWarn("Dataset reindex after DAC rule toggle terminated unexpectedly", t);
-      throw t;
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
@@ -24,12 +25,9 @@ import org.broadinstitute.consent.http.exceptions.ConsentConflictException;
 import org.broadinstitute.consent.http.exceptions.UnprocessableEntityException;
 import org.broadinstitute.consent.http.models.AutomationRuleToggleResponse;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
-import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
-import org.broadinstitute.consent.http.models.datause.DataUsePrimaryCategory;
-import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassification.Shape;
 import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
 import org.broadinstitute.consent.http.rules.AuditPageResults;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
@@ -54,14 +52,23 @@ public class DACAutomationRuleService implements ConsentLogger {
   private final VoteService voteService;
   private final VoteServiceDAO voteServiceDAO;
   private final ElasticSearchService elasticSearchService;
+  private final ExecutorService executorService;
+
+  /** Guards both reindex flags; see {@link #reindexDatasetsForRuleChange}. */
+  private final Object reindexLock = new Object();
+
+  private boolean reindexRunning = false;
+  private boolean reindexPending = false;
 
   @Inject
   public DACAutomationRuleService(
       Jdbi jdbi,
       VoteServiceDAO voteServiceDAO,
       VoteService voteService,
-      ElasticSearchService elasticSearchService) {
+      ElasticSearchService elasticSearchService,
+      ExecutorService executorService) {
     this.elasticSearchService = elasticSearchService;
+    this.executorService = executorService;
     this.dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     this.datasetDAO = jdbi.onDemand(DatasetDAO.class);
     this.ruleDAO = jdbi.onDemand(DACAutomationRuleDAO.class);
@@ -102,44 +109,79 @@ public class DACAutomationRuleService implements ConsentLogger {
             .orElseThrow(() -> new UnprocessableEntityException("Rule ID not found."));
     if (!isNull(ruleBeingToggled.enabledByUserId())) {
       ruleDAO.auditedDeleteDACRuleSetting(dacId, ruleId, user.getUserId());
-      reindexDatasetsForSoApprovalChange(dacId, ruleBeingToggled);
+      reindexDatasetsForRuleChange();
       return new AutomationRuleToggleResponse(ruleId, false, -1, null, null);
     }
     Instant insertTime = Instant.now();
     ruleDAO.auditedInsertDACRuleSetting(dacId, ruleId, user.getUserId(), insertTime);
-    reindexDatasetsForSoApprovalChange(dacId, ruleBeingToggled);
+    reindexDatasetsForRuleChange();
     return new AutomationRuleToggleResponse(
         ruleId, true, insertTime.toEpochMilli(), user.getDisplayName(), user.getEmail());
   }
 
   /**
-   * Indexed datasets carry their DAC's Signing Official authorization model, so toggling
-   * REQUIRE_SO_DAR_APPROVAL leaves those documents stale. Reindex failures are logged rather than
-   * raised: the toggle itself is already committed and audited, and the next reindex corrects the
-   * documents.
+   * Indexed datasets carry state derived from their DAC's automation rules — the Signing Official
+   * approval model and instant-approval eligibility — so a toggle leaves those documents stale.
+   *
+   * <p>Reindexes the whole corpus rather than just the toggling DAC's datasets, matching {@code
+   * POST /api/dataset/index}. Rule toggles are rare, and this keeps the reindex off the
+   * unbounded-IN-list path a DAC with many datasets would otherwise take. It runs off the request
+   * thread so toggle latency does not track corpus size.
+   *
+   * <p>Reindexes are coalesced: a toggle arriving while one is in flight does not start a second
+   * pass over the whole corpus, it marks another pass as pending so exactly one more runs once the
+   * current one finishes. Coalescing rather than skipping matters — the toggle that arrives last
+   * carries the newest state, so dropping it would leave the index behind until something else
+   * triggered a reindex.
    */
-  private void reindexDatasetsForSoApprovalChange(Integer dacId, DACAutomationRule rule) {
-    if (!DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL.equals(rule.ruleType())) {
-      return;
+  private void reindexDatasetsForRuleChange() {
+    synchronized (reindexLock) {
+      reindexPending = true;
+      if (reindexRunning) {
+        return;
+      }
+      reindexRunning = true;
     }
-    // The dataset lookup is inside the try as well: the rule change is already committed and
-    // audited by this point, so nothing here may fail the toggle
+    executorService.submit(this::drainPendingReindexes);
+  }
+
+  /**
+   * Runs reindex passes until none is pending. Both flags are read and written under {@code
+   * reindexLock}, so a toggle cannot observe {@code reindexRunning} as true moments before this
+   * clears it and have its request dropped.
+   */
+  private void drainPendingReindexes() {
+    while (true) {
+      synchronized (reindexLock) {
+        if (!reindexPending) {
+          reindexRunning = false;
+          return;
+        }
+        reindexPending = false;
+      }
+      reindexAllDatasets();
+    }
+  }
+
+  /**
+   * Failures are logged rather than raised: the toggle that triggered this is already committed and
+   * audited, so nothing here may fail it, and the next reindex corrects the documents either way.
+   */
+  private void reindexAllDatasets() {
     try {
-      List<Integer> datasetIds = datasetDAO.findDatasetIdsByDacIds(List.of(dacId));
+      List<Integer> datasetIds = datasetDAO.findAllDatasetIds();
       if (datasetIds.isEmpty()) {
         return;
       }
       try (Response response = elasticSearchService.indexDatasets(datasetIds)) {
         if (response.getStatus() >= 400) {
           logWarn(
-              "Error reindexing datasets after SO approval rule toggle for DAC %d: status %d"
-                  .formatted(dacId, response.getStatus()));
+              "Error reindexing datasets after DAC rule toggle: status %d"
+                  .formatted(response.getStatus()));
         }
       }
     } catch (Exception e) {
-      logException(
-          "Unable to reindex datasets after SO approval rule toggle for DAC %d".formatted(dacId),
-          e);
+      logException("Unable to reindex datasets after DAC rule toggle", e);
     }
   }
 
@@ -197,7 +239,7 @@ public class DACAutomationRuleService implements ConsentLogger {
   @VisibleForTesting
   protected Optional<Vote> applyRule(
       DACAutomationRule rule, Dataset dataset, DataAccessRequest dar, ContainerRequest request) {
-    if (dataset.getDataUse() == null || !hasCanonicalSinglePrimaryDataUse(dataset.getDataUse())) {
+    if (!DataUsePrimaryClassifier.hasCanonicalSinglePrimary(dataset.getDataUse())) {
       logInfo(
           String.format(
               "Rule %s not triggered for DAC id: %s and dataset id: %s because the dataset does not have a canonical single primary Data Use",
@@ -222,17 +264,6 @@ public class DACAutomationRuleService implements ConsentLogger {
               darContainsBannedCountry));
     }
     return Optional.empty();
-  }
-
-  /**
-   * DAC automation only supports canonical single-primary Data Use shapes. {@code Shape.SINGLE}
-   * also covers an Other-only primary category, which is non-canonical and must be excluded here to
-   * match the abstention policy in {@code DataUseMatcherV5}.
-   */
-  private boolean hasCanonicalSinglePrimaryDataUse(DataUse dataUse) {
-    var classification = DataUsePrimaryClassifier.classify(dataUse);
-    return classification.shape() == Shape.SINGLE
-        && !classification.categories().contains(DataUsePrimaryCategory.OTHER);
   }
 
   @VisibleForTesting

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -122,15 +122,19 @@ public class DACAutomationRuleService implements ConsentLogger {
     if (!DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL.equals(rule.ruleType())) {
       return;
     }
-    List<Integer> datasetIds = datasetDAO.findDatasetIdsByDacIds(List.of(dacId));
-    if (datasetIds.isEmpty()) {
-      return;
-    }
-    try (Response response = elasticSearchService.indexDatasets(datasetIds)) {
-      if (response.getStatus() >= 400) {
-        logWarn(
-            "Error reindexing datasets after SO approval rule toggle for DAC %d: status %d"
-                .formatted(dacId, response.getStatus()));
+    // The dataset lookup is inside the try as well: the rule change is already committed and
+    // audited by this point, so nothing here may fail the toggle
+    try {
+      List<Integer> datasetIds = datasetDAO.findDatasetIdsByDacIds(List.of(dacId));
+      if (datasetIds.isEmpty()) {
+        return;
+      }
+      try (Response response = elasticSearchService.indexDatasets(datasetIds)) {
+        if (response.getStatus() >= 400) {
+          logWarn(
+              "Error reindexing datasets after SO approval rule toggle for DAC %d: status %d"
+                  .formatted(dacId, response.getStatus()));
+        }
       }
     } catch (Exception e) {
       logException(

--- a/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DACAutomationRuleService.java
@@ -120,19 +120,13 @@ public class DACAutomationRuleService implements ConsentLogger {
   }
 
   /**
-   * Indexed datasets carry state derived from their DAC's automation rules — the Signing Official
-   * approval model and instant-approval eligibility — so a toggle leaves those documents stale.
+   * Indexed datasets carry state derived from their DAC's automation rules, so a toggle leaves
+   * those documents stale. Reindexes the whole corpus, matching {@code POST /api/dataset/index},
+   * off the request thread so toggle latency does not track corpus size.
    *
-   * <p>Reindexes the whole corpus rather than just the toggling DAC's datasets, matching {@code
-   * POST /api/dataset/index}. Rule toggles are rare, and this keeps the reindex off the
-   * unbounded-IN-list path a DAC with many datasets would otherwise take. It runs off the request
-   * thread so toggle latency does not track corpus size.
-   *
-   * <p>Reindexes are coalesced: a toggle arriving while one is in flight does not start a second
-   * pass over the whole corpus, it marks another pass as pending so exactly one more runs once the
-   * current one finishes. Coalescing rather than skipping matters — the toggle that arrives last
-   * carries the newest state, so dropping it would leave the index behind until something else
-   * triggered a reindex.
+   * <p>A toggle arriving mid-pass marks another pass pending rather than starting a second one, so
+   * concurrent toggles cannot stack two whole-corpus reindexes. Coalesced rather than dropped: the
+   * toggle that arrives last carries the newest state.
    */
   private void reindexDatasetsForRuleChange() {
     synchronized (reindexLock) {
@@ -145,9 +139,8 @@ public class DACAutomationRuleService implements ConsentLogger {
     try {
       executorService.submit(this::drainPendingReindexes);
     } catch (RuntimeException e) {
-      // Rejected submission (an executor shutting down) would otherwise leave reindexRunning set
-      // with nothing draining it, so every later toggle would coalesce into a pass that never runs.
-      // reindexPending stays true, so the next toggle that does schedule picks this one up.
+      // Released so a rejected submission does not leave every later toggle coalescing into a
+      // pass that never runs. reindexPending stays true, so the next toggle picks this one up.
       synchronized (reindexLock) {
         reindexRunning = false;
       }
@@ -157,19 +150,27 @@ public class DACAutomationRuleService implements ConsentLogger {
 
   /**
    * Runs reindex passes until none is pending. Both flags are read and written under {@code
-   * reindexLock}, so a toggle cannot observe {@code reindexRunning} as true moments before this
-   * clears it and have its request dropped.
+   * reindexLock}, so a toggle cannot have its request dropped by clearing {@code reindexRunning}.
    */
   private void drainPendingReindexes() {
-    while (true) {
-      synchronized (reindexLock) {
-        if (!reindexPending) {
-          reindexRunning = false;
-          return;
+    try {
+      while (true) {
+        synchronized (reindexLock) {
+          if (!reindexPending) {
+            reindexRunning = false;
+            return;
+          }
+          reindexPending = false;
         }
-        reindexPending = false;
+        reindexAllDatasets();
       }
-      reindexAllDatasets();
+    } catch (Throwable t) {
+      // An Error escaping the inner catch would otherwise leave reindexRunning stuck set
+      synchronized (reindexLock) {
+        reindexRunning = false;
+      }
+      logWarn("Dataset reindex after DAC rule toggle terminated unexpectedly", t);
+      throw t;
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -29,11 +29,13 @@ import java.util.stream.Collectors;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
+import org.broadinstitute.consent.http.enumeration.SoApprovalModel;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetProperty;
@@ -50,6 +52,7 @@ import org.broadinstitute.consent.http.models.elastic_search.InstitutionTerm;
 import org.broadinstitute.consent.http.models.elastic_search.StudyTerm;
 import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -62,6 +65,7 @@ public class ElasticSearchService implements ConsentLogger {
   private final RestClient esClient;
   private final ElasticSearchConfiguration esConfig;
   private final DacDAO dacDAO;
+  private final DACAutomationRuleDAO dacAutomationRuleDAO;
   private final UserDAO userDAO;
   private final OntologyService ontologyService;
   private final InstitutionDAO institutionDAO;
@@ -81,6 +85,7 @@ public class ElasticSearchService implements ConsentLogger {
     this.esClient = esClient;
     this.esConfig = esConfig;
     this.dacDAO = jdbi.onDemand(DacDAO.class);
+    this.dacAutomationRuleDAO = jdbi.onDemand(DACAutomationRuleDAO.class);
     this.userDAO = jdbi.onDemand(UserDAO.class);
     this.ontologyService = ontologyService;
     this.institutionDAO = jdbi.onDemand(InstitutionDAO.class);
@@ -404,8 +409,13 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public Response indexDatasetList(List<Dataset> datasets) throws IOException {
+    // Resolved once for the whole batch rather than per dataset
+    Set<Integer> dacIdsRequiringSoDarApproval = resolveDacIdsRequiringSoDarApproval().orElse(null);
     List<DatasetTerm> datasetTerms =
-        datasets.parallelStream().filter(Objects::nonNull).map(this::toDatasetTerm).toList();
+        datasets.parallelStream()
+            .filter(Objects::nonNull)
+            .map(dataset -> toDatasetTerm(dataset, dacIdsRequiringSoDarApproval))
+            .toList();
     if (datasetTerms.isEmpty()) {
       return Response.status(Status.NOT_FOUND).build();
     }
@@ -433,7 +443,33 @@ public class ElasticSearchService implements ConsentLogger {
     };
   }
 
+  /**
+   * Ids of DACs that require the Signing Official named in a DAR to approve that request before DAC
+   * review. Empty when the rule could not be resolved at all, which is distinct from resolving to
+   * no DACs: indexing continues either way, but an unresolved rule must not be reported as an
+   * authorization model.
+   */
+  private Optional<Set<Integer>> resolveDacIdsRequiringSoDarApproval() {
+    try {
+      return Optional.of(
+          dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+              DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL));
+    } catch (Exception e) {
+      logWarn("Unable to resolve DACs requiring SO DAR approval: %s".formatted(e.getMessage()));
+      return Optional.empty();
+    }
+  }
+
   public DatasetTerm toDatasetTerm(Dataset dataset) {
+    return toDatasetTerm(dataset, resolveDacIdsRequiringSoDarApproval().orElse(null));
+  }
+
+  /**
+   * @param dacIdsRequiringSoDarApproval resolved DAC ids, or {@code null} when the rule could not
+   *     be resolved — the SO approval model is then left unset so clients render nothing rather
+   *     than being told the wrong approval process
+   */
+  public DatasetTerm toDatasetTerm(Dataset dataset, Set<Integer> dacIdsRequiringSoDarApproval) {
     if (Objects.isNull(dataset)) {
       return null;
     }
@@ -471,6 +507,15 @@ public class ElasticSearchService implements ConsentLogger {
               }
               term.setDac(toDacTerm(dac));
             });
+
+    // Left unset when the rule is unresolved; a dataset with no DAC has no per-DAR step to satisfy
+    if (Objects.nonNull(dacIdsRequiringSoDarApproval)) {
+      term.setSoApprovalModel(
+          Objects.nonNull(dataset.getDacId())
+                  && dacIdsRequiringSoDarApproval.contains(dataset.getDacId())
+              ? SoApprovalModel.PER_DAR
+              : SoApprovalModel.PRE_AUTHORIZED);
+    }
 
     if (Objects.nonNull(dataset.getDataUse())) {
       DataUseSummary summary = ontologyService.translateDataUseSummary(dataset.getDataUse());

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -448,13 +448,11 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   /**
-   * The automation rules each DAC currently has enabled, keyed by DAC id.
-   *
-   * <p>{@code Optional.empty()} means the rules could not be resolved at all; an empty map inside
-   * the Optional means they resolved successfully and no DAC has any rule enabled. Indexing
-   * continues either way, but unresolved rules must not be reported as dataset state.
+   * The automation rules each DAC currently has enabled, keyed by DAC id. {@code Optional.empty()}
+   * means they could not be resolved at all, unlike an empty map, which means no DAC has any rule
+   * enabled. Indexing continues either way, but unresolved rules are not reported as dataset state.
    */
-  private Optional<Map<Integer, Set<DACAutomationRuleType>>> resolveEnabledRulesByDacId() {
+  Optional<Map<Integer, Set<DACAutomationRuleType>>> resolveEnabledRulesByDacId() {
     try {
       List<DACRuleAssignment> assignments =
           Objects.requireNonNullElse(dacAutomationRuleDAO.findEnabledRuleAssignments(), List.of());
@@ -473,12 +471,8 @@ public class ElasticSearchService implements ConsentLogger {
 
   /**
    * Whether the dataset's DAC has an enabled rule that would automatically approve a matching
-   * request for it. Evaluated with the rule implementations themselves rather than a re-derivation,
-   * so the indexed flag and the approval engine cannot disagree about which datasets qualify. Only
-   * the dataset half of each rule applies here; the request half is unknowable at indexing time.
-   *
-   * <p>Mirrors {@code DACAutomationRuleService.applyRule}: the shape gate comes first, because
-   * automation abstains on a non-canonical primary Data Use before any rule is consulted.
+   * request for it. Only the dataset half of each rule applies; the request half is unknowable at
+   * indexing time. Mirrors {@code DACAutomationRuleService.applyRule}, shape gate first.
    */
   private boolean isInstantApprovalEligible(Dataset dataset, Set<DACAutomationRuleType> dacRules) {
     if (!DataUsePrimaryClassifier.hasCanonicalSinglePrimary(dataset.getDataUse())) {
@@ -489,23 +483,12 @@ public class ElasticSearchService implements ConsentLogger {
         .anyMatch(rule -> rule.datasetQualifies(dataset));
   }
 
-  public DatasetTerm toDatasetTerm(Dataset dataset) {
-    if (Objects.isNull(dataset)) {
-      return null;
-    }
-    // A dataset with no DAC has no rules to resolve, so it does not need the query at all
-    if (Objects.isNull(dataset.getDacId())) {
-      return toDatasetTerm(dataset, Map.of());
-    }
-    return toDatasetTerm(dataset, resolveEnabledRulesByDacId().orElse(null));
-  }
-
   /**
    * @param enabledRulesByDacId resolved DAC rules, or {@code null} when they could not be resolved
    *     — the rule-derived fields are then left unset so clients render nothing rather than being
    *     told the wrong approval process
    */
-  private DatasetTerm toDatasetTerm(
+  DatasetTerm toDatasetTerm(
       Dataset dataset, Map<Integer, Set<DACAutomationRuleType>> enabledRulesByDacId) {
     if (Objects.isNull(dataset)) {
       return null;

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -43,6 +43,7 @@ import org.broadinstitute.consent.http.models.Institution;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.datause.DataUsePrimaryClassifier;
 import org.broadinstitute.consent.http.models.elastic_search.DacTerm;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.elastic_search.ElasticSearchHits;
@@ -53,6 +54,8 @@ import org.broadinstitute.consent.http.models.elastic_search.StudyTerm;
 import org.broadinstitute.consent.http.models.elastic_search.UserTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
+import org.broadinstitute.consent.http.rules.DACRuleAssignment;
+import org.broadinstitute.consent.http.rules.Rules;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -410,11 +413,12 @@ public class ElasticSearchService implements ConsentLogger {
 
   public Response indexDatasetList(List<Dataset> datasets) throws IOException {
     // Resolved once for the whole batch rather than per dataset
-    Set<Integer> dacIdsRequiringSoDarApproval = resolveDacIdsRequiringSoDarApproval().orElse(null);
+    Map<Integer, Set<DACAutomationRuleType>> enabledRulesByDacId =
+        resolveEnabledRulesByDacId().orElse(null);
     List<DatasetTerm> datasetTerms =
         datasets.parallelStream()
             .filter(Objects::nonNull)
-            .map(dataset -> toDatasetTerm(dataset, dacIdsRequiringSoDarApproval))
+            .map(dataset -> toDatasetTerm(dataset, enabledRulesByDacId))
             .toList();
     if (datasetTerms.isEmpty()) {
       return Response.status(Status.NOT_FOUND).build();
@@ -444,34 +448,62 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   /**
-   * Ids of DACs that require the Signing Official named in a DAR to approve that request before DAC
-   * review.
+   * The automation rules each DAC currently has enabled, keyed by DAC id.
    *
-   * <p>{@code Optional.empty()} means the rule could not be resolved at all; an empty {@code Set}
-   * inside the Optional means it resolved successfully and no DAC has the rule enabled. Indexing
-   * continues either way, but an unresolved rule must not be reported as an authorization model.
+   * <p>{@code Optional.empty()} means the rules could not be resolved at all; an empty map inside
+   * the Optional means they resolved successfully and no DAC has any rule enabled. Indexing
+   * continues either way, but unresolved rules must not be reported as dataset state.
    */
-  private Optional<Set<Integer>> resolveDacIdsRequiringSoDarApproval() {
+  private Optional<Map<Integer, Set<DACAutomationRuleType>>> resolveEnabledRulesByDacId() {
     try {
+      List<DACRuleAssignment> assignments =
+          Objects.requireNonNullElse(dacAutomationRuleDAO.findEnabledRuleAssignments(), List.of());
       return Optional.of(
-          dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-              DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL));
+          assignments.stream()
+              .collect(
+                  Collectors.groupingBy(
+                      DACRuleAssignment::dacId,
+                      Collectors.mapping(
+                          DACRuleAssignment::ruleType, Collectors.toUnmodifiableSet()))));
     } catch (Exception e) {
-      logWarn("Unable to resolve DACs requiring SO DAR approval", e);
+      logWarn("Unable to resolve enabled DAC automation rules", e);
       return Optional.empty();
     }
   }
 
+  /**
+   * Whether the dataset's DAC has an enabled rule that would automatically approve a matching
+   * request for it. Evaluated with the rule implementations themselves rather than a re-derivation,
+   * so the indexed flag and the approval engine cannot disagree about which datasets qualify. Only
+   * the dataset half of each rule applies here; the request half is unknowable at indexing time.
+   *
+   * <p>Mirrors {@code DACAutomationRuleService.applyRule}: the shape gate comes first, because
+   * automation abstains on a non-canonical primary Data Use before any rule is consulted.
+   */
+  private boolean isInstantApprovalEligible(Dataset dataset, Set<DACAutomationRuleType> dacRules) {
+    if (!DataUsePrimaryClassifier.hasCanonicalSinglePrimary(dataset.getDataUse())) {
+      return false;
+    }
+    return Rules.implementationList.stream()
+        .filter(rule -> dacRules.contains(rule.getRuleType()))
+        .anyMatch(rule -> rule.datasetQualifies(dataset));
+  }
+
   public DatasetTerm toDatasetTerm(Dataset dataset) {
-    return toDatasetTerm(dataset, resolveDacIdsRequiringSoDarApproval().orElse(null));
+    // A dataset with no DAC has no rules to resolve, so it does not need the query at all
+    if (Objects.nonNull(dataset) && Objects.isNull(dataset.getDacId())) {
+      return toDatasetTerm(dataset, Map.of());
+    }
+    return toDatasetTerm(dataset, resolveEnabledRulesByDacId().orElse(null));
   }
 
   /**
-   * @param dacIdsRequiringSoDarApproval resolved DAC ids, or {@code null} when the rule could not
-   *     be resolved — the SO approval model is then left unset so clients render nothing rather
-   *     than being told the wrong approval process
+   * @param enabledRulesByDacId resolved DAC rules, or {@code null} when they could not be resolved
+   *     — the rule-derived fields are then left unset so clients render nothing rather than being
+   *     told the wrong approval process
    */
-  private DatasetTerm toDatasetTerm(Dataset dataset, Set<Integer> dacIdsRequiringSoDarApproval) {
+  private DatasetTerm toDatasetTerm(
+      Dataset dataset, Map<Integer, Set<DACAutomationRuleType>> enabledRulesByDacId) {
     if (Objects.isNull(dataset)) {
       return null;
     }
@@ -510,15 +542,20 @@ public class ElasticSearchService implements ConsentLogger {
               term.setDac(toDacTerm(dac));
             });
 
-    // A dataset with no DAC has no per-DAR approval step to satisfy, which holds whether or not
-    // the rule resolved; only datasets whose model depends on the unresolved rule are left unset
+    // A dataset with no DAC has no per-request approval step to satisfy and no DAC rule that could
+    // auto-approve it, which holds whether or not the rules resolved; only datasets whose state
+    // depends on the unresolved rules are left unset
     if (Objects.isNull(dataset.getDacId())) {
       term.setSoApprovalModel(SoApprovalModel.PRE_AUTHORIZED);
-    } else if (Objects.nonNull(dacIdsRequiringSoDarApproval)) {
+      term.setInstantApprovalEligible(false);
+    } else if (Objects.nonNull(enabledRulesByDacId)) {
+      Set<DACAutomationRuleType> dacRules =
+          enabledRulesByDacId.getOrDefault(dataset.getDacId(), Set.of());
       term.setSoApprovalModel(
-          dacIdsRequiringSoDarApproval.contains(dataset.getDacId())
-              ? SoApprovalModel.PER_DAR
+          dacRules.contains(DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL)
+              ? SoApprovalModel.PER_REQUEST
               : SoApprovalModel.PRE_AUTHORIZED);
+      term.setInstantApprovalEligible(isInstantApprovalEligible(dataset, dacRules));
     }
 
     if (Objects.nonNull(dataset.getDataUse())) {

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -471,7 +471,7 @@ public class ElasticSearchService implements ConsentLogger {
    *     be resolved — the SO approval model is then left unset so clients render nothing rather
    *     than being told the wrong approval process
    */
-  public DatasetTerm toDatasetTerm(Dataset dataset, Set<Integer> dacIdsRequiringSoDarApproval) {
+  private DatasetTerm toDatasetTerm(Dataset dataset, Set<Integer> dacIdsRequiringSoDarApproval) {
     if (Objects.isNull(dataset)) {
       return null;
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -490,8 +490,11 @@ public class ElasticSearchService implements ConsentLogger {
   }
 
   public DatasetTerm toDatasetTerm(Dataset dataset) {
+    if (Objects.isNull(dataset)) {
+      return null;
+    }
     // A dataset with no DAC has no rules to resolve, so it does not need the query at all
-    if (Objects.nonNull(dataset) && Objects.isNull(dataset.getDacId())) {
+    if (Objects.isNull(dataset.getDacId())) {
       return toDatasetTerm(dataset, Map.of());
     }
     return toDatasetTerm(dataset, resolveEnabledRulesByDacId().orElse(null));

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -455,7 +455,7 @@ public class ElasticSearchService implements ConsentLogger {
           dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
               DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL));
     } catch (Exception e) {
-      logWarn("Unable to resolve DACs requiring SO DAR approval: %s".formatted(e.getMessage()));
+      logWarn("Unable to resolve DACs requiring SO DAR approval", e);
       return Optional.empty();
     }
   }
@@ -509,10 +509,13 @@ public class ElasticSearchService implements ConsentLogger {
             });
 
     // Left unset when the rule is unresolved; a dataset with no DAC has no per-DAR step to satisfy
-    if (Objects.nonNull(dacIdsRequiringSoDarApproval)) {
+    // A dataset with no DAC has no per-DAR approval step to satisfy, which holds whether or not
+    // the rule resolved; only datasets whose model depends on the unresolved rule are left unset
+    if (Objects.isNull(dataset.getDacId())) {
+      term.setSoApprovalModel(SoApprovalModel.PRE_AUTHORIZED);
+    } else if (Objects.nonNull(dacIdsRequiringSoDarApproval)) {
       term.setSoApprovalModel(
-          Objects.nonNull(dataset.getDacId())
-                  && dacIdsRequiringSoDarApproval.contains(dataset.getDacId())
+          dacIdsRequiringSoDarApproval.contains(dataset.getDacId())
               ? SoApprovalModel.PER_DAR
               : SoApprovalModel.PRE_AUTHORIZED);
     }

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -445,9 +445,11 @@ public class ElasticSearchService implements ConsentLogger {
 
   /**
    * Ids of DACs that require the Signing Official named in a DAR to approve that request before DAC
-   * review. Empty when the rule could not be resolved at all, which is distinct from resolving to
-   * no DACs: indexing continues either way, but an unresolved rule must not be reported as an
-   * authorization model.
+   * review.
+   *
+   * <p>{@code Optional.empty()} means the rule could not be resolved at all; an empty {@code Set}
+   * inside the Optional means it resolved successfully and no DAC has the rule enabled. Indexing
+   * continues either way, but an unresolved rule must not be reported as an authorization model.
    */
   private Optional<Set<Integer>> resolveDacIdsRequiringSoDarApproval() {
     try {
@@ -508,7 +510,6 @@ public class ElasticSearchService implements ConsentLogger {
               term.setDac(toDacTerm(dac));
             });
 
-    // Left unset when the rule is unresolved; a dataset with no DAC has no per-DAR step to satisfy
     // A dataset with no DAC has no per-DAR approval step to satisfy, which holds whether or not
     // the rule resolved; only datasets whose model depends on the unresolved rule are left unset
     if (Objects.isNull(dataset.getDacId())) {

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -68,6 +68,7 @@ post:
                   dataLocation: Not Determined
                   dacId: 3
                   soApprovalModel: PRE_AUTHORIZED
+                  instantApprovalEligible: false
                   accessManagement: controlled
                   study:
                     description: Test study details

--- a/src/main/resources/assets/paths/datasetSearchIndex.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndex.yaml
@@ -67,6 +67,7 @@ post:
                         description: Local ethics committee approval is required.
                   dataLocation: Not Determined
                   dacId: 3
+                  soApprovalModel: PRE_AUTHORIZED
                   accessManagement: controlled
                   study:
                     description: Test study details

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -79,7 +79,8 @@ post:
                               - code: NCU
                           dacId: 2
                           dacApproval: true
-                          soApprovalModel: PER_DAR
+                          soApprovalModel: PER_REQUEST
+                          instantApprovalEligible: false
                           approvedUserIds: [1,2,3]
                           submitter:
                             userId: 10

--- a/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
+++ b/src/main/resources/assets/paths/datasetSearchIndexV2.yaml
@@ -79,6 +79,7 @@ post:
                               - code: NCU
                           dacId: 2
                           dacApproval: true
+                          soApprovalModel: PER_DAR
                           approvedUserIds: [1,2,3]
                           submitter:
                             userId: 10

--- a/src/main/resources/assets/schemas/DatasetSearch.yaml
+++ b/src/main/resources/assets/schemas/DatasetSearch.yaml
@@ -24,6 +24,17 @@ properties:
   dacId:
     type: integer
     description: The unique identifier for a DAC
+  soApprovalModel:
+    type: string
+    enum:
+      - PER_DAR
+      - PRE_AUTHORIZED
+    description: >-
+      Which Signing Official authorization model the dataset's DAC uses. PER_DAR means the SO
+      named in each Data Access Request must approve that request before the DAC reviews it;
+      PRE_AUTHORIZED means the SO authorizes researchers in advance. Absent when the model
+      could not be resolved at indexing time, or on documents indexed before this field
+      existed; clients should treat an absent value as unknown rather than assuming a model.
   study:
     type: object
     title: DatasetSearchStudy

--- a/src/main/resources/assets/schemas/DatasetSearch.yaml
+++ b/src/main/resources/assets/schemas/DatasetSearch.yaml
@@ -27,14 +27,22 @@ properties:
   soApprovalModel:
     type: string
     enum:
-      - PER_DAR
+      - PER_REQUEST
       - PRE_AUTHORIZED
     description: >-
-      Which Signing Official authorization model the dataset's DAC uses. PER_DAR means the SO
-      named in each Data Access Request must approve that request before the DAC reviews it;
+      Which Signing Official authorization model the dataset's DAC uses. PER_REQUEST means the
+      SO named in each access request must approve that request before the DAC reviews it;
       PRE_AUTHORIZED means the SO authorizes researchers in advance. Absent when the model
       could not be resolved at indexing time, or on documents indexed before this field
       existed; clients should treat an absent value as unknown rather than assuming a model.
+  instantApprovalEligible:
+    type: boolean
+    description: >-
+      Whether the dataset's DAC has an automation rule enabled that would automatically approve a
+      matching access request for it. Only the dataset half of each rule is evaluated here, so a
+      true value means the dataset qualifies, not that any given request will be approved. Absent
+      when the DAC's rules could not be resolved at indexing time, or on documents indexed before
+      this field existed; clients should treat an absent value as unknown rather than as false.
   study:
     type: object
     title: DatasetSearchStudy

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
@@ -27,6 +28,47 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
     Assertions.assertFalse(rules.isEmpty());
     assertTrue(
         rules.stream().anyMatch(rule -> rule.ruleType().equals(DACAutomationRuleType.GRU_V1)));
+  }
+
+  @Test
+  void testFindDacIdsWithRuleEnabled() {
+    User user = createUser();
+    Integer enabledDacId = createRandomDAC();
+    Integer untouchedDacId = createRandomDAC();
+    DACAutomationRule soRule =
+        dacAutomationRuleDAO.findAll().stream()
+            .filter(r -> r.ruleType().equals(DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+            .findFirst()
+            .orElseThrow();
+    dacAutomationRuleDAO.auditedInsertDACRuleSetting(
+        enabledDacId, soRule.id(), user.getUserId(), Instant.now());
+
+    Set<Integer> dacIds =
+        dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL);
+
+    assertTrue(dacIds.contains(enabledDacId));
+    Assertions.assertFalse(dacIds.contains(untouchedDacId));
+  }
+
+  @Test
+  void testFindDacIdsWithRuleEnabledIsScopedToTheRequestedRule() {
+    User user = createUser();
+    Integer dacId = createRandomDAC();
+    DACAutomationRule gruRule =
+        dacAutomationRuleDAO.findAll().stream()
+            .filter(r -> r.ruleType().equals(DACAutomationRuleType.GRU_V1))
+            .findFirst()
+            .orElseThrow();
+    dacAutomationRuleDAO.auditedInsertDACRuleSetting(
+        dacId, gruRule.id(), user.getUserId(), Instant.now());
+
+    // Enabling an unrelated rule must not mark the DAC as requiring SO DAR approval
+    Set<Integer> dacIds =
+        dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL);
+
+    Assertions.assertFalse(dacIds.contains(dacId));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -7,11 +7,11 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleAudit;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
+import org.broadinstitute.consent.http.rules.DACRuleAssignment;
 import org.broadinstitute.consent.http.rules.RuleAuditAction;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Assertions;
@@ -30,45 +30,48 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
         rules.stream().anyMatch(rule -> rule.ruleType().equals(DACAutomationRuleType.GRU_V1)));
   }
 
-  @Test
-  void testFindDacIdsWithRuleEnabled() {
-    User user = createUser();
-    Integer enabledDacId = createRandomDAC();
-    Integer untouchedDacId = createRandomDAC();
-    DACAutomationRule soRule =
-        dacAutomationRuleDAO.findAll().stream()
-            .filter(r -> r.ruleType().equals(DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
-            .findFirst()
-            .orElseThrow();
-    dacAutomationRuleDAO.auditedInsertDACRuleSetting(
-        enabledDacId, soRule.id(), user.getUserId(), Instant.now());
-
-    Set<Integer> dacIds =
-        dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL);
-
-    assertTrue(dacIds.contains(enabledDacId));
-    Assertions.assertFalse(dacIds.contains(untouchedDacId));
+  private DACAutomationRule findRule(DACAutomationRuleType ruleType) {
+    return dacAutomationRuleDAO.findAll().stream()
+        .filter(r -> r.ruleType().equals(ruleType))
+        .findFirst()
+        .orElseThrow();
   }
 
   @Test
-  void testFindDacIdsWithRuleEnabledIsScopedToTheRequestedRule() {
+  void testFindEnabledRuleAssignments() {
+    User user = createUser();
+    Integer enabledDacId = createRandomDAC();
+    Integer untouchedDacId = createRandomDAC();
+    DACAutomationRule soRule = findRule(DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL);
+    dacAutomationRuleDAO.auditedInsertDACRuleSetting(
+        enabledDacId, soRule.id(), user.getUserId(), Instant.now());
+
+    List<DACRuleAssignment> assignments = dacAutomationRuleDAO.findEnabledRuleAssignments();
+
+    assertTrue(
+        assignments.contains(
+            new DACRuleAssignment(enabledDacId, DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL)));
+    Assertions.assertFalse(
+        assignments.stream().anyMatch(a -> Objects.equals(a.dacId(), untouchedDacId)));
+  }
+
+  @Test
+  void testFindEnabledRuleAssignmentsReportsTheRuleThatIsEnabled() {
     User user = createUser();
     Integer dacId = createRandomDAC();
-    DACAutomationRule gruRule =
-        dacAutomationRuleDAO.findAll().stream()
-            .filter(r -> r.ruleType().equals(DACAutomationRuleType.GRU_V1))
-            .findFirst()
-            .orElseThrow();
+    DACAutomationRule gruRule = findRule(DACAutomationRuleType.GRU_V1);
     dacAutomationRuleDAO.auditedInsertDACRuleSetting(
         dacId, gruRule.id(), user.getUserId(), Instant.now());
 
-    // Enabling an unrelated rule must not mark the DAC as requiring SO DAR approval
-    Set<Integer> dacIds =
-        dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL);
+    List<DACRuleAssignment> assignments = dacAutomationRuleDAO.findEnabledRuleAssignments();
 
-    Assertions.assertFalse(dacIds.contains(dacId));
+    // Enabling one rule must not report the DAC as having any other rule enabled
+    assertEquals(
+        List.of(DACAutomationRuleType.GRU_V1),
+        assignments.stream()
+            .filter(a -> Objects.equals(a.dacId(), dacId))
+            .map(DACRuleAssignment::ruleType)
+            .toList());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DACAutomationRuleDAOTest.java
@@ -75,6 +75,35 @@ class DACAutomationRuleDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindEnabledRuleAssignmentsIgnoresIncompleteSettingsRows() {
+    User user = createUser();
+    Integer dacId = createRandomDAC();
+    DACAutomationRule gruRule = findRule(DACAutomationRuleType.GRU_V1);
+    // dac_id and user_id are both nullable. A row naming no user is what
+    // findAllDACAutomationRulesByDACId reports as disabled, and a null dac_id has no pairing to key
+    jdbi.useHandle(
+        handle -> {
+          handle
+              .createUpdate(
+                  "INSERT INTO dac_rule_settings (dac_id, rule_id, user_id) VALUES (:dacId, :ruleId, NULL)")
+              .bind("dacId", dacId)
+              .bind("ruleId", gruRule.id())
+              .execute();
+          handle
+              .createUpdate(
+                  "INSERT INTO dac_rule_settings (dac_id, rule_id, user_id) VALUES (NULL, :ruleId, :userId)")
+              .bind("ruleId", gruRule.id())
+              .bind("userId", user.getUserId())
+              .execute();
+        });
+
+    List<DACRuleAssignment> assignments = dacAutomationRuleDAO.findEnabledRuleAssignments();
+
+    Assertions.assertFalse(assignments.stream().anyMatch(a -> Objects.equals(a.dacId(), dacId)));
+    Assertions.assertTrue(assignments.stream().allMatch(a -> Objects.nonNull(a.dacId())));
+  }
+
+  @Test
   void testInsertDACRuleSetting() {
     User user = createUser();
     Integer dacId = createRandomDAC();

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -373,9 +374,10 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
       service.toggleRule(1, 1, user);
       releaseFirstPass.countDown();
 
-      // after() waits the full window before verifying, so an uncoalesced third pass fails this;
-      // timeout().times(2) would return as soon as it saw the second and never notice
-      verify(elasticSearchService, after(1000).times(2)).indexDatasets(List.of(10, 11));
+      // Waits for the follow-up pass rather than assuming a fixed window is long enough for it
+      verify(elasticSearchService, timeout(5000).times(2)).indexDatasets(List.of(10, 11));
+      // Then holds to catch a third: the two toggles must share one pass, not get one each
+      verify(elasticSearchService, after(500).times(2)).indexDatasets(List.of(10, 11));
       assertEquals(2, passes.get());
     } finally {
       releaseFirstPass.countDown();

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -21,12 +22,18 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
@@ -59,6 +66,7 @@ import org.broadinstitute.consent.http.service.dao.VoteServiceDAO;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.transaction.TransactionalCallback;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +97,8 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   @Mock private ContainerRequest request;
 
   private DACAutomationRuleService service;
+
+  private ExecutorService executorService;
 
   private static DACAutomationRule makeDacAutomationRuleGRU() {
     return new DACAutomationRule(
@@ -157,7 +167,16 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(ElectionDAO.class)).thenReturn(electionDAO);
     when(jdbi.onDemand(UserDAO.class)).thenReturn(userDAO);
     when(jdbi.onDemand(VoteDAO.class)).thenReturn(voteDAO);
-    service = new DACAutomationRuleService(jdbi, voteServiceDAO, voteService, elasticSearchService);
+    // Direct executor so the best-effort reindex runs inline and these tests can assert on it
+    executorService = MoreExecutors.newDirectExecutorService();
+    service =
+        new DACAutomationRuleService(
+            jdbi, voteServiceDAO, voteService, elasticSearchService, executorService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    executorService.shutdownNow();
   }
 
   @Test
@@ -242,7 +261,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testToggleSoApprovalRuleReindexesDacDatasets() throws Exception {
+  void testToggleSoApprovalRuleReindexesAllDatasets() throws Exception {
     when(ruleDAO.findAllDACAutomationRulesByDACId(1))
         .thenReturn(
             List.of(
@@ -256,7 +275,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
-    when(datasetDAO.findDatasetIdsByDacIds(List.of(1))).thenReturn(List.of(10, 11));
+    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
     when(elasticSearchService.indexDatasets(List.of(10, 11))).thenReturn(Response.ok().build());
 
     AutomationRuleToggleResponse result = service.toggleRule(1, 1, user);
@@ -266,7 +285,8 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testToggleNonSoApprovalRuleDoesNotReindex() throws Exception {
+  void testToggleAutoApprovalRuleAlsoReindexes() throws Exception {
+    // Auto-approve rules drive instantApprovalEligible, so their toggles stale documents too
     when(ruleDAO.findAllDACAutomationRulesByDACId(1))
         .thenReturn(
             List.of(
@@ -280,6 +300,30 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
+    when(elasticSearchService.indexDatasets(List.of(10, 11))).thenReturn(Response.ok().build());
+
+    service.toggleRule(1, 1, user);
+
+    verify(elasticSearchService).indexDatasets(List.of(10, 11));
+  }
+
+  @Test
+  void testToggleRuleSkipsReindexWhenThereAreNoDatasets() throws Exception {
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.GRU_V1,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of());
 
     service.toggleRule(1, 1, user);
 
@@ -287,7 +331,58 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testToggleSoApprovalRuleSucceedsWhenReindexFails() throws Exception {
+  void testTogglesDuringAnInFlightReindexCoalesceIntoOneFollowUpPass() throws Exception {
+    // A real executor, so the reindex genuinely runs off-thread and can be held mid-flight
+    ExecutorService realExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    service =
+        new DACAutomationRuleService(
+            jdbi, voteServiceDAO, voteService, elasticSearchService, realExecutor);
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.GRU_V1,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
+    CountDownLatch firstPassStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstPass = new CountDownLatch(1);
+    AtomicInteger passes = new AtomicInteger();
+    when(elasticSearchService.indexDatasets(any()))
+        .thenAnswer(
+            invocation -> {
+              if (passes.incrementAndGet() == 1) {
+                firstPassStarted.countDown();
+                releaseFirstPass.await(5, TimeUnit.SECONDS);
+              }
+              return Response.ok().build();
+            });
+
+    try {
+      service.toggleRule(1, 1, user);
+      assertTrue(firstPassStarted.await(5, TimeUnit.SECONDS));
+      // Both land while the first pass is still running, so they share a single follow-up pass
+      service.toggleRule(1, 1, user);
+      service.toggleRule(1, 1, user);
+      releaseFirstPass.countDown();
+
+      // after() waits the full window before verifying, so an uncoalesced third pass fails this;
+      // timeout().times(2) would return as soon as it saw the second and never notice
+      verify(elasticSearchService, after(1000).times(2)).indexDatasets(List.of(10, 11));
+      assertEquals(2, passes.get());
+    } finally {
+      releaseFirstPass.countDown();
+      realExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void testToggleRuleSucceedsWhenReindexFails() throws Exception {
     when(ruleDAO.findAllDACAutomationRulesByDACId(1))
         .thenReturn(
             List.of(
@@ -301,7 +396,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     "alice",
                     "alice@fake.org")));
     doNothing().when(ruleDAO).auditedDeleteDACRuleSetting(anyInt(), anyInt(), anyInt());
-    when(datasetDAO.findDatasetIdsByDacIds(List.of(1))).thenReturn(List.of(10));
+    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10));
     when(elasticSearchService.indexDatasets(List.of(10))).thenThrow(new IOException("es down"));
 
     // The rule change is already committed and audited, so a failed reindex must not surface

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -81,6 +83,8 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   @Mock private UserDAO userDAO;
 
   @Mock private VoteService voteService;
+
+  @Mock private ElasticSearchService elasticSearchService;
 
   @Mock private ContainerRequest request;
 
@@ -153,7 +157,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(ElectionDAO.class)).thenReturn(electionDAO);
     when(jdbi.onDemand(UserDAO.class)).thenReturn(userDAO);
     when(jdbi.onDemand(VoteDAO.class)).thenReturn(voteDAO);
-    service = new DACAutomationRuleService(jdbi, voteServiceDAO, voteService);
+    service = new DACAutomationRuleService(jdbi, voteServiceDAO, voteService, elasticSearchService);
   }
 
   @Test
@@ -235,6 +239,75 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
     assertFalse(result.isRuleEnabled());
     assertEquals(1, result.getRuleId());
     assertEquals(-1, result.getEnabledTime());
+  }
+
+  @Test
+  void testToggleSoApprovalRuleReindexesDacDatasets() throws Exception {
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+    when(datasetDAO.findDatasetIdsByDacIds(List.of(1))).thenReturn(List.of(10, 11));
+    when(elasticSearchService.indexDatasets(List.of(10, 11))).thenReturn(Response.ok().build());
+
+    AutomationRuleToggleResponse result = service.toggleRule(1, 1, user);
+
+    assertTrue(result.isRuleEnabled());
+    verify(elasticSearchService).indexDatasets(List.of(10, 11));
+  }
+
+  @Test
+  void testToggleNonSoApprovalRuleDoesNotReindex() throws Exception {
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.GRU_V1,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+
+    service.toggleRule(1, 1, user);
+
+    verify(elasticSearchService, never()).indexDatasets(any());
+  }
+
+  @Test
+  void testToggleSoApprovalRuleSucceedsWhenReindexFails() throws Exception {
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    FIXED_TIMESTAMP,
+                    1,
+                    "alice",
+                    "alice@fake.org")));
+    doNothing().when(ruleDAO).auditedDeleteDACRuleSetting(anyInt(), anyInt(), anyInt());
+    when(datasetDAO.findDatasetIdsByDacIds(List.of(1))).thenReturn(List.of(10));
+    when(elasticSearchService.indexDatasets(List.of(10))).thenThrow(new IOException("es down"));
+
+    // The rule change is already committed and audited, so a failed reindex must not surface
+    AutomationRuleToggleResponse result = service.toggleRule(1, 1, user);
+
+    assertFalse(result.isRuleEnabled());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -416,6 +416,34 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testToggleRuleStaysSchedulableAfterAnErrorEscapesAReindexPass() throws Exception {
+    // An Error escapes the best-effort catch, which only handles Exception. The guard must still be
+    // released, or every later reindex would coalesce into a pass that never runs.
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.GRU_V1,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+    when(datasetDAO.findAllDatasetIds())
+        .thenThrow(new StackOverflowError("boom"))
+        .thenReturn(List.of(10));
+    when(elasticSearchService.indexDatasets(List.of(10))).thenReturn(Response.ok().build());
+
+    service.toggleRule(1, 1, user);
+    service.toggleRule(1, 1, user);
+
+    verify(elasticSearchService).indexDatasets(List.of(10));
+  }
+
+  @Test
   void testToggleRuleSucceedsWhenReindexFails() throws Exception {
     when(ruleDAO.findAllDACAutomationRulesByDACId(1))
         .thenReturn(

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -27,6 +27,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -162,6 +165,10 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
     return makeDataset(1, "Test Dataset", 0);
   }
 
+  private static List<Dataset> datasetsWithIds(int... datasetIds) {
+    return Arrays.stream(datasetIds).mapToObj(id -> makeDataset(id, "Dataset " + id, 1)).toList();
+  }
+
   @BeforeEach
   void setUp() {
     when(jdbi.onDemand(DataAccessRequestDAO.class)).thenReturn(dataAccessRequestDAO);
@@ -264,7 +271,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
   }
 
   @Test
-  void testToggleSoApprovalRuleReindexesAllDatasets() throws Exception {
+  void testToggleSoApprovalRuleReindexesTheDacsDatasets() throws Exception {
     when(ruleDAO.findAllDACAutomationRulesByDACId(1))
         .thenReturn(
             List.of(
@@ -278,13 +285,15 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
-    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
+    when(datasetDAO.findDatasetsAssociatedWithDac(1)).thenReturn(datasetsWithIds(10, 11));
     when(elasticSearchService.indexDatasets(List.of(10, 11))).thenReturn(Response.ok().build());
 
     AutomationRuleToggleResponse result = service.toggleRule(1, 1, user);
 
     assertTrue(result.isRuleEnabled());
     verify(elasticSearchService).indexDatasets(List.of(10, 11));
+    // The rest of the corpus is external entries with no DAC, which no rule change can affect
+    verify(datasetDAO, never()).findAllDatasetIds();
   }
 
   @Test
@@ -303,7 +312,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
-    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
+    when(datasetDAO.findDatasetsAssociatedWithDac(1)).thenReturn(datasetsWithIds(10, 11));
     when(elasticSearchService.indexDatasets(List.of(10, 11))).thenReturn(Response.ok().build());
 
     service.toggleRule(1, 1, user);
@@ -326,7 +335,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
-    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of());
+    when(datasetDAO.findDatasetsAssociatedWithDac(1)).thenReturn(List.of());
 
     service.toggleRule(1, 1, user);
 
@@ -352,7 +361,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null,
                     null)));
-    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10, 11));
+    when(datasetDAO.findDatasetsAssociatedWithDac(1)).thenReturn(datasetsWithIds(10, 11));
     CountDownLatch firstPassStarted = new CountDownLatch(1);
     CountDownLatch releaseFirstPass = new CountDownLatch(1);
     AtomicInteger passes = new AtomicInteger();
@@ -379,6 +388,61 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
       // Then holds to catch a third: the two toggles must share one pass, not get one each
       verify(elasticSearchService, after(500).times(2)).indexDatasets(List.of(10, 11));
       assertEquals(2, passes.get());
+    } finally {
+      releaseFirstPass.countDown();
+      realExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void testQueuedDacsAreReindexedInTheOrderTheyWereToggled() throws Exception {
+    ExecutorService realExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    service =
+        new DACAutomationRuleService(
+            jdbi, voteServiceDAO, voteService, elasticSearchService, realExecutor);
+    List<Integer> dacIds = List.of(7, 8, 9);
+    dacIds.forEach(
+        dacId -> {
+          when(ruleDAO.findAllDACAutomationRulesByDACId(dacId))
+              .thenReturn(
+                  List.of(
+                      new DACAutomationRule(
+                          1,
+                          DACAutomationRuleType.GRU_V1,
+                          "Test Rule",
+                          RuleState.AVAILABLE,
+                          null,
+                          null,
+                          null,
+                          null)));
+          when(datasetDAO.findDatasetsAssociatedWithDac(dacId))
+              .thenReturn(List.of(makeDataset(dacId * 10, "Dataset", dacId)));
+        });
+    CountDownLatch firstPassStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirstPass = new CountDownLatch(1);
+    List<List<Integer>> indexedInOrder = Collections.synchronizedList(new ArrayList<>());
+    when(elasticSearchService.indexDatasets(any()))
+        .thenAnswer(
+            invocation -> {
+              List<Integer> ids = invocation.getArgument(0);
+              indexedInOrder.add(ids);
+              if (indexedInOrder.size() == 1) {
+                firstPassStarted.countDown();
+                releaseFirstPass.await(5, TimeUnit.SECONDS);
+              }
+              return Response.ok().build();
+            });
+
+    try {
+      // The first toggle holds the drain, so the other two queue behind it while it runs
+      service.toggleRule(7, 1, user);
+      assertTrue(firstPassStarted.await(5, TimeUnit.SECONDS));
+      service.toggleRule(8, 1, user);
+      service.toggleRule(9, 1, user);
+      releaseFirstPass.countDown();
+
+      verify(elasticSearchService, timeout(5000).times(3)).indexDatasets(any());
+      assertEquals(List.of(List.of(70), List.of(80), List.of(90)), indexedInOrder);
     } finally {
       releaseFirstPass.countDown();
       realExecutor.shutdownNow();
@@ -434,9 +498,9 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     null,
                     null)));
     when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
-    when(datasetDAO.findAllDatasetIds())
+    when(datasetDAO.findDatasetsAssociatedWithDac(1))
         .thenThrow(new StackOverflowError("boom"))
-        .thenReturn(List.of(10));
+        .thenReturn(datasetsWithIds(10));
     when(elasticSearchService.indexDatasets(List.of(10))).thenReturn(Response.ok().build());
 
     service.toggleRule(1, 1, user);
@@ -460,7 +524,7 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
                     "alice",
                     "alice@fake.org")));
     doNothing().when(ruleDAO).auditedDeleteDACRuleSetting(anyInt(), anyInt(), anyInt());
-    when(datasetDAO.findAllDatasetIds()).thenReturn(List.of(10));
+    when(datasetDAO.findDatasetsAssociatedWithDac(1)).thenReturn(datasetsWithIds(10));
     when(elasticSearchService.indexDatasets(List.of(10))).thenThrow(new IOException("es down"));
 
     // The rule change is already committed and audited, so a failed reindex must not surface

--- a/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DACAutomationRuleServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.broadinstitute.consent.http.AbstractTestHelper;
@@ -379,6 +381,38 @@ class DACAutomationRuleServiceTest extends AbstractTestHelper {
       releaseFirstPass.countDown();
       realExecutor.shutdownNow();
     }
+  }
+
+  @Test
+  void testToggleRuleSurvivesARejectedReindexAndStaysSchedulable() throws Exception {
+    // An executor shutting down rejects the submission. The toggle is already committed and
+    // audited by then, so it must not fail — and reindexRunning must be released, or the
+    // coalescing guard would swallow every later reindex for the life of the process.
+    ExecutorService rejecting = mock(ExecutorService.class);
+    when(rejecting.submit(any(Runnable.class))).thenThrow(new RejectedExecutionException("down"));
+    service =
+        new DACAutomationRuleService(
+            jdbi, voteServiceDAO, voteService, elasticSearchService, rejecting);
+    when(ruleDAO.findAllDACAutomationRulesByDACId(1))
+        .thenReturn(
+            List.of(
+                new DACAutomationRule(
+                    1,
+                    DACAutomationRuleType.GRU_V1,
+                    "Test Rule",
+                    RuleState.AVAILABLE,
+                    null,
+                    null,
+                    null,
+                    null)));
+    when(ruleDAO.auditedInsertDACRuleSetting(anyInt(), anyInt(), anyInt(), any())).thenReturn(1);
+
+    AutomationRuleToggleResponse result = service.toggleRule(1, 1, user);
+    assertTrue(result.isRuleEnabled());
+
+    // A second toggle must still attempt to schedule rather than coalescing into a dead pass
+    service.toggleRule(1, 1, user);
+    verify(rejecting, times(2)).submit(any(Runnable.class));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -50,12 +50,14 @@ import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.entity.NStringEntity;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.consent.http.db.DACAutomationRuleDAO;
 import org.broadinstitute.consent.http.db.DacDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.InstitutionDAO;
 import org.broadinstitute.consent.http.db.StudyDAO;
 import org.broadinstitute.consent.http.db.UserDAO;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
+import org.broadinstitute.consent.http.enumeration.SoApprovalModel;
 import org.broadinstitute.consent.http.models.Dac;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataUse;
@@ -71,6 +73,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
+import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -102,6 +105,8 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
   @Mock private DacDAO dacDAO;
 
+  @Mock private DACAutomationRuleDAO dacAutomationRuleDAO;
+
   @Mock private UserDAO userDao;
 
   @Mock private InstitutionDAO institutionDAO;
@@ -117,6 +122,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @BeforeEach
   void initService() {
     when(jdbi.onDemand(DacDAO.class)).thenReturn(dacDAO);
+    when(jdbi.onDemand(DACAutomationRuleDAO.class)).thenReturn(dacAutomationRuleDAO);
     when(jdbi.onDemand(UserDAO.class)).thenReturn(userDao);
     when(jdbi.onDemand(InstitutionDAO.class)).thenReturn(institutionDAO);
     when(jdbi.onDemand(DatasetDAO.class)).thenReturn(datasetDAO);
@@ -576,6 +582,65 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
             .findFirst();
     assertTrue(dataProp.isPresent());
     assertEquals(refMap, term.getData());
+  }
+
+  @Test
+  void testToDatasetTermSoApprovalModelPerDar() {
+    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+        .thenReturn(Set.of(7));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertEquals(SoApprovalModel.PER_DAR, term.getSoApprovalModel());
+  }
+
+  @Test
+  void testToDatasetTermSoApprovalModelPreAuthorized() {
+    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+        .thenReturn(Set.of(99));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
+  }
+
+  @Test
+  void testToDatasetTermSoApprovalModelWithNoDac() {
+    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+        .thenReturn(Set.of(7));
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
+  }
+
+  @Test
+  void testToDatasetTermSoApprovalModelUnsetWhenRuleLookupFails() {
+    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+        .thenThrow(new RuntimeException("db down"));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+
+    // Indexing continues, but an unresolved rule must not be reported as a model
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertNull(term.getSoApprovalModel());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.service;
 import static jakarta.ws.rs.core.Response.Status.fromStatusCode;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.assets;
 import static org.broadinstitute.consent.http.models.dataset_registration_v1.builder.DatasetRegistrationSchemaV1Builder.data;
+import static org.broadinstitute.consent.http.rules.DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,6 +75,7 @@ import org.broadinstitute.consent.http.models.elastic_search.DatasetTerm;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
+import org.broadinstitute.consent.http.rules.DACRuleAssignment;
 import org.broadinstitute.consent.http.service.dao.DatasetServiceDAO;
 import org.broadinstitute.consent.http.util.TestAppender;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
@@ -584,11 +586,17 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     assertEquals(refMap, term.getData());
   }
 
+  /** A data use that clears hasNoModifiers, so only the primary code decides which rules match. */
+  private DataUse unmodifiedDataUse() {
+    DataUse dataUse = new DataUse();
+    dataUse.setDiseaseRestrictions(List.of());
+    return dataUse;
+  }
+
   @Test
-  void testToDatasetTermSoApprovalModelPerDar() {
-    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
-        .thenReturn(Set.of(7));
+  void testToDatasetTermSoApprovalModelPerRequest() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, REQUIRE_SO_DAR_APPROVAL)));
     when(dacDAO.findById(7)).thenReturn(new Dac());
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
@@ -596,14 +604,13 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
     DatasetTerm term = service.toDatasetTerm(dataset);
 
-    assertEquals(SoApprovalModel.PER_DAR, term.getSoApprovalModel());
+    assertEquals(SoApprovalModel.PER_REQUEST, term.getSoApprovalModel());
   }
 
   @Test
   void testToDatasetTermSoApprovalModelPreAuthorized() {
-    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
-        .thenReturn(Set.of(99));
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(99, REQUIRE_SO_DAR_APPROVAL)));
     when(dacDAO.findById(7)).thenReturn(new Dac());
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
@@ -616,45 +623,193 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
   @Test
   void testToDatasetTermSoApprovalModelWithNoDac() {
-    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
-        .thenReturn(Set.of(7));
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
 
     DatasetTerm term = service.toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
+    assertFalse(term.getInstantApprovalEligible());
+    // Nothing about a DAC-less dataset depends on the rules, so the lookup is skipped entirely
+    verify(dacAutomationRuleDAO, never()).findEnabledRuleAssignments();
   }
 
   @Test
-  void testToDatasetTermSoApprovalModelUnsetWhenRuleLookupFails() {
-    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+  void testToDatasetTermRuleDerivedFieldsUnsetWhenRuleLookupFails() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
         .thenThrow(new RuntimeException("db down"));
     when(dacDAO.findById(7)).thenReturn(new Dac());
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    // Indexing continues, but an unresolved rule must not be reported as a model
+    // Indexing continues, but unresolved rules must not be reported as dataset state
     DatasetTerm term = service.toDatasetTerm(dataset);
 
     assertNull(term.getSoApprovalModel());
+    assertNull(term.getInstantApprovalEligible());
   }
 
   @Test
-  void testToDatasetTermSoApprovalModelWithNoDacWhenRuleLookupFails() {
-    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
-            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
-        .thenThrow(new RuntimeException("db down"));
+  void testToDatasetTermTreatsNullRuleLookupAsNoRulesEnabled() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments()).thenReturn(null);
+    when(dacDAO.findById(7)).thenReturn(new Dac());
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
+    dataset.setDacId(7);
 
-    // A dataset with no DAC does not depend on the rule, so it resolves even when the lookup fails
     DatasetTerm term = service.toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
+    assertFalse(term.getInstantApprovalEligible());
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalEligibleForMatchingRule() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setGeneralUse(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertTrue(term.getInstantApprovalEligible());
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalIneligibleWhenRuleCoversOtherCode() {
+    // The DAC auto-approves GRU, but this dataset is HMB
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setHmbResearch(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertFalse(term.getInstantApprovalEligible());
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalIneligibleWhenDataUseCarriesModifier() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setGeneralUse(true);
+    dataUse.setEthicsApprovalRequired(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertFalse(term.getInstantApprovalEligible());
+  }
+
+  /**
+   * The indexed document is duos-ui's only source for these two fields, and it reads them by the
+   * exact names and values asserted here (DT-3799). Serialized through the same GsonUtil the bulk
+   * indexer uses, so a rename on either side fails this rather than silently blanking the Data
+   * Library's SO Approval column and instant-approval badge.
+   */
+  @Test
+  void testIndexedDocumentCarriesTheRuleDerivedFieldsClientsRead() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(
+            List.of(
+                new DACRuleAssignment(7, REQUIRE_SO_DAR_APPROVAL),
+                new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setGeneralUse(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    String json = GsonUtil.getInstance().toJson(service.toDatasetTerm(dataset));
+
+    assertTrue(json.contains("\"soApprovalModel\":\"PER_REQUEST\""), json);
+    assertTrue(json.contains("\"instantApprovalEligible\":true"), json);
+  }
+
+  @Test
+  void testIndexedDocumentOmitsRuleDerivedFieldsWhenUnresolved() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenThrow(new RuntimeException("db down"));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+
+    String json = GsonUtil.getInstance().toJson(service.toDatasetTerm(dataset));
+
+    // Absent rather than false/null, so clients can tell "not eligible" from "not yet known"
+    assertFalse(json.contains("soApprovalModel"), json);
+    assertFalse(json.contains("instantApprovalEligible"), json);
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalIneligibleForMultiplePrimaryDataUse() {
+    // Two primary categories is not a shape automation acts on, so the engine abstains before
+    // consulting any rule — the indexed flag has to abstain with it
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setGeneralUse(true);
+    dataUse.setHmbResearch(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertFalse(term.getInstantApprovalEligible());
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalIneligibleForNonApprovingRule() {
+    // REQUIRE_SO_DAR_APPROVAL never auto-approves, so it cannot make a dataset eligible
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, REQUIRE_SO_DAR_APPROVAL)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    DataUse dataUse = unmodifiedDataUse();
+    dataUse.setGeneralUse(true);
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+    dataset.setDataUse(dataUse);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertFalse(term.getInstantApprovalEligible());
+  }
+
+  @Test
+  void testToDatasetTermInstantApprovalIneligibleWithoutDataUse() {
+    when(dacAutomationRuleDAO.findEnabledRuleAssignments())
+        .thenReturn(List.of(new DACRuleAssignment(7, DACAutomationRuleType.GRU_V1)));
+    when(dacDAO.findById(7)).thenReturn(new Dac());
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setDacId(7);
+
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertFalse(term.getInstantApprovalEligible());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -239,6 +239,11 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     return dataUseSummary;
   }
 
+  /** Mirrors indexDatasetList: rules resolved once, then applied to the dataset. */
+  private DatasetTerm toDatasetTerm(Dataset dataset) {
+    return service.toDatasetTerm(dataset, service.resolveEnabledRulesByDacId().orElse(null));
+  }
+
   /** Private container record to consolidate dataset and associated object creation */
   private record DatasetRecord(
       User createUser, User updateUser, Dac dac, Dataset dataset, Study study) {}
@@ -384,7 +389,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         .thenReturn(datasetRecord.updateUser.getInstitution());
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
     assertEquals(datasetRecord.createUser.getUserId(), term.getCreateUserId());
     assertEquals(datasetRecord.createUser.getDisplayName(), term.getCreateUserDisplayName());
     assertEquals(datasetRecord.createUser.getUserId(), term.getSubmitter().userId());
@@ -412,7 +417,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         .thenReturn(datasetRecord.updateUser);
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
     assertEquals(datasetRecord.study.getDescription(), term.getStudy().getDescription());
     assertEquals(datasetRecord.study.getName(), term.getStudy().getStudyName());
     assertEquals(datasetRecord.study.getStudyId(), term.getStudy().getStudyId());
@@ -489,7 +494,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
         .thenReturn(datasetRecord.updateUser);
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
 
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
     switch (propKey) {
       case assets:
         assertEquals(refMap, term.getStudy().getAssets());
@@ -519,7 +524,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     card2.setUserId(dar2.getUserId());
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(ontologyService.translateDataUseSummary(any())).thenReturn(dataUseSummary);
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
 
     assertEquals(datasetRecord.dataset.getDatasetId(), term.getDatasetId());
     assertEquals(datasetRecord.dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
@@ -577,7 +582,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     datasetProperties.add(newProperty);
     dataset.setProperties(datasetProperties);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
     Optional<DatasetProperty> dataProp =
         dataset.getProperties().stream()
             .filter(p -> p.getSchemaProperty().equals(data))
@@ -602,7 +607,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PER_REQUEST, term.getSoApprovalModel());
   }
@@ -616,7 +621,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
   }
@@ -626,12 +631,10 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
     assertFalse(term.getInstantApprovalEligible());
-    // Nothing about a DAC-less dataset depends on the rules, so the lookup is skipped entirely
-    verify(dacAutomationRuleDAO, never()).findEnabledRuleAssignments();
   }
 
   @Test
@@ -644,7 +647,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
 
     // Indexing continues, but unresolved rules must not be reported as dataset state
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertNull(term.getSoApprovalModel());
     assertNull(term.getInstantApprovalEligible());
@@ -658,7 +661,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
     assertFalse(term.getInstantApprovalEligible());
@@ -676,7 +679,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertTrue(term.getInstantApprovalEligible());
   }
@@ -694,7 +697,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertFalse(term.getInstantApprovalEligible());
   }
@@ -712,7 +715,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertFalse(term.getInstantApprovalEligible());
   }
@@ -738,7 +741,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    String json = GsonUtil.getInstance().toJson(service.toDatasetTerm(dataset));
+    String json = GsonUtil.getInstance().toJson(toDatasetTerm(dataset));
 
     assertTrue(json.contains("\"soApprovalModel\":\"PER_REQUEST\""), json);
     assertTrue(json.contains("\"instantApprovalEligible\":true"), json);
@@ -753,7 +756,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    String json = GsonUtil.getInstance().toJson(service.toDatasetTerm(dataset));
+    String json = GsonUtil.getInstance().toJson(toDatasetTerm(dataset));
 
     // Absent rather than false/null, so clients can tell "not eligible" from "not yet known"
     assertFalse(json.contains("soApprovalModel"), json);
@@ -775,7 +778,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertFalse(term.getInstantApprovalEligible());
   }
@@ -793,7 +796,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDacId(7);
     dataset.setDataUse(dataUse);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertFalse(term.getInstantApprovalEligible());
   }
@@ -807,7 +810,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetId(1);
     dataset.setDacId(7);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertFalse(term.getInstantApprovalEligible());
   }
@@ -822,7 +825,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     property.setPropertyValue("open");
     dataset.setProperties(Set.of(property));
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals("open", term.getAccessManagement());
   }
@@ -833,7 +836,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
 
     assertEquals(datasetRecord.dataset.getDacApproval(), term.getDacApproval());
     assertEquals(datasetRecord.dac.getDacId(), term.getDacId());
@@ -847,7 +850,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
     assertEquals(
         datasetRecord.dataset.getNihInstitutionalCertificationFile() != null,
         term.getHasInstitutionCertification());
@@ -860,7 +863,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
     datasetRecord.dataset.setNihInstitutionalCertificationFile(null);
-    DatasetTerm term = service.toDatasetTerm(datasetRecord.dataset);
+    DatasetTerm term = toDatasetTerm(datasetRecord.dataset);
     assertNull(term.getHasInstitutionCertification());
   }
 
@@ -886,7 +889,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     when(dacDAO.findById(any())).thenReturn(datasetRecord.dac);
     when(userDao.findUserById(datasetRecord.createUser.getUserId()))
         .thenReturn(datasetRecord.createUser);
-    assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
+    assertDoesNotThrow(() -> toDatasetTerm(dataset));
   }
 
   @Test
@@ -897,7 +900,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setDatasetIdentifier();
     dataset.setProperties(Set.of());
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertEquals(dataset.getDatasetId(), term.getDatasetId());
     assertEquals(dataset.getDatasetIdentifier(), term.getDatasetIdentifier());
@@ -915,7 +918,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setStudy(study);
     when(userDao.findUserById(user.getUserId())).thenReturn(user);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     Optional<DatasetProperty> requestLocationProp =
         dataset.getProperties().stream()
@@ -936,7 +939,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     dataset.setProperties(Set.of(createDatasetProperty("url", PropertyType.String, "url")));
     when(userDao.findUserById(user.getUserId())).thenReturn(user);
 
-    DatasetTerm term = service.toDatasetTerm(dataset);
+    DatasetTerm term = toDatasetTerm(dataset);
 
     assertNull(term.getRequestLocation());
   }
@@ -944,7 +947,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   @Test
   void testToDatasetTermNullDatasetProps() {
     Dataset dataset = new Dataset();
-    assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
+    assertDoesNotThrow(() -> toDatasetTerm(dataset));
   }
 
   @Test
@@ -955,7 +958,7 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
     study.setDescription(randomAlphabetic(20));
     study.setStudyId(randomInt(1, 100));
     dataset.setStudy(study);
-    assertDoesNotThrow(() -> service.toDatasetTerm(dataset));
+    assertDoesNotThrow(() -> toDatasetTerm(dataset));
   }
 
   @Captor ArgumentCaptor<Request> request;

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -644,6 +644,20 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testToDatasetTermSoApprovalModelWithNoDacWhenRuleLookupFails() {
+    when(dacAutomationRuleDAO.findDacIdsWithRuleEnabled(
+            DACAutomationRuleType.REQUIRE_SO_DAR_APPROVAL))
+        .thenThrow(new RuntimeException("db down"));
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+
+    // A dataset with no DAC does not depend on the rule, so it resolves even when the lookup fails
+    DatasetTerm term = service.toDatasetTerm(dataset);
+
+    assertEquals(SoApprovalModel.PRE_AUTHORIZED, term.getSoApprovalModel());
+  }
+
+  @Test
   void testToDatasetTermUsesLegacyAccessManagementProperty() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3888

### Summary

Datasets now carry the DAC automation state clients need, so duos-ui no longer resolves DAC rules itself — it was issuing one `/api/dac/{id}/rules` request per unique DAC per page of results and re-deriving the rules in JS.

`DatasetTerm` gains two fields:

- `soApprovalModel` (`PER_REQUEST` | `PRE_AUTHORIZED`), from whether the DAC has `REQUIRE_SO_DAR_APPROVAL` enabled.
- `instantApprovalEligible`, from whether the DAC has an auto-approve rule enabled that this dataset's own data use satisfies.

Eligibility runs the rule implementations themselves rather than restating the policy. The dataset-side half of each rule is split out as `datasetQualifies(Dataset)`, so `compare()` becomes `datasetQualifies(dataset) && requestIsOnlyHMB(...)` — unchanged otherwise, and the existing rule tests pass untouched. `hasCanonicalSinglePrimary` moved to `DataUsePrimaryClassifier` so `applyRule` and the indexer share one definition of the shape gate rather than each holding a copy.

**This changes which datasets can show the instant-approval badge — measured impact on prod: 3 datasets.** The client-side re-derivation matched the translated `DataUseSummary` and rejected four secondary codes (`IRB, COL, GSO, NPU`); `hasNoModifiers` rejects roughly twenty. A GRU dataset carrying a publication moratorium (`MOR`), a geographic restriction (`GS`), or required publication of results (`PUB`) could therefore advertise instant approval that no DAR against it would ever receive.

Measured against prod: **3 datasets lose the badge** — DUOS-000151, DUOS-000157 and DUOS-000266, all in DAC 1, all via `secondaryOther` (free text, rendered as secondary code `OTHER`, which the old frontend check never looked at). Dev showed 0, so this is confined to one DAC. **No approval outcome changes**: `hasNoModifiers` already rejects a non-empty `secondaryOther`, so `compare()` returns false for all three today and the engine has never auto-approved them — the UI simply stops claiming otherwise.

One of the three carries a genuine restriction ("Possible restriction on gamete research"). The other two carry an audit note rather than a restriction, and are being excluded from auto-approval today by that stray text — a pre-existing data issue this change surfaces rather than causes, raised separately with @ncalvanese1 and not a blocker here.

Rules are resolved once per index batch via `findEnabledRuleAssignments()`, returning every enabled `(dac_id, rule)` pair for AVAILABLE rules in one query. Still DAC-keyed rather than reusing `filterDatasetIdsByAutomationRuleType`, because indexing walks the entire dataset corpus and a dataset-keyed query would mean an unbounded IN list. A dataset with no DAC resolves to `PRE_AUTHORIZED` and ineligible without consulting the query at all.

Both fields are left absent, not `false`, when the rules cannot be resolved, so clients can tell "not eligible" from "not yet known" and render nothing rather than being told the wrong approval process. Two tests assert the serialized document through the same `GsonUtil` the bulk indexer uses, since those field names and values are duos-ui's only contract here and a rename on either side should fail a test rather than silently blank the Data Library.

Any rule toggle now reindexes that DAC's datasets — every rule affects an indexed field, so the previous rule-type check no longer described anything. Scoped to the DAC rather than the whole corpus, since prod is now mostly external entries with no DAC, which no rule change can affect. `findDatasetsAssociatedWithDac` rather than `findDatasetIdsByDacIds`, so datasets carrying the DAC as a `dataAccessCommitteeId` property are covered too; it returns full rows and its property joins can repeat a dataset, so ids are mapped and deduped. The IN list is bounded by DAC size rather than corpus size.

It runs off the request thread so toggle latency does not track DAC size, and toggles are queued FIFO so DACs reindex in the order they were toggled. A DAC already queued is not queued twice — the pending pass has not started and reads the newest state when it does. Failures are logged rather than raised: the toggle is already committed and audited by the time the reindex runs.

**Deploy order matters.** This PR, then `POST /api/dataset/index`, then DataBiosphere/duos-ui#3787. Unlike the SO Approval column, the instant-approval badge is an existing feature, so shipping the UI first would make it vanish rather than degrade.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-3888]: https://broadworkbench.atlassian.net/browse/DT-3888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




