### PR TITLE
[DT-3803] Update FROM to DUOS.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/EmailService.java
@@ -43,6 +43,14 @@ import org.jdbi.v3.core.result.ResultIterable;
 public class EmailService implements ConsentLogger {
 
   private static final int LOOKBACK_DELAY_HOURS = 24;
+
+  /**
+   * Friendly name shown as the sender of all outgoing SendGrid messages. Without it, the From
+   * header carries a bare address and mail clients typically display the local part instead -
+   * 'duos', for the production account.
+   */
+  private static final String FROM_NAME = "DUOS";
+
   @VisibleForTesting protected static int sendgridThrottleMessageCount = 500;
   @VisibleForTesting protected static int sendgridThrottleResetTime = 60;
   private final UserDAO userDAO;
@@ -80,7 +88,7 @@ public class EmailService implements ConsentLogger {
     String content = out.toString();
     Mail message =
         new Mail(
-            new Email(fromAccount),
+            new Email(fromAccount, FROM_NAME),
             mailMessage.createSubject(),
             new Email(mailMessage.toUser.getEmail()),
             new Content("text/html", content));

--- a/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/EmailServiceTest.java
@@ -69,6 +69,7 @@ class EmailServiceTest extends AbstractTestHelper {
 
   private static final String SERVER_URL = "http://localhost:8000/#/";
   private static final String FROM = "from@duos";
+  private static final String FROM_NAME = "DUOS";
   private EmailService service;
   @Mock private ElectionDAO electionDAO;
   @Mock private UserDAO userDAO;
@@ -137,6 +138,7 @@ class EmailServiceTest extends AbstractTestHelper {
     verify(sendGridAPI).sendMessage(captor.capture(), eq(user.getEmail()));
     var mail = captor.getValue();
     assertEquals(FROM, mail.getFrom().getEmail());
+    assertEquals(FROM_NAME, mail.getFrom().getName());
     assertEquals(
         user.getEmail(), mail.getPersonalization().getFirst().getTos().getFirst().getEmail());
     assertEquals(subject, mail.getSubject());


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3803](https://broadworkbench.atlassian.net/browse/DT-3803)

### Summary

* Updates email to be sent from the name 'DUOS' so that sendgrid does not default to the local portion of the email address.
* Adds test to confirm the property is set.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
