### PR TITLE
[DT-3960] Update error text on SO and IT director submission to match new FE language.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -678,12 +678,12 @@ public class DataAccessRequestService implements ConsentLogger {
 
     if (piEmail.equalsIgnoreCase(soEmail)) {
       throw new IllegalArgumentException(
-          "Principal Investigator email cannot be the same as Signing Official email");
+          "You cannot be both the requester and Principal Investigator and the Signing Official on the same Data Access Request.");
     }
 
     if (piEmail.equalsIgnoreCase(itEmail)) {
       throw new IllegalArgumentException(
-          "Principal Investigator email cannot be the same as IT Director email");
+          "You cannot be both the requester and Principal Investigator and the IT Director on the same Data Access Request.");
     }
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DataAccessRequestService.java
@@ -678,12 +678,12 @@ public class DataAccessRequestService implements ConsentLogger {
 
     if (piEmail.equalsIgnoreCase(soEmail)) {
       throw new IllegalArgumentException(
-          "You cannot be both the requester and Principal Investigator and the Signing Official on the same Data Access Request.");
+          "You cannot be both the requester and the Signing Official on the same Data Access Request.");
     }
 
     if (piEmail.equalsIgnoreCase(itEmail)) {
       throw new IllegalArgumentException(
-          "You cannot be both the requester and Principal Investigator and the IT Director on the same Data Access Request.");
+          "You cannot be both the requester and the IT Director on the same Data Access Request.");
     }
   }
 


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3960](https://broadworkbench.atlassian.net/browse/DT-3960)

### Summary

The ticket updates the frontend to include specific, helpful text to communicate that a signing official can not be both the submitter (PI) and the SO on the same DAR.  Consent also provides an error for this that is displayed on DAR submission when the case arrises.  This ticket updates the consent error (and adjacent IT director error message) to match the language now displayed in the UI.

No tests required modification.  Coverage exists, but only confirms the exception was thrown, not the error text.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
