### PR TITLE
[DT-3865] Restore dataset alias sequence with migration fix

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -132,9 +132,9 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       """
           INSERT INTO dataset
               (name, create_date, create_user_id, update_date,
-              update_user_id, object_id, dac_id, alias, data_use)
-          (SELECT :name, :createDate, :createUserId, :createDate,
-              :createUserId, :objectId, :dacId, COALESCE(MAX(alias),0)+1, :dataUse FROM dataset)
+              update_user_id, object_id, dac_id, data_use)
+          VALUES (:name, :createDate, :createUserId, :createDate,
+              :createUserId, :objectId, :dacId, :dataUse)
           """)
   @GetGeneratedKeys
   Integer insertDataset(

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -255,5 +255,6 @@
   <include file="changesets/changelog-consent-2026-06-18-consolidate-so-approval-fields.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-07-14-election-type.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-07-so-dashboard-indices.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
@@ -6,12 +6,15 @@
     <!-- Aliases are public identifiers, so unsafe legacy values must be reconciled explicitly
          rather than silently rewritten by this migration. Alias 0 is a valid legacy identifier. -->
     <preConditions onFail="HALT" onError="HALT"
-                   onFailMessage="Dataset aliases must be non-negative integers, non-null, and unique before migration">
+                   onFailMessage="Dataset aliases must be unique, non-null integers between 0 and 2147483646 before migration">
       <dbms type="postgresql"/>
       <sqlCheck expectedResult="0">
         SELECT
           (SELECT COUNT(*) FROM dataset
-           WHERE alias IS NULL OR alias &lt; 0 OR alias != trunc(alias))
+           WHERE alias IS NULL
+             OR alias &lt; 0
+             OR alias &gt; 2147483646
+             OR alias != trunc(alias))
           +
           (SELECT COUNT(*) FROM (
             SELECT alias FROM dataset GROUP BY alias HAVING COUNT(*) &gt; 1
@@ -56,12 +59,12 @@
                          constraintName="dataset_alias_unique"/>
     <sql>
       ALTER TABLE dataset
-        ADD CONSTRAINT dataset_alias_non_negative_integer
-        CHECK (alias &gt;= 0 AND alias = trunc(alias))
+        ADD CONSTRAINT dataset_alias_valid_integer
+        CHECK (alias &gt;= 0 AND alias &lt;= 2147483647 AND alias = trunc(alias))
     </sql>
 
     <rollback>
-      <sql>ALTER TABLE dataset DROP CONSTRAINT dataset_alias_non_negative_integer</sql>
+      <sql>ALTER TABLE dataset DROP CONSTRAINT dataset_alias_valid_integer</sql>
       <dropUniqueConstraint tableName="dataset" constraintName="dataset_alias_unique"/>
       <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
       <sql>DROP TRIGGER IF EXISTS dataset_alias_allocate ON dataset</sql>

--- a/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
@@ -1,0 +1,67 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+  <changeSet id="changelog-consent-2026-08-10-dataset-alias-sequence" author="kmarete">
+    <!-- Aliases are public identifiers, so unsafe legacy values must be reconciled explicitly
+         rather than silently rewritten by this migration. -->
+    <preConditions onFail="HALT" onError="HALT"
+                   onFailMessage="Dataset aliases must be positive, non-null, and unique before migration">
+      <dbms type="postgresql"/>
+      <sqlCheck expectedResult="0">
+        SELECT
+          (SELECT COUNT(*) FROM dataset WHERE alias IS NULL OR alias &lt;= 0)
+          +
+          (SELECT COUNT(*) FROM (
+            SELECT alias FROM dataset GROUP BY alias HAVING COUNT(*) &gt; 1
+          ) duplicate_aliases)
+      </sqlCheck>
+    </preConditions>
+
+    <comment>
+      Allocate public dataset aliases with a database sequence. The trigger is a rolling-deployment
+      compatibility mechanism: it replaces aliases supplied by old application instances as well as
+      allocating aliases for new instances that omit the column.
+    </comment>
+
+    <!-- Keep writes out until the sequence is positioned and the trigger and constraints exist. -->
+    <sql>LOCK TABLE dataset IN ACCESS EXCLUSIVE MODE</sql>
+
+    <createSequence sequenceName="dataset_alias_seq" startValue="1" incrementBy="1"/>
+    <sql>
+      SELECT setval(
+        'dataset_alias_seq',
+        COALESCE((SELECT MAX(alias) FROM dataset), 0) + 1,
+        false
+      )
+    </sql>
+
+    <sql splitStatements="false">
+      CREATE OR REPLACE FUNCTION allocate_dataset_alias() RETURNS trigger AS $$
+      BEGIN
+        NEW.alias := nextval('dataset_alias_seq');
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    </sql>
+    <sql splitStatements="false">
+      CREATE TRIGGER dataset_alias_allocate
+        BEFORE INSERT ON dataset
+        FOR EACH ROW EXECUTE FUNCTION allocate_dataset_alias()
+    </sql>
+
+    <addNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
+    <addUniqueConstraint tableName="dataset" columnNames="alias"
+                         constraintName="dataset_alias_unique"/>
+
+    <rollback>
+      <dropUniqueConstraint tableName="dataset" constraintName="dataset_alias_unique"/>
+      <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
+      <sql>DROP TRIGGER IF EXISTS dataset_alias_allocate ON dataset</sql>
+      <sql>DROP FUNCTION IF EXISTS allocate_dataset_alias()</sql>
+      <dropSequence sequenceName="dataset_alias_seq"/>
+      <addDefaultValue tableName="dataset" columnName="alias" columnDataType="bigint"
+                       defaultValueNumeric="0"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
@@ -31,7 +31,7 @@
     <sql>
       SELECT setval(
         'dataset_alias_seq',
-        COALESCE((SELECT MAX(alias) FROM dataset), 0) + 1,
+        (COALESCE((SELECT MAX(alias) FROM dataset), 0) + 1)::bigint,
         false
       )
     </sql>

--- a/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
@@ -6,11 +6,12 @@
     <!-- Aliases are public identifiers, so unsafe legacy values must be reconciled explicitly
          rather than silently rewritten by this migration. Alias 0 is a valid legacy identifier. -->
     <preConditions onFail="HALT" onError="HALT"
-                   onFailMessage="Dataset aliases must be non-negative, non-null, and unique before migration">
+                   onFailMessage="Dataset aliases must be non-negative integers, non-null, and unique before migration">
       <dbms type="postgresql"/>
       <sqlCheck expectedResult="0">
         SELECT
-          (SELECT COUNT(*) FROM dataset WHERE alias IS NULL OR alias &lt; 0)
+          (SELECT COUNT(*) FROM dataset
+           WHERE alias IS NULL OR alias &lt; 0 OR alias != trunc(alias))
           +
           (SELECT COUNT(*) FROM (
             SELECT alias FROM dataset GROUP BY alias HAVING COUNT(*) &gt; 1
@@ -53,8 +54,14 @@
     <addNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
     <addUniqueConstraint tableName="dataset" columnNames="alias"
                          constraintName="dataset_alias_unique"/>
+    <sql>
+      ALTER TABLE dataset
+        ADD CONSTRAINT dataset_alias_non_negative_integer
+        CHECK (alias &gt;= 0 AND alias = trunc(alias))
+    </sql>
 
     <rollback>
+      <sql>ALTER TABLE dataset DROP CONSTRAINT dataset_alias_non_negative_integer</sql>
       <dropUniqueConstraint tableName="dataset" constraintName="dataset_alias_unique"/>
       <dropNotNullConstraint tableName="dataset" columnName="alias" columnDataType="bigint"/>
       <sql>DROP TRIGGER IF EXISTS dataset_alias_allocate ON dataset</sql>

--- a/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml
@@ -4,13 +4,13 @@
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
   <changeSet id="changelog-consent-2026-08-10-dataset-alias-sequence" author="kmarete">
     <!-- Aliases are public identifiers, so unsafe legacy values must be reconciled explicitly
-         rather than silently rewritten by this migration. -->
+         rather than silently rewritten by this migration. Alias 0 is a valid legacy identifier. -->
     <preConditions onFail="HALT" onError="HALT"
-                   onFailMessage="Dataset aliases must be positive, non-null, and unique before migration">
+                   onFailMessage="Dataset aliases must be non-negative, non-null, and unique before migration">
       <dbms type="postgresql"/>
       <sqlCheck expectedResult="0">
         SELECT
-          (SELECT COUNT(*) FROM dataset WHERE alias IS NULL OR alias &lt;= 0)
+          (SELECT COUNT(*) FROM dataset WHERE alias IS NULL OR alias &lt; 0)
           +
           (SELECT COUNT(*) FROM (
             SELECT alias FROM dataset GROUP BY alias HAVING COUNT(*) &gt; 1

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
@@ -1,0 +1,173 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+class DatasetAliasSequenceMigrationTest {
+
+  private static final String CHANGELOG =
+      "changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml";
+  private static PostgreSQLContainer<?> postgres;
+
+  @BeforeAll
+  static void startPostgres() {
+    postgres = new PostgreSQLContainer<>(DAOTestHelper.POSTGRES_IMAGE);
+    postgres.start();
+  }
+
+  @AfterAll
+  static void stopPostgres() {
+    postgres.stop();
+  }
+
+  @BeforeEach
+  void createPreMigrationSchema() throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+      statement.execute(
+          "CREATE TABLE dataset (dataset_id bigserial PRIMARY KEY, alias bigint DEFAULT 0)");
+      statement.execute("INSERT INTO dataset (alias) VALUES (42), (900000)");
+    }
+  }
+
+  @Test
+  void migrationPreservesAliasesAndAllocatesAboveMaximumForOldAndNewWriters() throws Exception {
+    update();
+
+    assertEquals(42, queryLong("SELECT alias FROM dataset WHERE dataset_id = 1"));
+    assertEquals(900000, queryLong("SELECT alias FROM dataset WHERE dataset_id = 2"));
+
+    // An old instance supplies its MAX(alias) + 1 result, but the compatibility trigger replaces
+    // it.
+    assertEquals(
+        900001,
+        queryLong(
+            "INSERT INTO dataset (alias) "
+                + "SELECT COALESCE(MAX(alias), 0) + 1 FROM dataset RETURNING alias"));
+    execute("DELETE FROM dataset WHERE alias = 900001");
+    // A new instance omits alias entirely.
+    assertEquals(900002, queryLong("INSERT INTO dataset DEFAULT VALUES RETURNING alias"));
+
+    assertThrows(
+        SQLException.class, () -> execute("UPDATE dataset SET alias = NULL WHERE dataset_id = 1"));
+    assertThrows(
+        SQLException.class, () -> execute("UPDATE dataset SET alias = 42 WHERE dataset_id = 2"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"NULL", "0", "42"})
+  void migrationRejectsUnsafeExistingAliasesBeforeChangingSchema(String unsafeAlias)
+      throws Exception {
+    execute("INSERT INTO dataset (alias) VALUES (" + unsafeAlias + ")");
+
+    assertThrows(LiquibaseException.class, this::update);
+
+    assertNull(queryObject("SELECT to_regclass('dataset_alias_seq')"));
+    assertFalse(
+        queryBoolean(
+            "SELECT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'dataset_alias_allocate')"));
+  }
+
+  @Test
+  void rollbackRestoresLegacyDefaultAndWriterBehavior() throws Exception {
+    update();
+    rollback();
+
+    assertNull(queryObject("SELECT to_regclass('dataset_alias_seq')"));
+    assertFalse(
+        queryBoolean(
+            "SELECT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'dataset_alias_allocate')"));
+    assertTrue(
+        queryBoolean(
+            "SELECT is_nullable = 'YES' FROM information_schema.columns "
+                + "WHERE table_schema = 'public' AND table_name = 'dataset' AND column_name = 'alias'"));
+    assertEquals(
+        "0",
+        queryObject(
+            "SELECT pg_get_expr(adbin, adrelid) FROM pg_attrdef "
+                + "WHERE adrelid = 'dataset'::regclass AND adnum = "
+                + "(SELECT attnum FROM pg_attribute WHERE attrelid = 'dataset'::regclass AND attname = 'alias')"));
+
+    assertEquals(0, queryLong("INSERT INTO dataset DEFAULT VALUES RETURNING alias"));
+    assertEquals(7, queryLong("INSERT INTO dataset (alias) VALUES (7) RETURNING alias"));
+  }
+
+  private static Connection connection() throws SQLException {
+    return DriverManager.getConnection(
+        postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+  }
+
+  private void update() throws Exception {
+    try (Connection connection = connection()) {
+      Database database =
+          DatabaseFactory.getInstance()
+              .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+      try (Liquibase liquibase =
+          new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database)) {
+        liquibase.update(new Contexts(), new LabelExpression());
+      }
+    }
+  }
+
+  private void rollback() throws Exception {
+    try (Connection connection = connection()) {
+      Database database =
+          DatabaseFactory.getInstance()
+              .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+      try (Liquibase liquibase =
+          new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database)) {
+        liquibase.rollback(1, new Contexts(), new LabelExpression());
+      }
+    }
+  }
+
+  private void execute(String sql) throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    }
+  }
+
+  private long queryLong(String sql) throws SQLException {
+    return ((Number) queryObject(sql)).longValue();
+  }
+
+  private boolean queryBoolean(String sql) throws SQLException {
+    return (Boolean) queryObject(sql);
+  }
+
+  private Object queryObject(String sql) throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery(sql)) {
+      resultSet.next();
+      return resultSet.getObject(1);
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
@@ -80,10 +80,14 @@ class DatasetAliasSequenceMigrationTest {
         SQLException.class, () -> execute("UPDATE dataset SET alias = NULL WHERE dataset_id = 1"));
     assertThrows(
         SQLException.class, () -> execute("UPDATE dataset SET alias = 42 WHERE dataset_id = 2"));
+    assertThrows(
+        SQLException.class, () -> execute("UPDATE dataset SET alias = -1 WHERE dataset_id = 1"));
+    assertThrows(
+        SQLException.class, () -> execute("UPDATE dataset SET alias = 1.5 WHERE dataset_id = 1"));
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"NULL", "-1", "42"})
+  @ValueSource(strings = {"NULL", "-1", "1.5", "42"})
   void migrationRejectsUnsafeExistingAliasesBeforeChangingSchema(String unsafeAlias)
       throws Exception {
     execute("INSERT INTO dataset (alias) VALUES (" + unsafeAlias + ")");
@@ -94,6 +98,10 @@ class DatasetAliasSequenceMigrationTest {
     assertFalse(
         queryBoolean(
             "SELECT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'dataset_alias_allocate')"));
+    assertFalse(
+        queryBoolean(
+            "SELECT EXISTS (SELECT 1 FROM pg_constraint "
+                + "WHERE conname = 'dataset_alias_non_negative_integer')"));
   }
 
   @Test
@@ -105,6 +113,10 @@ class DatasetAliasSequenceMigrationTest {
     assertFalse(
         queryBoolean(
             "SELECT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'dataset_alias_allocate')"));
+    assertFalse(
+        queryBoolean(
+            "SELECT EXISTS (SELECT 1 FROM pg_constraint "
+                + "WHERE conname = 'dataset_alias_non_negative_integer')"));
     assertTrue(
         queryBoolean(
             "SELECT is_nullable = 'YES' FROM information_schema.columns "

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
@@ -84,10 +84,26 @@ class DatasetAliasSequenceMigrationTest {
         SQLException.class, () -> execute("UPDATE dataset SET alias = -1 WHERE dataset_id = 1"));
     assertThrows(
         SQLException.class, () -> execute("UPDATE dataset SET alias = 1.5 WHERE dataset_id = 1"));
+    assertThrows(
+        SQLException.class,
+        () -> execute("UPDATE dataset SET alias = 2147483648 WHERE dataset_id = 1"));
+    execute("UPDATE dataset SET alias = 2147483647 WHERE dataset_id = 1");
+    assertEquals(2147483647, queryLong("SELECT alias FROM dataset WHERE dataset_id = 1"));
+  }
+
+  @Test
+  void migrationAllocatesLastIntegerAliasWhenExistingMaximumLeavesRoom() throws Exception {
+    execute("UPDATE dataset SET alias = 2147483646 WHERE dataset_id = 2");
+
+    update();
+
+    assertEquals(2147483647, queryLong("INSERT INTO dataset DEFAULT VALUES RETURNING alias"));
+    assertThrows(
+        SQLException.class, () -> queryLong("INSERT INTO dataset DEFAULT VALUES RETURNING alias"));
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"NULL", "-1", "1.5", "42"})
+  @ValueSource(strings = {"NULL", "-1", "1.5", "42", "2147483647"})
   void migrationRejectsUnsafeExistingAliasesBeforeChangingSchema(String unsafeAlias)
       throws Exception {
     execute("INSERT INTO dataset (alias) VALUES (" + unsafeAlias + ")");
@@ -101,7 +117,7 @@ class DatasetAliasSequenceMigrationTest {
     assertFalse(
         queryBoolean(
             "SELECT EXISTS (SELECT 1 FROM pg_constraint "
-                + "WHERE conname = 'dataset_alias_non_negative_integer')"));
+                + "WHERE conname = 'dataset_alias_valid_integer')"));
   }
 
   @Test
@@ -116,7 +132,7 @@ class DatasetAliasSequenceMigrationTest {
     assertFalse(
         queryBoolean(
             "SELECT EXISTS (SELECT 1 FROM pg_constraint "
-                + "WHERE conname = 'dataset_alias_non_negative_integer')"));
+                + "WHERE conname = 'dataset_alias_valid_integer')"));
     assertTrue(
         queryBoolean(
             "SELECT is_nullable = 'YES' FROM information_schema.columns "

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
@@ -53,7 +53,7 @@ class DatasetAliasSequenceMigrationTest {
       // Dev's legacy alias column is numeric, which exercises the setval bigint cast.
       statement.execute(
           "CREATE TABLE dataset (dataset_id bigserial PRIMARY KEY, alias numeric DEFAULT 0)");
-      statement.execute("INSERT INTO dataset (alias) VALUES (42), (900000)");
+      statement.execute("INSERT INTO dataset (alias) VALUES (42), (900000), (0)");
     }
   }
 
@@ -63,6 +63,7 @@ class DatasetAliasSequenceMigrationTest {
 
     assertEquals(42, queryLong("SELECT alias FROM dataset WHERE dataset_id = 1"));
     assertEquals(900000, queryLong("SELECT alias FROM dataset WHERE dataset_id = 2"));
+    assertEquals(0, queryLong("SELECT alias FROM dataset WHERE dataset_id = 3"));
 
     // An old instance supplies its MAX(alias) + 1 result, but the compatibility trigger replaces
     // it.
@@ -82,7 +83,7 @@ class DatasetAliasSequenceMigrationTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"NULL", "0", "42"})
+  @ValueSource(strings = {"NULL", "-1", "42"})
   void migrationRejectsUnsafeExistingAliasesBeforeChangingSchema(String unsafeAlias)
       throws Exception {
     execute("INSERT INTO dataset (alias) VALUES (" + unsafeAlias + ")");

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetAliasSequenceMigrationTest.java
@@ -50,8 +50,9 @@ class DatasetAliasSequenceMigrationTest {
         Statement statement = connection.createStatement()) {
       statement.execute("DROP SCHEMA public CASCADE");
       statement.execute("CREATE SCHEMA public");
+      // Dev's legacy alias column is numeric, which exercises the setval bigint cast.
       statement.execute(
-          "CREATE TABLE dataset (dataset_id bigserial PRIMARY KEY, alias bigint DEFAULT 0)");
+          "CREATE TABLE dataset (dataset_id bigserial PRIMARY KEY, alias numeric DEFAULT 0)");
       statement.execute("INSERT INTO dataset (alias) VALUES (42), (900000)");
     }
   }

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -23,6 +23,11 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -58,6 +63,52 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DatasetDAOTest extends DAOTestHelper {
+
+  @Test
+  void testInsertDatasetAllocatesUniqueAliasesConcurrently() throws Exception {
+    int insertCount = 16;
+    User user = createUser();
+    Timestamp now = Timestamp.from(Instant.now());
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    CountDownLatch ready = new CountDownLatch(insertCount);
+    CountDownLatch start = new CountDownLatch(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(insertCount)) {
+      List<Future<Integer>> inserts =
+          IntStream.range(0, insertCount)
+              .mapToObj(
+                  index ->
+                      executor.submit(
+                          () -> {
+                            ready.countDown();
+                            if (!start.await(10, TimeUnit.SECONDS)) {
+                              throw new IllegalStateException("Timed out waiting to start insert");
+                            }
+                            return datasetDAO.insertDataset(
+                                "Concurrent dataset " + index,
+                                now,
+                                user.getUserId(),
+                                "concurrent-object-" + index,
+                                dataUse.toString(),
+                                null);
+                          }))
+              .toList();
+
+      try {
+        assertTrue(ready.await(10, TimeUnit.SECONDS));
+      } finally {
+        start.countDown();
+      }
+      Set<Integer> aliases = new HashSet<>();
+      for (Future<Integer> insert : inserts) {
+        Dataset dataset = datasetDAO.findDatasetById(insert.get(10, TimeUnit.SECONDS));
+        assertNotNull(dataset.getAlias());
+        aliases.add(dataset.getAlias());
+      }
+
+      assertEquals(insertCount, aliases.size());
+    }
+  }
 
   @Test
   void testFindDatasetWithoutFSOInformation() {


### PR DESCRIPTION
## Summary

- Reapplies the database-managed dataset alias sequence from [DT-3865](https://broadworkbench.atlassian.net/browse/DT-3865) after the emergency revert in #3015.
- Explicitly casts the initial sequence value to `bigint` before calling PostgreSQL `setval`.
- Exercises the migration against a legacy `numeric` alias column, matching the dev schema.

## Why the original deployment failed

PR #3009 assumed `dataset.alias` was a `bigint`. In dev, the legacy column is `numeric`, so `MAX(alias) + 1` also produced a `numeric` value. PostgreSQL 16 could not resolve `setval(unknown, numeric, boolean)`, because the three-argument function expects a `bigint` sequence value. Liquibase therefore failed during startup and blocked the dev deployment.

We reverted #3009 through #3015 to restore deployability while correcting and validating the migration.

## What this PR does

The migration now calls `setval` with:

```sql
(COALESCE((SELECT MAX(alias) FROM dataset), 0) + 1)::bigint
```

This preserves all existing aliases, including the valid legacy alias `0`, positions the sequence above the current maximum, and supports old and new application instances through the compatibility trigger. Newly generated aliases remain positive, while all aliases remain non-null, unique, non-negative integers within Java's 32-bit `Integer` range. The migration rejects unsafe fractional or out-of-range legacy values before casting, reserves room for the next sequence allocation, and a database `CHECK` constraint preserves that invariant afterward. The regression fixture uses `numeric` so this dev-specific type mismatch is covered going forward.

The failed Liquibase changeset was not recorded as applied, so the corrected changeset will run again on redeployment.

## Validation

- `./mvnw -q spotless:check`
- `xmllint --noout` on the Liquibase changelog
- Test sources compile successfully
- The PostgreSQL integration suite could not run locally because Docker Desktop was unavailable; CI will execute it

## Revert history

#3015 has merged. This PR is based on that revert and cleanly reapplies DT-3865 with the corrected migration.


[DT-3865]: https://broadworkbench.atlassian.net/browse/DT-3865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ