### PR TITLE
[DT-3982] Serve data use groups on the DAR collection summary

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -757,8 +757,10 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
       Jdbi jdbi,
       DarCollectionServiceDAO darCollectionServiceDAO,
       EmailService emailService,
-      DACAutomationRuleService ruleService) {
-    return new DarCollectionService(jdbi, darCollectionServiceDAO, emailService, ruleService);
+      DACAutomationRuleService ruleService,
+      OntologyService ontologyService) {
+    return new DarCollectionService(
+        jdbi, darCollectionServiceDAO, emailService, ruleService, ontologyService);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/VoteDAO.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.db;
 
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.VoteMapper;
+import org.broadinstitute.consent.http.db.mapper.VoteWithDisplayNameMapper;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.Vote;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
@@ -27,6 +28,23 @@ public interface VoteDAO extends Transactional<VoteDAO> {
 
   @SqlQuery("select * from vote v where v.election_id IN (<electionIds>)")
   List<Vote> findVotesByElectionIds(
+      @BindList(value = "electionIds", onEmpty = EmptyHandling.NULL_STRING)
+          List<Integer> electionIds);
+
+  /**
+   * DAC member votes for the given elections, with the voting member's name. One query for a whole
+   * page of collections, rather than one per collection.
+   */
+  @RegisterRowMapper(VoteWithDisplayNameMapper.class)
+  @SqlQuery(
+      """
+      SELECT v.*, u.display_name
+      FROM vote v
+      INNER JOIN users u ON u.user_id = v.user_id
+      WHERE LOWER(v.type) = 'dac'
+      AND v.election_id IN (<electionIds>)
+      """)
+  List<Vote> findDacVotesWithNamesByElectionIds(
       @BindList(value = "electionIds", onEmpty = EmptyHandling.NULL_STRING)
           List<Integer> electionIds);
 

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/VoteWithDisplayNameMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/VoteWithDisplayNameMapper.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.Vote;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+/** {@link VoteMapper} plus the voting user's name, for queries that join users. */
+public class VoteWithDisplayNameMapper implements RowMapper<Vote> {
+
+  private final VoteMapper voteMapper = new VoteMapper();
+
+  @Override
+  public Vote map(ResultSet r, StatementContext ctx) throws SQLException {
+    Vote vote = voteMapper.map(r, ctx);
+    vote.setDisplayName(r.getString("display_name"));
+    return vote;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DarCollectionSummary.java
@@ -38,6 +38,7 @@ public class DarCollectionSummary {
   @Expose private boolean requiresSOApproval;
   @Expose private Integer soApproverId;
   @Expose private Timestamp soApproverTimestamp;
+  @Expose private List<DataUseGroup> dataUseGroups;
   private String signingOfficialEmail;
 
   // Normally unused by the UI, but used in data population. Can be included in the JSON response
@@ -292,6 +293,14 @@ public class DarCollectionSummary {
 
   public void setCloseoutSupplement(CloseoutSupplement closeoutSupplement) {
     this.closeoutSupplement = closeoutSupplement;
+  }
+
+  public List<DataUseGroup> getDataUseGroups() {
+    return dataUseGroups;
+  }
+
+  public void setDataUseGroups(List<DataUseGroup> dataUseGroups) {
+    this.dataUseGroups = dataUseGroups;
   }
 
   public void setSigningOfficialEmail(String signingOfficialEmail) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.consent.http.models;
+
+import com.google.gson.annotations.Expose;
+import java.util.List;
+
+/**
+ * A collection's datasets grouped by the data use they share, as rendered by the Data Access
+ * Requests table. Votes are populated only for the DAC that casts them.
+ */
+public record DataUseGroup(
+    @Expose String key,
+    @Expose String label,
+    @Expose List<GroupDataset> datasets,
+    @Expose List<GroupVote> votes) {
+
+  /** A dataset in the group, named as the table's dataset-count tooltip shows it. */
+  public record GroupDataset(
+      @Expose Integer datasetId, @Expose String name, @Expose String datasetIdentifier) {}
+
+  /** One DAC member's vote on the group. A null vote is still pending. */
+  public record GroupVote(
+      @Expose Integer userId, @Expose Boolean vote, @Expose String displayName) {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
@@ -9,7 +9,7 @@ import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
  * Requests table. Votes are populated only for the DAC that casts them.
  */
 public record DataUseGroup(
-    @Expose String key,
+    @Expose List<Integer> key,
     @Expose DataUseSummary dataUse,
     @Expose List<GroupDataset> datasets,
     @Expose List<GroupVote> votes) {

--- a/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/DataUseGroup.java
@@ -2,6 +2,7 @@ package org.broadinstitute.consent.http.models;
 
 import com.google.gson.annotations.Expose;
 import java.util.List;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
 
 /**
  * A collection's datasets grouped by the data use they share, as rendered by the Data Access
@@ -9,7 +10,7 @@ import java.util.List;
  */
 public record DataUseGroup(
     @Expose String key,
-    @Expose String label,
+    @Expose DataUseSummary dataUse,
     @Expose List<GroupDataset> datasets,
     @Expose List<GroupVote> votes) {
 

--- a/src/main/java/org/broadinstitute/consent/http/models/ontology/DataUseSummary.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ontology/DataUseSummary.java
@@ -1,11 +1,12 @@
 package org.broadinstitute.consent.http.models.ontology;
 
+import com.google.gson.annotations.Expose;
 import java.util.List;
 
 public class DataUseSummary {
 
-  private List<DataUseTerm> primary;
-  private List<DataUseTerm> secondary;
+  @Expose private List<DataUseTerm> primary;
+  @Expose private List<DataUseTerm> secondary;
 
   public DataUseSummary() {}
 

--- a/src/main/java/org/broadinstitute/consent/http/models/ontology/DataUseTerm.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/ontology/DataUseTerm.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.consent.http.models.ontology;
 
+import com.google.gson.annotations.Expose;
+
 public class DataUseTerm {
 
-  private String code;
-  private String description;
+  @Expose private String code;
+  @Expose private String description;
 
   public DataUseTerm() {}
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -504,11 +504,7 @@ public class DarCollectionService implements ConsentLogger {
         .map(
             entry -> {
               List<Dataset> datasets = entry.getValue();
-              String key =
-                  "bucket-"
-                      + datasets.stream()
-                          .map(d -> String.valueOf(d.getDatasetId()))
-                          .collect(Collectors.joining("-"));
+              List<Integer> key = datasets.stream().map(Dataset::getDatasetId).toList();
               DataUseSummary dataUse =
                   summariesByDataUse.computeIfAbsent(
                       entry.getKey(),

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -17,9 +17,11 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -56,15 +58,19 @@ import org.broadinstitute.consent.http.models.DarCollection;
 import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUseGroup;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
 import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.jdbi.v3.core.Jdbi;
 
@@ -90,13 +96,17 @@ public class DarCollectionService implements ConsentLogger {
   private final DarCollectionServiceDAO collectionServiceDAO;
   private final EmailService emailService;
   private final DACAutomationRuleService dacAutomationRuleService;
+  private final OntologyService ontologyService;
+
+  private static final String UNDEFINED_DATA_USE = "Undefined Data Use";
 
   @Inject
   public DarCollectionService(
       Jdbi jdbi,
       DarCollectionServiceDAO darCollectionServiceDAO,
       EmailService emailService,
-      DACAutomationRuleService dacAutomationRuleService) {
+      DACAutomationRuleService dacAutomationRuleService,
+      OntologyService ontologyService) {
     this.dacDAO = jdbi.onDemand(DacDAO.class);
     this.daaDAO = jdbi.onDemand(DaaDAO.class);
     this.darCollectionDAO = jdbi.onDemand(DarCollectionDAO.class);
@@ -108,6 +118,7 @@ public class DarCollectionService implements ConsentLogger {
     this.voteDAO = jdbi.onDemand(VoteDAO.class);
     this.collectionServiceDAO = darCollectionServiceDAO;
     this.emailService = emailService;
+    this.ontologyService = ontologyService;
     this.dacAutomationRuleService = dacAutomationRuleService;
   }
 
@@ -424,7 +435,141 @@ public class DarCollectionService implements ConsentLogger {
         summaries = List.of();
         break;
     }
+    // Votes are only ever shown to the DAC that casts them.
+    attachDataUseGroups(summaries, role == UserRoles.CHAIRPERSON || role == UserRoles.MEMBER);
     return summaries;
+  }
+
+  /**
+   * Group each summary's datasets by the data use they share. Everything is fetched for the whole
+   * page at once, and translation runs per distinct data use rather than per dataset: it reads the
+   * ontology store, so per-dataset translation would trade one N+1 for another.
+   */
+  private void attachDataUseGroups(List<DarCollectionSummary> summaries, boolean includeVotes) {
+    Set<Integer> allDatasetIds =
+        summaries.stream()
+            .map(DarCollectionSummary::getDatasetIds)
+            .flatMap(Set::stream)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    if (allDatasetIds.isEmpty()) {
+      return;
+    }
+    Map<Integer, Dataset> datasetsById =
+        datasetDAO.findDatasetsByIdList(List.copyOf(allDatasetIds)).stream()
+            .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity(), (a, b) -> a));
+
+    Map<Integer, List<Vote>> votesByElectionId =
+        includeVotes ? findDacVotesByElectionId(summaries) : Map.of();
+
+    Map<String, String> labelsByDataUse = new HashMap<>();
+    summaries.forEach(
+        summary ->
+            summary.setDataUseGroups(
+                buildDataUseGroups(summary, datasetsById, votesByElectionId, labelsByDataUse)));
+  }
+
+  private Map<Integer, List<Vote>> findDacVotesByElectionId(List<DarCollectionSummary> summaries) {
+    List<Integer> electionIds =
+        summaries.stream()
+            .map(DarCollectionSummary::getElections)
+            .map(Map::values)
+            .flatMap(Collection::stream)
+            .map(Election::getElectionId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+    if (electionIds.isEmpty()) {
+      return Map.of();
+    }
+    return voteDAO.findDacVotesWithNamesByElectionIds(electionIds).stream()
+        .filter(v -> Objects.nonNull(v.getElectionId()))
+        .collect(Collectors.groupingBy(Vote::getElectionId));
+  }
+
+  private List<DataUseGroup> buildDataUseGroups(
+      DarCollectionSummary summary,
+      Map<Integer, Dataset> datasetsById,
+      Map<Integer, List<Vote>> votesByElectionId,
+      Map<String, String> labelsByDataUse) {
+    Map<String, List<Dataset>> datasetsByDataUse = new LinkedHashMap<>();
+    summary.getDatasetIds().stream()
+        .map(datasetsById::get)
+        .filter(Objects::nonNull)
+        .sorted(Comparator.comparing(Dataset::getDatasetId))
+        .forEach(
+            dataset ->
+                datasetsByDataUse
+                    .computeIfAbsent(dataUseKey(dataset), k -> new ArrayList<>())
+                    .add(dataset));
+
+    return datasetsByDataUse.entrySet().stream()
+        .map(
+            entry -> {
+              List<Dataset> datasets = entry.getValue();
+              String key =
+                  "bucket-"
+                      + datasets.stream()
+                          .map(d -> String.valueOf(d.getDatasetId()))
+                          .collect(Collectors.joining("-"));
+              String label =
+                  labelsByDataUse.computeIfAbsent(
+                      entry.getKey(), k -> translateDataUseLabel(datasets.getFirst()));
+              List<DataUseGroup.GroupDataset> groupDatasets =
+                  datasets.stream()
+                      .map(
+                          d ->
+                              new DataUseGroup.GroupDataset(
+                                  d.getDatasetId(), d.getName(), d.getDatasetIdentifier()))
+                      .toList();
+              return new DataUseGroup(
+                  key, label, groupDatasets, collapseVotes(summary, datasets, votesByElectionId));
+            })
+        .toList();
+  }
+
+  private String dataUseKey(Dataset dataset) {
+    return Objects.isNull(dataset.getDataUse())
+        ? "none"
+        : GsonUtil.getInstance().toJson(dataset.getDataUse());
+  }
+
+  private String translateDataUseLabel(Dataset dataset) {
+    DataUseSummary summary = ontologyService.translateDataUseSummary(dataset.getDataUse());
+    if (Objects.isNull(summary)) {
+      return UNDEFINED_DATA_USE;
+    }
+    String label =
+        Stream.concat(
+                Optional.ofNullable(summary.getPrimary()).orElse(List.of()).stream(),
+                Optional.ofNullable(summary.getSecondary()).orElse(List.of()).stream())
+            .map(DataUseTerm::getCode)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining(", "));
+    return label.isBlank() ? UNDEFINED_DATA_USE : label;
+  }
+
+  /**
+   * One entry per member per distinct vote value: a member who has voted on one of the group's
+   * elections but not another counts as both an Approve and a Pending, as the tallies always have.
+   */
+  private List<DataUseGroup.GroupVote> collapseVotes(
+      DarCollectionSummary summary,
+      List<Dataset> datasets,
+      Map<Integer, List<Vote>> votesByElectionId) {
+    Set<Integer> datasetIds =
+        datasets.stream().map(Dataset::getDatasetId).collect(Collectors.toSet());
+    Map<String, DataUseGroup.GroupVote> byUserAndVote = new LinkedHashMap<>();
+    summary.getElections().values().stream()
+        .filter(e -> datasetIds.contains(e.getDatasetId()))
+        .map(Election::getElectionId)
+        .flatMap(id -> votesByElectionId.getOrDefault(id, List.of()).stream())
+        .forEach(
+            v ->
+                byUserAndVote.putIfAbsent(
+                    v.getUserId() + "|" + v.getVote(),
+                    new DataUseGroup.GroupVote(v.getUserId(), v.getVote(), v.getDisplayName())));
+    return List.copyOf(byUserAndVote.values());
   }
 
   private List<Integer> getDatasetIdsForUserAndRoleId(User user, Integer roleId) {

--- a/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DarCollectionService.java
@@ -65,7 +65,6 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
 import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
-import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.dao.DarCollectionServiceDAO;
@@ -97,8 +96,6 @@ public class DarCollectionService implements ConsentLogger {
   private final EmailService emailService;
   private final DACAutomationRuleService dacAutomationRuleService;
   private final OntologyService ontologyService;
-
-  private static final String UNDEFINED_DATA_USE = "Undefined Data Use";
 
   @Inject
   public DarCollectionService(
@@ -462,11 +459,11 @@ public class DarCollectionService implements ConsentLogger {
     Map<Integer, List<Vote>> votesByElectionId =
         includeVotes ? findDacVotesByElectionId(summaries) : Map.of();
 
-    Map<String, String> labelsByDataUse = new HashMap<>();
+    Map<String, DataUseSummary> summariesByDataUse = new HashMap<>();
     summaries.forEach(
         summary ->
             summary.setDataUseGroups(
-                buildDataUseGroups(summary, datasetsById, votesByElectionId, labelsByDataUse)));
+                buildDataUseGroups(summary, datasetsById, votesByElectionId, summariesByDataUse)));
   }
 
   private Map<Integer, List<Vote>> findDacVotesByElectionId(List<DarCollectionSummary> summaries) {
@@ -491,7 +488,7 @@ public class DarCollectionService implements ConsentLogger {
       DarCollectionSummary summary,
       Map<Integer, Dataset> datasetsById,
       Map<Integer, List<Vote>> votesByElectionId,
-      Map<String, String> labelsByDataUse) {
+      Map<String, DataUseSummary> summariesByDataUse) {
     Map<String, List<Dataset>> datasetsByDataUse = new LinkedHashMap<>();
     summary.getDatasetIds().stream()
         .map(datasetsById::get)
@@ -512,9 +509,12 @@ public class DarCollectionService implements ConsentLogger {
                       + datasets.stream()
                           .map(d -> String.valueOf(d.getDatasetId()))
                           .collect(Collectors.joining("-"));
-              String label =
-                  labelsByDataUse.computeIfAbsent(
-                      entry.getKey(), k -> translateDataUseLabel(datasets.getFirst()));
+              DataUseSummary dataUse =
+                  summariesByDataUse.computeIfAbsent(
+                      entry.getKey(),
+                      k ->
+                          ontologyService.translateDataUseSummary(
+                              datasets.getFirst().getDataUse()));
               List<DataUseGroup.GroupDataset> groupDatasets =
                   datasets.stream()
                       .map(
@@ -523,7 +523,7 @@ public class DarCollectionService implements ConsentLogger {
                                   d.getDatasetId(), d.getName(), d.getDatasetIdentifier()))
                       .toList();
               return new DataUseGroup(
-                  key, label, groupDatasets, collapseVotes(summary, datasets, votesByElectionId));
+                  key, dataUse, groupDatasets, collapseVotes(summary, datasets, votesByElectionId));
             })
         .toList();
   }
@@ -532,21 +532,6 @@ public class DarCollectionService implements ConsentLogger {
     return Objects.isNull(dataset.getDataUse())
         ? "none"
         : GsonUtil.getInstance().toJson(dataset.getDataUse());
-  }
-
-  private String translateDataUseLabel(Dataset dataset) {
-    DataUseSummary summary = ontologyService.translateDataUseSummary(dataset.getDataUse());
-    if (Objects.isNull(summary)) {
-      return UNDEFINED_DATA_USE;
-    }
-    String label =
-        Stream.concat(
-                Optional.ofNullable(summary.getPrimary()).orElse(List.of()).stream(),
-                Optional.ofNullable(summary.getSecondary()).orElse(List.of()).stream())
-            .map(DataUseTerm::getCode)
-            .filter(Objects::nonNull)
-            .collect(Collectors.joining(", "));
-    return label.isBlank() ? UNDEFINED_DATA_USE : label;
   }
 
   /**

--- a/src/main/resources/assets/schemas/DarCollectionSummary.yaml
+++ b/src/main/resources/assets/schemas/DarCollectionSummary.yaml
@@ -60,3 +60,8 @@ properties:
   requiresSOApproval:
     type: boolean
     description: True if the most recent DAR in the collection requires Signing Official Approval
+  dataUseGroups:
+    type: array
+    description: The collection's datasets grouped by the data use they share, as rendered by the Data Access Requests table. Votes are populated only for Chairperson and Member.
+    items:
+      $ref: './DataUseGroup.yaml'

--- a/src/main/resources/assets/schemas/DataUseGroup.yaml
+++ b/src/main/resources/assets/schemas/DataUseGroup.yaml
@@ -1,8 +1,10 @@
 type: object
 properties:
   key:
-    type: string
-    description: Stable identifier for the group within its collection
+    type: array
+    description: IDs of the datasets sharing this data use, ascending
+    items:
+      type: integer
   dataUse:
     type: object
     description: Translated data use terms shared by the group's datasets, in the same shape the dataset search index returns

--- a/src/main/resources/assets/schemas/DataUseGroup.yaml
+++ b/src/main/resources/assets/schemas/DataUseGroup.yaml
@@ -3,9 +3,28 @@ properties:
   key:
     type: string
     description: Stable identifier for the group within its collection
-  label:
-    type: string
-    description: Comma separated data use codes shared by the group's datasets
+  dataUse:
+    type: object
+    description: Translated data use terms shared by the group's datasets, in the same shape the dataset search index returns
+    properties:
+      primary:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            description:
+              type: string
+      secondary:
+        type: array
+        items:
+          type: object
+          properties:
+            code:
+              type: string
+            description:
+              type: string
   datasets:
     type: array
     description: The datasets in this group

--- a/src/main/resources/assets/schemas/DataUseGroup.yaml
+++ b/src/main/resources/assets/schemas/DataUseGroup.yaml
@@ -1,0 +1,38 @@
+type: object
+properties:
+  key:
+    type: string
+    description: Stable identifier for the group within its collection
+  label:
+    type: string
+    description: Comma separated data use codes shared by the group's datasets
+  datasets:
+    type: array
+    description: The datasets in this group
+    items:
+      type: object
+      properties:
+        datasetId:
+          type: integer
+          description: Dataset ID
+        name:
+          type: string
+          description: Dataset name
+        datasetIdentifier:
+          type: string
+          description: Dataset identifier, e.g. DUOS-000001
+  votes:
+    type: array
+    description: DAC member votes on this group. Empty unless the caller is a Chairperson or Member.
+    items:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: The voting member's user ID
+        vote:
+          type: boolean
+          description: The member's vote. Null when the member has not yet voted.
+        displayName:
+          type: string
+          description: The voting member's name

--- a/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/VoteDAOTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -112,6 +113,41 @@ class VoteDAOTest extends DAOTestHelper {
     assertNotNull(foundVotes);
     assertFalse(foundVotes.isEmpty());
     assertEquals(2, foundVotes.size());
+  }
+
+  @Test
+  void testFindDacVotesWithNamesByElectionIds() {
+    User chair = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+    User member = createUserWithRole(UserRoles.MEMBER.getRoleId());
+    Dataset dataset = createDataset();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection("DAR-24680", chair.getUserId(), new Date());
+    DataAccessRequest dar =
+        createDataAccessRequestWithDatasetAndCollectionInfo(
+            collectionId, dataset.getDatasetId(), chair.getUserId());
+    Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
+    createDacVote(chair.getUserId(), election.getElectionId());
+    createDacVote(member.getUserId(), election.getElectionId());
+    // Final votes belong to the collection's outcome, not to the members' tallies.
+    createFinalVote(chair.getUserId(), election.getElectionId());
+
+    List<Vote> votes =
+        voteDAO.findDacVotesWithNamesByElectionIds(List.of(election.getElectionId()));
+
+    assertEquals(2, votes.size());
+    assertTrue(votes.stream().allMatch(v -> VoteType.DAC.getValue().equalsIgnoreCase(v.getType())));
+    assertTrue(votes.stream().allMatch(v -> Objects.nonNull(v.getDisplayName())));
+    assertTrue(
+        votes.stream().anyMatch(v -> chair.getDisplayName().equals(v.getDisplayName())),
+        "the voting member's name is needed for the table's vote tooltip");
+    assertTrue(votes.stream().anyMatch(v -> member.getDisplayName().equals(v.getDisplayName())));
+    // A member who has not voted yet still has a vote row, with no value.
+    assertTrue(votes.stream().allMatch(v -> Objects.isNull(v.getVote())));
+  }
+
+  @Test
+  void testFindDacVotesWithNamesByElectionIdsWithNoElections() {
+    assertTrue(voteDAO.findDacVotesWithNamesByElectionIds(List.of()).isEmpty());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
@@ -21,7 +21,7 @@ class DataUseGroupTest {
 
   private DataUseGroup group() {
     return new DataUseGroup(
-        "bucket-1-2",
+        List.of(1, 2),
         new DataUseSummary(List.of(new DataUseTerm("GRU", "General research use")), List.of()),
         List.of(new DataUseGroup.GroupDataset(1, "Set A", "DUOS-000001")),
         List.of(new DataUseGroup.GroupVote(7, true, "Alice")));
@@ -31,7 +31,8 @@ class DataUseGroupTest {
   void testNestedGroupFieldsSurviveExposeFiltering() {
     JsonObject json = JsonParser.parseString(listContextGson().toJson(group())).getAsJsonObject();
 
-    assertEquals("bucket-1-2", json.get("key").getAsString());
+    assertEquals(2, json.getAsJsonArray("key").size());
+    assertEquals(1, json.getAsJsonArray("key").get(0).getAsInt());
     // The ontology models must survive @Expose filtering too, or the pill renders empty.
     JsonObject primary =
         json.getAsJsonObject("dataUse").getAsJsonArray("primary").get(0).getAsJsonObject();
@@ -75,7 +76,7 @@ class DataUseGroupTest {
   void testPendingVoteIsAbsentRatherThanFalse() {
     DataUseGroup pending =
         new DataUseGroup(
-            "bucket-1", null, List.of(), List.of(new DataUseGroup.GroupVote(7, null, "Alice")));
+            List.of(1), null, List.of(), List.of(new DataUseGroup.GroupVote(7, null, "Alice")));
 
     JsonObject vote =
         JsonParser.parseString(listContextGson().toJson(pending))

--- a/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.List;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Test;
+
+class DataUseGroupTest {
+
+  /** The Gson the collection summary resources serialize list responses with. */
+  private Gson listContextGson() {
+    return GsonUtil.gsonBuilderWithAdapters().excludeFieldsWithoutExposeAnnotation().create();
+  }
+
+  private DataUseGroup group() {
+    return new DataUseGroup(
+        "bucket-1-2",
+        "GRU",
+        List.of(new DataUseGroup.GroupDataset(1, "Set A", "DUOS-000001")),
+        List.of(new DataUseGroup.GroupVote(7, true, "Alice")));
+  }
+
+  @Test
+  void testNestedGroupFieldsSurviveExposeFiltering() {
+    JsonObject json = JsonParser.parseString(listContextGson().toJson(group())).getAsJsonObject();
+
+    assertEquals("bucket-1-2", json.get("key").getAsString());
+    assertEquals("GRU", json.get("label").getAsString());
+
+    JsonObject dataset = json.getAsJsonArray("datasets").get(0).getAsJsonObject();
+    assertEquals(1, dataset.get("datasetId").getAsInt());
+    assertEquals("Set A", dataset.get("name").getAsString());
+    assertEquals("DUOS-000001", dataset.get("datasetIdentifier").getAsString());
+
+    JsonObject vote = json.getAsJsonArray("votes").get(0).getAsJsonObject();
+    assertEquals(7, vote.get("userId").getAsInt());
+    assertTrue(vote.get("vote").getAsBoolean());
+    assertEquals("Alice", vote.get("displayName").getAsString());
+  }
+
+  @Test
+  void testGroupsAreSerializedOnTheCollectionSummary() {
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setDarCollectionId(1);
+    summary.setDataUseGroups(List.of(group()));
+
+    JsonObject json = JsonParser.parseString(listContextGson().toJson(summary)).getAsJsonObject();
+
+    assertEquals(1, json.getAsJsonArray("dataUseGroups").size());
+    assertEquals(
+        "GRU",
+        json.getAsJsonArray("dataUseGroups").get(0).getAsJsonObject().get("label").getAsString());
+  }
+
+  @Test
+  void testPendingVoteIsAbsentRatherThanFalse() {
+    DataUseGroup pending =
+        new DataUseGroup(
+            "bucket-1", "GRU", List.of(), List.of(new DataUseGroup.GroupVote(7, null, "Alice")));
+
+    JsonObject vote =
+        JsonParser.parseString(listContextGson().toJson(pending))
+            .getAsJsonObject()
+            .getAsJsonArray("votes")
+            .get(0)
+            .getAsJsonObject();
+
+    // A member who has not voted must not be read as a denial.
+    assertTrue(vote.get("vote") == null || vote.get("vote").isJsonNull());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/DataUseGroupTest.java
@@ -7,6 +7,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.List;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +22,7 @@ class DataUseGroupTest {
   private DataUseGroup group() {
     return new DataUseGroup(
         "bucket-1-2",
-        "GRU",
+        new DataUseSummary(List.of(new DataUseTerm("GRU", "General research use")), List.of()),
         List.of(new DataUseGroup.GroupDataset(1, "Set A", "DUOS-000001")),
         List.of(new DataUseGroup.GroupVote(7, true, "Alice")));
   }
@@ -30,7 +32,11 @@ class DataUseGroupTest {
     JsonObject json = JsonParser.parseString(listContextGson().toJson(group())).getAsJsonObject();
 
     assertEquals("bucket-1-2", json.get("key").getAsString());
-    assertEquals("GRU", json.get("label").getAsString());
+    // The ontology models must survive @Expose filtering too, or the pill renders empty.
+    JsonObject primary =
+        json.getAsJsonObject("dataUse").getAsJsonArray("primary").get(0).getAsJsonObject();
+    assertEquals("GRU", primary.get("code").getAsString());
+    assertEquals("General research use", primary.get("description").getAsString());
 
     JsonObject dataset = json.getAsJsonArray("datasets").get(0).getAsJsonObject();
     assertEquals(1, dataset.get("datasetId").getAsInt());
@@ -54,14 +60,22 @@ class DataUseGroupTest {
     assertEquals(1, json.getAsJsonArray("dataUseGroups").size());
     assertEquals(
         "GRU",
-        json.getAsJsonArray("dataUseGroups").get(0).getAsJsonObject().get("label").getAsString());
+        json.getAsJsonArray("dataUseGroups")
+            .get(0)
+            .getAsJsonObject()
+            .getAsJsonObject("dataUse")
+            .getAsJsonArray("primary")
+            .get(0)
+            .getAsJsonObject()
+            .get("code")
+            .getAsString());
   }
 
   @Test
   void testPendingVoteIsAbsentRatherThanFalse() {
     DataUseGroup pending =
         new DataUseGroup(
-            "bucket-1", "GRU", List.of(), List.of(new DataUseGroup.GroupVote(7, null, "Alice")));
+            "bucket-1", null, List.of(), List.of(new DataUseGroup.GroupVote(7, null, "Alice")));
 
     JsonObject vote =
         JsonParser.parseString(listContextGson().toJson(pending))

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1230,6 +1230,10 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     return dataset;
   }
 
+  private List<String> codesOf(DataUseGroup group) {
+    return group.dataUse().getPrimary().stream().map(DataUseTerm::getCode).toList();
+  }
+
   private DataUseSummary summaryOfCodes(String... codes) {
     return new DataUseSummary(
         Arrays.stream(codes).map(c -> new DataUseTerm(c, c)).toList(), List.of());
@@ -1261,12 +1265,12 @@ class DarCollectionServiceTest extends AbstractTestHelper {
 
     assertEquals(2, groups.size());
     DataUseGroup gruGroup =
-        groups.stream().filter(g -> g.label().equals("GRU")).findFirst().orElseThrow();
+        groups.stream().filter(g -> codesOf(g).equals(List.of("GRU"))).findFirst().orElseThrow();
     assertEquals(2, gruGroup.datasets().size());
     assertEquals("bucket-1-2", gruGroup.key());
     assertEquals("DUOS-000001", gruGroup.datasets().getFirst().datasetIdentifier());
     assertEquals("One", gruGroup.datasets().getFirst().name());
-    assertEquals(1, groups.stream().filter(g -> g.label().equals("HMB")).count());
+    assertEquals(1, groups.stream().filter(g -> codesOf(g).equals(List.of("HMB"))).count());
   }
 
   @Test
@@ -1333,7 +1337,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
         service.getSummariesForRole(user, UserRoles.ADMIN).getFirst().getDataUseGroups();
 
     assertEquals(1, groups.size());
-    assertEquals("Undefined Data Use", groups.getFirst().label());
+    assertNull(groups.getFirst().dataUse());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -1267,7 +1267,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     DataUseGroup gruGroup =
         groups.stream().filter(g -> codesOf(g).equals(List.of("GRU"))).findFirst().orElseThrow();
     assertEquals(2, gruGroup.datasets().size());
-    assertEquals("bucket-1-2", gruGroup.key());
+    assertEquals(List.of(1, 2), gruGroup.key());
     assertEquals("DUOS-000001", gruGroup.datasets().getFirst().datasetIdentifier());
     assertEquals("One", gruGroup.datasets().getFirst().name());
     assertEquals(1, groups.stream().filter(g -> codesOf(g).equals(List.of("HMB"))).count());

--- a/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DarCollectionServiceTest.java
@@ -31,10 +31,12 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.AbstractTestHelper;
@@ -69,12 +71,16 @@ import org.broadinstitute.consent.http.models.DarCollectionSummary;
 import org.broadinstitute.consent.http.models.DataAccessRequest;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.models.DataManagementIncident;
+import org.broadinstitute.consent.http.models.DataUse;
 import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.DataUseGroup;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.UserRole;
 import org.broadinstitute.consent.http.models.Vote;
+import org.broadinstitute.consent.http.models.ontology.DataUseSummary;
+import org.broadinstitute.consent.http.models.ontology.DataUseTerm;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.broadinstitute.consent.http.service.DarCollectionService.DacUserClassification;
@@ -109,6 +115,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
   @Mock private DaaDAO daaDAO;
   @Mock private Jdbi jdbi;
   @Mock private DACAutomationRuleService dacAutomationRuleService;
+  @Mock private OntologyService ontologyService;
   @Mock private ContainerRequest request;
 
   @BeforeEach
@@ -124,7 +131,7 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     when(jdbi.onDemand(DaaDAO.class)).thenReturn(daaDAO);
     service =
         new DarCollectionService(
-            jdbi, darCollectionServiceDAO, emailService, dacAutomationRuleService);
+            jdbi, darCollectionServiceDAO, emailService, dacAutomationRuleService, ontologyService);
   }
 
   @Test
@@ -1212,6 +1219,189 @@ class DarCollectionServiceTest extends AbstractTestHelper {
     assertTrue(s.getStatus().equalsIgnoreCase(DarCollectionStatus.SUBMITTED.getValue()));
     assertTrue(s.requiresSOApproval());
     assertFalse(s.getActions().contains(DarCollectionActions.APPROVE.getValue()));
+  }
+
+  private Dataset datasetWithDataUse(Integer datasetId, String name, DataUse dataUse) {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(datasetId);
+    dataset.setName(name);
+    dataset.setAlias(datasetId);
+    dataset.setDataUse(dataUse);
+    return dataset;
+  }
+
+  private DataUseSummary summaryOfCodes(String... codes) {
+    return new DataUseSummary(
+        Arrays.stream(codes).map(c -> new DataUseTerm(c, c)).toList(), List.of());
+  }
+
+  @Test
+  void testDataUseGroupsGroupDatasetsBySharedDataUse() {
+    User user = new User();
+    user.setUserId(1);
+    DataUse gru = new DataUseBuilder().setGeneralUse(true).build();
+    DataUse hmb = new DataUseBuilder().setHmbResearch(true).build();
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.addDatasetId(1);
+    summary.addDatasetId(2);
+    summary.addDatasetId(3);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin()).thenReturn(List.of(summary));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(
+            List.of(
+                datasetWithDataUse(1, "One", gru),
+                datasetWithDataUse(2, "Two", gru),
+                datasetWithDataUse(3, "Three", hmb)));
+    when(ontologyService.translateDataUseSummary(gru)).thenReturn(summaryOfCodes("GRU"));
+    when(ontologyService.translateDataUseSummary(hmb)).thenReturn(summaryOfCodes("HMB"));
+
+    List<DataUseGroup> groups =
+        service.getSummariesForRole(user, UserRoles.ADMIN).getFirst().getDataUseGroups();
+
+    assertEquals(2, groups.size());
+    DataUseGroup gruGroup =
+        groups.stream().filter(g -> g.label().equals("GRU")).findFirst().orElseThrow();
+    assertEquals(2, gruGroup.datasets().size());
+    assertEquals("bucket-1-2", gruGroup.key());
+    assertEquals("DUOS-000001", gruGroup.datasets().getFirst().datasetIdentifier());
+    assertEquals("One", gruGroup.datasets().getFirst().name());
+    assertEquals(1, groups.stream().filter(g -> g.label().equals("HMB")).count());
+  }
+
+  @Test
+  void testDataUseGroupsTranslateOncePerDistinctDataUseNotPerDataset() {
+    User user = new User();
+    user.setUserId(1);
+    DataUse gru = new DataUseBuilder().setGeneralUse(true).build();
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.addDatasetId(1);
+    summary.addDatasetId(2);
+    summary.addDatasetId(3);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin()).thenReturn(List.of(summary));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(
+            List.of(
+                datasetWithDataUse(1, "One", gru),
+                datasetWithDataUse(2, "Two", gru),
+                datasetWithDataUse(3, "Three", gru)));
+    when(ontologyService.translateDataUseSummary(any())).thenReturn(summaryOfCodes("GRU"));
+
+    service.getSummariesForRole(user, UserRoles.ADMIN);
+
+    // Translation reads the ontology store, so it must not run per dataset.
+    verify(ontologyService, times(1)).translateDataUseSummary(any());
+  }
+
+  @Test
+  void testDataUseGroupsFetchDatasetsOnceForThePage() {
+    User user = new User();
+    user.setUserId(1);
+    DataUse gru = new DataUseBuilder().setGeneralUse(true).build();
+    DarCollectionSummary first = new DarCollectionSummary();
+    first.setLatestReferenceId(UUID.randomUUID().toString());
+    first.addDatasetId(1);
+    DarCollectionSummary second = new DarCollectionSummary();
+    second.setLatestReferenceId(UUID.randomUUID().toString());
+    second.addDatasetId(2);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin())
+        .thenReturn(List.of(first, second));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(List.of(datasetWithDataUse(1, "One", gru), datasetWithDataUse(2, "Two", gru)));
+    when(ontologyService.translateDataUseSummary(any())).thenReturn(summaryOfCodes("GRU"));
+
+    service.getSummariesForRole(user, UserRoles.ADMIN);
+
+    // One dataset query for every collection on the page, not one per collection.
+    verify(datasetDAO, times(1)).findDatasetsByIdList(any());
+  }
+
+  @Test
+  void testDataUseGroupsLabelDatasetsWithNoDataUse() {
+    User user = new User();
+    user.setUserId(1);
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.addDatasetId(1);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin()).thenReturn(List.of(summary));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(List.of(datasetWithDataUse(1, "One", null)));
+    when(ontologyService.translateDataUseSummary(null)).thenReturn(null);
+
+    List<DataUseGroup> groups =
+        service.getSummariesForRole(user, UserRoles.ADMIN).getFirst().getDataUseGroups();
+
+    assertEquals(1, groups.size());
+    assertEquals("Undefined Data Use", groups.getFirst().label());
+  }
+
+  @Test
+  void testDataUseGroupsIncludeDacMemberVotesForChair() {
+    User user = new User();
+    user.setUserId(1);
+    DataUse gru = new DataUseBuilder().setGeneralUse(true).build();
+    Election election = new Election();
+    election.setElectionId(10);
+    election.setDatasetId(1);
+    election.setStatus(ElectionStatus.OPEN.getValue());
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.addDatasetId(1);
+    summary.addElection(election);
+    Vote approve = new Vote();
+    approve.setVoteId(1);
+    approve.setUserId(7);
+    approve.setElectionId(10);
+    approve.setVote(true);
+    approve.setDisplayName("Alice");
+    Vote pending = new Vote();
+    pending.setVoteId(2);
+    pending.setUserId(8);
+    pending.setElectionId(10);
+    pending.setDisplayName("Bob");
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForDACRole(any(), any()))
+        .thenReturn(List.of(summary));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(List.of(datasetWithDataUse(1, "One", gru)));
+    when(ontologyService.translateDataUseSummary(any())).thenReturn(summaryOfCodes("GRU"));
+    when(voteDAO.findDacVotesWithNamesByElectionIds(any())).thenReturn(List.of(approve, pending));
+
+    List<DataUseGroup> groups =
+        service.getSummariesForRole(user, UserRoles.CHAIRPERSON).getFirst().getDataUseGroups();
+
+    List<DataUseGroup.GroupVote> votes = groups.getFirst().votes();
+    assertEquals(2, votes.size());
+    assertEquals(1, votes.stream().filter(v -> Boolean.TRUE.equals(v.vote())).count());
+    assertEquals(1, votes.stream().filter(v -> Objects.isNull(v.vote())).count());
+    assertEquals(
+        "Alice",
+        votes.stream()
+            .filter(v -> Boolean.TRUE.equals(v.vote()))
+            .findFirst()
+            .orElseThrow()
+            .displayName());
+  }
+
+  @Test
+  void testDataUseGroupsWithholdVotesFromNonDacRoles() {
+    User user = new User();
+    user.setUserId(1);
+    DataUse gru = new DataUseBuilder().setGeneralUse(true).build();
+    DarCollectionSummary summary = new DarCollectionSummary();
+    summary.setLatestReferenceId(UUID.randomUUID().toString());
+    summary.addDatasetId(1);
+    when(darCollectionSummaryDAO.getDarCollectionSummariesForAdmin()).thenReturn(List.of(summary));
+    when(datasetDAO.findDatasetsByIdList(any()))
+        .thenReturn(List.of(datasetWithDataUse(1, "One", gru)));
+    when(ontologyService.translateDataUseSummary(any())).thenReturn(summaryOfCodes("GRU"));
+
+    List<DataUseGroup> groups =
+        service.getSummariesForRole(user, UserRoles.ADMIN).getFirst().getDataUseGroups();
+
+    // DAC member votes are only ever shown to the DAC that casts them.
+    assertTrue(groups.getFirst().votes().isEmpty());
+    verify(voteDAO, never()).findDacVotesWithNamesByElectionIds(any());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3982](https://broadworkbench.atlassian.net/browse/DT-3982)

Security risk: no

### Summary

The Data Access Requests table renders one row per data-use group. Until now each console derived those groups in the browser: per visible collection a `getCollectionById`, a match lookup and a dataset-terms search, so roughly thirty requests to fill a page of ten. Everything needed is already in Postgres, so `getSummariesForRole` now attaches the groups and the console renders what it is given.

Work is batched across the whole response rather than per collection: one `findDatasetsByIdList`, one member-vote query, and one data use translation per **distinct** data use. That last part is the point — translation reads the ontology store for disease restrictions, so translating per dataset would have moved the N+1 into the service rather than removed it. A DAC's datasets share very few distinct data uses (19 distinct across 275 groups in a local run), so this collapses to a handful of reads.

Groups carry the translated `DataUseSummary` rather than a flat label, so the UI renders them with the same helper the Data Library grid uses and the two cannot drift apart. `DataUseSummary` and `DataUseTerm` needed `@Expose` to survive the list-context Gson the collection resources serialize with.

Member votes are attached only for Chairperson and Member. Researchers and Signing Officials get the same groups with an empty vote list, and the vote query is not issued at all for those roles — DAC voting is not theirs to see. `VoteDAO` gains `findDacVotesWithNamesByElectionIds`, with a mapper that adds the voting member's name, because the interface-level `VoteMapper` builds a `Vote` without one.

Additive only: no existing response field or behaviour changes, and `binCollectionToBuckets` is untouched, so the DAR review page and DUC addendum are unaffected.

### API change

`GET /api/collections/role/{roleName}/summary` gains one field on each `DarCollectionSummary`: `dataUseGroups`. Every other field is unchanged, and no other endpoint is affected — `/summary/{collectionId}` and `GET /api/collections/{id}` do not carry groups.

Each entry is one data-use group within the collection: the datasets that share a data use, that data use translated, and (Chair/Member only) the DAC's votes on it. `key` is stable within a collection and is what the table uses for its row id.

```jsonc
// GET /api/collections/role/Chairperson/summary   (values below are illustrative)
[
  {
    "darCollectionId": 855,
    "darCode": "DAR-855",
    "status": "Submitted",
    "datasetCount": 3,
    // ... all existing fields unchanged ...
    "dataUseGroups": [
      {
        "key": "bucket-2",
        "dataUse": {
          "primary": [
            { "code": "DS",   "description": "Data use is limited for studying: cancerophobia, diabetes mellitus [DS]" },
            { "code": "NPOA", "description": "Future use for population origins or ancestry research is prohibited. [POA]" }
          ],
          "secondary": [
            { "code": "POP-F",  "description": "Data use is limited to research on females. [RS-FM]" },
            { "code": "POP-PD", "description": "Data use is limited to pediatric research. [RS-PD]" }
          ]
        },
        "datasets": [
          { "datasetId": 2, "name": "Example Cohort Study", "datasetIdentifier": "DUOS-000002" }
        ],
        "votes": [
          { "userId": 101, "vote": true,  "displayName": "Member One" },
          { "userId": 102, "vote": false, "displayName": "Member Two" },
          { "userId": 103,                "displayName": "Member Three" }   // no vote yet: still pending
        ]
      },
      {
        "key": "bucket-7-9",
        "dataUse": { "primary": [ { "code": "HMB", "description": "Data is limited for health/medical/biomedical research. [HMB]" } ] },
        "datasets": [
          { "datasetId": 7, "name": "Example Registry",  "datasetIdentifier": "DUOS-000007" },
          { "datasetId": 9, "name": "Example Biobank",   "datasetIdentifier": "DUOS-000009" }
        ],
        "votes": []
      }
    ]
  }
]
```

Notes on the shape:

- `vote` is absent when the member has not voted yet, so a pending vote is never read as a denial. Present and `false` means denied.
- `votes` is always empty for Admin, Signing Official and Researcher, and the vote query is not issued for those roles at all.
- `dataUse` is the translated `DataUseSummary`, the same shape the dataset search index stores, so the UI renders it with the helper the Data Library grid already uses. It is null when a group's datasets carry no data use.
- A collection with no datasets visible to the caller returns an empty `dataUseGroups` array. The field is omitted entirely when no collection in the response has any visible datasets.

### Notes for review

- **The duos-ui side depends on this being deployed first.** [duos-ui#3858](https://github.com/DataBiosphere/duos-ui/pull/3858) reads `dataUseGroups`; if it ships first the Data Use, Datasets and Votes columns render empty across all six consoles.
- The endpoint returns every collection for the role and groups all of them, while the table shows ten at a time. Measured locally on 227 collections: the endpoint goes from ~0.91s to ~1.18s and the response from 123KB to 303KB, which gzips to 17.7KB → 27.0KB on the wire. The pre-existing lack of server-side pagination on this endpoint dominates that cost; narrowing it would mean pushing search and sort server-side for all six consoles, which is out of scope here.
- Verified end to end against a local stack with the seeded database: 227 collections all carrying groups, correct disease-restriction labels, member names on votes, and zero votes returned for the Researcher role.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
