### PR TITLE
[DT-3871] Expose typed study/dataset template validation and create valid drafts

### DIFF
--- a/docs/API_GUIDELINES.md
+++ b/docs/API_GUIDELINES.md
@@ -26,6 +26,7 @@ Use these rules when adding or changing endpoints in the Consent service.
 - `403 Forbidden`: caller lacks required permissions.
 - `404 Not Found`: resource does not exist.
 - `409 Conflict`: version/state conflict.
+- `413 Content Too Large`: the request body exceeds an endpoint-specific size limit.
 - `500 Internal Server Error`: unhandled server-side error.
 
 ## Security and Authorization

--- a/docs/study-template-v1.md
+++ b/docs/study-template-v1.md
@@ -350,16 +350,20 @@ interface TemplateValidationError {
 }
 
 type TemplateValidationResponse =
-  | { valid: false, errors: TemplateValidationError[] }
+  | { valid: false, errors: TemplateValidationError[], truncated: boolean }
   | {
       valid: true
       errors: []
+      truncated: false
       draft: {
         id: string
         draftType: 'StudyDatasetSubmissionV1'
       }
     }
 ```
+
+`truncated` reports that the 100-error cap was reached. The last error says so as well, so a client
+that ignores the flag still tells the producer that errors were omitted.
 
 `row` is the one-based physical line the record starts on, counting the CSV header as row 1, so it
 matches the line the producer sees in their editor or spreadsheet: ignored blank lines still occupy

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -81,6 +81,7 @@ import org.broadinstitute.consent.http.resources.ResearcherDashboardResource;
 import org.broadinstitute.consent.http.resources.SamResource;
 import org.broadinstitute.consent.http.resources.SigningOfficialDashboardResource;
 import org.broadinstitute.consent.http.resources.StatusResource;
+import org.broadinstitute.consent.http.resources.StudyDatasetTemplateResource;
 import org.broadinstitute.consent.http.resources.StudyResource;
 import org.broadinstitute.consent.http.resources.SupportResource;
 import org.broadinstitute.consent.http.resources.SwaggerResource;
@@ -197,6 +198,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(SigningOfficialDashboardResource.class));
     env.jersey().register(injector.getInstance(SwaggerResource.class));
     env.jersey().register(injector.getInstance(StatusResource.class));
+    env.jersey().register(injector.getInstance(StudyDatasetTemplateResource.class));
     env.jersey().register(injector.getInstance(StudyResource.class));
     env.jersey().register(injector.getInstance(SupportResource.class));
     env.jersey().register(injector.getInstance(TDRResource.class));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -44,6 +44,7 @@ import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
 import org.broadinstitute.consent.http.filters.RateLimitFilter;
 import org.broadinstitute.consent.http.filters.RequestHeaderCacheFilter;
 import org.broadinstitute.consent.http.filters.ResponseServerFilter;
+import org.broadinstitute.consent.http.filters.TemplateSizeLimitFilter;
 import org.broadinstitute.consent.http.health.EcmHealthCheck;
 import org.broadinstitute.consent.http.health.ElasticSearchHealthCheck;
 import org.broadinstitute.consent.http.health.GCSHealthCheck;
@@ -52,6 +53,7 @@ import org.broadinstitute.consent.http.health.SendGridHealthCheck;
 import org.broadinstitute.consent.http.mappers.ForbiddenExceptionMapper;
 import org.broadinstitute.consent.http.mappers.JsonErrorHandler;
 import org.broadinstitute.consent.http.mappers.NotFoundExceptionMapper;
+import org.broadinstitute.consent.http.mappers.TemplateTooLargeExceptionMapper;
 import org.broadinstitute.consent.http.models.AuthUser;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.resources.DACAutomationRuleResource;
@@ -164,6 +166,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     // response body. Expand to include other codes when necessary.
     env.jersey().register(NotFoundExceptionMapper.class);
     env.jersey().register(ForbiddenExceptionMapper.class);
+    env.jersey().register(TemplateTooLargeExceptionMapper.class);
     // Last-resort net for requests that never reach Jersey's dispatch at all (e.g. a path that
     // matches no @Path template), which the ExceptionMappers above cannot intercept.
     env.getApplicationContext().setErrorHandler(new JsonErrorHandler());
@@ -237,6 +240,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(RequestHeaderCacheFilter.class));
     env.jersey().register(injector.getInstance(RateLimitFilter.class));
     env.jersey().register(RolesAllowedDynamicFeature.class);
+    env.jersey().register(TemplateSizeLimitFilter.class);
   }
 
   @Override

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -196,6 +197,16 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
   @Singleton
   private ExecutorService providesExecutorService() {
     return executorService;
+  }
+
+  /**
+   * One mapper for the registration document, so the draft written from a template is serialized by
+   * the same configuration the registration endpoint reads it back with.
+   */
+  @Provides
+  @Singleton
+  private ObjectMapper providesObjectMapper() {
+    return new ObjectMapper();
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -199,10 +199,7 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
     return executorService;
   }
 
-  /**
-   * One mapper for the registration document, so the draft written from a template is serialized by
-   * the same configuration the registration endpoint reads it back with.
-   */
+  /** One mapper, so a draft written from a template is serialized as the registration reads it. */
   @Provides
   @Singleton
   private ObjectMapper providesObjectMapper() {

--- a/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
@@ -53,14 +53,15 @@ public interface DraftDAO extends Transactional<DraftDAO> {
           LEFT JOIN file_storage_object fso ON fso.entity_id = ds.uuid::text AND fso.deleted = false
           """;
 
-  // jsonb rejects a U+0000 escape, so it is stripped here as it is for data access requests.
+  // jsonb rejects a U+0000 escape, so it is stripped here as it is for data access requests. The
+  // lookbehind spares an already-escaped backslash, whose second one would otherwise start a match.
   @SqlUpdate(
       """
           INSERT into draft
               (name, create_date, create_user_id, update_date,
               update_user_id, json, uuid, draft_type)
           (SELECT :name, :createdDate, :createdUserId, :createdDate, :createdUserId,
-              regexp_replace(:json, '\\\\u0000', '', 'g')::jsonb, :uuid, :draftType)
+              regexp_replace(:json, '(?<!\\\\)\\\\u0000', '', 'g')::jsonb, :uuid, :draftType)
           """)
   @GetGeneratedKeys
   Integer insert(
@@ -78,7 +79,7 @@ public interface DraftDAO extends Transactional<DraftDAO> {
       SET name = :name,
           update_date = :updateDate,
           update_user_id = :updateUserId,
-          json = regexp_replace(:json, '\\\\u0000', '', 'g')::jsonb,
+          json = regexp_replace(:json, '(?<!\\\\)\\\\u0000', '', 'g')::jsonb,
           draft_type = :draftType
       WHERE uuid = :uuid
       """)

--- a/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
@@ -53,12 +53,14 @@ public interface DraftDAO extends Transactional<DraftDAO> {
           LEFT JOIN file_storage_object fso ON fso.entity_id = ds.uuid::text AND fso.deleted = false
           """;
 
+  // jsonb rejects a U+0000 escape, so it is stripped here as it is for data access requests.
   @SqlUpdate(
       """
           INSERT into draft
               (name, create_date, create_user_id, update_date,
               update_user_id, json, uuid, draft_type)
-          (SELECT :name, :createdDate, :createdUserId, :createdDate, :createdUserId, :json::jsonb, :uuid, :draftType)
+          (SELECT :name, :createdDate, :createdUserId, :createdDate, :createdUserId,
+              regexp_replace(:json, '\\\\u0000', '', 'g')::jsonb, :uuid, :draftType)
           """)
   @GetGeneratedKeys
   Integer insert(
@@ -69,13 +71,14 @@ public interface DraftDAO extends Transactional<DraftDAO> {
       @Bind("uuid") UUID uuid,
       @Bind("draftType") String draftType);
 
+  // Same strip as insert: a draft is meant to be edited and saved, so this path is as exposed.
   @SqlUpdate(
       """
       UPDATE draft
       SET name = :name,
           update_date = :updateDate,
           update_user_id = :updateUserId,
-          json = :json::jsonb,
+          json = regexp_replace(:json, '\\\\u0000', '', 'g')::jsonb,
           draft_type = :draftType
       WHERE uuid = :uuid
       """)

--- a/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DraftDAO.java
@@ -53,15 +53,15 @@ public interface DraftDAO extends Transactional<DraftDAO> {
           LEFT JOIN file_storage_object fso ON fso.entity_id = ds.uuid::text AND fso.deleted = false
           """;
 
-  // jsonb rejects a U+0000 escape, so it is stripped here as it is for data access requests. The
-  // lookbehind spares an already-escaped backslash, whose second one would otherwise start a match.
+  // Both the name and the document reach here free of the U+0000 neither column accepts:
+  // NulCharacters strips it for the draft writes, which SQL cannot do for either value.
   @SqlUpdate(
       """
           INSERT into draft
               (name, create_date, create_user_id, update_date,
               update_user_id, json, uuid, draft_type)
           (SELECT :name, :createdDate, :createdUserId, :createdDate, :createdUserId,
-              regexp_replace(:json, '(?<!\\\\)\\\\u0000', '', 'g')::jsonb, :uuid, :draftType)
+              :json::jsonb, :uuid, :draftType)
           """)
   @GetGeneratedKeys
   Integer insert(
@@ -72,14 +72,15 @@ public interface DraftDAO extends Transactional<DraftDAO> {
       @Bind("uuid") UUID uuid,
       @Bind("draftType") String draftType);
 
-  // Same strip as insert: a draft is meant to be edited and saved, so this path is as exposed.
+  // Stripped before binding as insert's values are: a draft is meant to be edited and saved,
+  // and the rename this serves carries a name of its own.
   @SqlUpdate(
       """
       UPDATE draft
       SET name = :name,
           update_date = :updateDate,
           update_user_id = :updateUserId,
-          json = regexp_replace(:json, '(?<!\\\\)\\\\u0000', '', 'g')::jsonb,
+          json = :json::jsonb,
           draft_type = :draftType
       WHERE uuid = :uuid
       """)

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
@@ -1,0 +1,11 @@
+package org.broadinstitute.consent.http.exceptions;
+
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.core.Response.Status;
+
+/** An upload too large to validate: a failed request rather than a validation result. */
+public class TemplateTooLargeException extends ClientErrorException {
+  public TemplateTooLargeException(String message) {
+    super(message, Status.REQUEST_ENTITY_TOO_LARGE);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
@@ -1,9 +1,8 @@
 package org.broadinstitute.consent.http.exceptions;
 
 /**
- * An upload too large to validate: a failed request rather than a validation result. Deliberately
- * not a JAX-RS exception — the validator that raises it has no HTTP to answer with, and the
- * resource that catches it decides the status.
+ * An upload too large to validate: a failed request, not a validation result. Not a JAX-RS
+ * exception — the validator has no HTTP to answer with, and the resource decides the status.
  */
 public class TemplateTooLargeException extends RuntimeException {
   public TemplateTooLargeException(String message) {

--- a/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
+++ b/src/main/java/org/broadinstitute/consent/http/exceptions/TemplateTooLargeException.java
@@ -1,11 +1,12 @@
 package org.broadinstitute.consent.http.exceptions;
 
-import jakarta.ws.rs.ClientErrorException;
-import jakarta.ws.rs.core.Response.Status;
-
-/** An upload too large to validate: a failed request rather than a validation result. */
-public class TemplateTooLargeException extends ClientErrorException {
+/**
+ * An upload too large to validate: a failed request rather than a validation result. Deliberately
+ * not a JAX-RS exception — the validator that raises it has no HTTP to answer with, and the
+ * resource that catches it decides the status.
+ */
+public class TemplateTooLargeException extends RuntimeException {
   public TemplateTooLargeException(String message) {
-    super(message, Status.REQUEST_ENTITY_TOO_LARGE);
+    super(message);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
@@ -38,7 +38,7 @@ public class TemplateSizeLimitFilter implements ContainerRequestFilter {
    * epilogue. Generous, since the file limit is what a client is told about and this only has to
    * leave a template of the largest allowed size room to arrive.
    */
-  private static final long ENVELOPE_ALLOWANCE = 8 * 1024;
+  private static final long ENVELOPE_ALLOWANCE = 8L * 1024;
 
   static final long MAX_REQUEST_BYTES =
       StudyTemplateValidationService.MAX_TEMPLATE_BYTES + ENVELOPE_ALLOWANCE;

--- a/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
@@ -1,0 +1,119 @@
+package org.broadinstitute.consent.http.filters;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
+import org.broadinstitute.consent.http.mappers.TemplateTooLargeExceptionMapper;
+import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
+
+/**
+ * Bounds a template upload at the request, which the validator's limit cannot do: a resource method
+ * taking a multipart parameter is called only after Jersey has read the whole entity, so by then
+ * the body has already been spooled whatever its size. The validator still owns the limit on the
+ * file itself, and this owns only the boundary — the point past which no more of the request is
+ * read.
+ *
+ * <p>Two guards, because either alone leaves a way through. A {@code Content-Length} past the cap
+ * is refused before a byte of the body is read, which is the honest oversize upload. A body sent
+ * chunked, or under a {@code Content-Length} that lies, has no length to check, so the entity
+ * stream is bounded as well and stops the read at the cap. That second refusal is raised while
+ * Jersey is reading the body, and reaches the client as a 413 through {@link
+ * TemplateTooLargeExceptionMapper} rather than from the resource method; whether Jersey routes
+ * every reader-phase failure there is best-effort, but the read stops at the cap either way.
+ */
+@Provider
+@TemplateSizeLimited
+@Priority(Priorities.USER)
+public class TemplateSizeLimitFilter implements ContainerRequestFilter {
+
+  /**
+   * What the multipart envelope adds around the file: the boundaries, the part headers, and the
+   * epilogue. Generous, since the file limit is what a client is told about and this only has to
+   * leave a template of the largest allowed size room to arrive.
+   */
+  private static final int ENVELOPE_ALLOWANCE = 8 * 1024;
+
+  static final long MAX_REQUEST_BYTES =
+      StudyTemplateValidationService.MAX_TEMPLATE_BYTES + ENVELOPE_ALLOWANCE;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    if (declaredLength(requestContext) > MAX_REQUEST_BYTES) {
+      requestContext.abortWith(
+          TemplateTooLargeExceptionMapper.tooLarge(
+              StudyTemplateValidationService.TOO_LARGE_MESSAGE));
+      return;
+    }
+    requestContext.setEntityStream(
+        new BoundedEntityStream(requestContext.getEntityStream(), MAX_REQUEST_BYTES));
+  }
+
+  /**
+   * Read as a long rather than through {@code getLength()}, whose int parse turns the header of a
+   * multi-gigabyte body — the one this most needs to catch — into an unknown length.
+   */
+  private static long declaredLength(ContainerRequestContext requestContext) {
+    String header = requestContext.getHeaderString(HttpHeaders.CONTENT_LENGTH);
+    if (header == null || header.isBlank()) {
+      return -1;
+    }
+    try {
+      return Long.parseLong(header.trim());
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  /** Refuses to hand out more than the cap, so a body with no declared length is bounded too. */
+  private static final class BoundedEntityStream extends FilterInputStream {
+
+    private final long limit;
+    private long read;
+
+    private BoundedEntityStream(InputStream in, long limit) {
+      super(in);
+      this.limit = limit;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int value = super.read();
+      if (value != -1) {
+        count(1);
+      }
+      return value;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      int count = super.read(buffer, offset, length);
+      if (count > 0) {
+        count(count);
+      }
+      return count;
+    }
+
+    @Override
+    public long skip(long requested) throws IOException {
+      long skipped = super.skip(requested);
+      if (skipped > 0) {
+        count(skipped);
+      }
+      return skipped;
+    }
+
+    private void count(long bytes) {
+      read += bytes;
+      if (read > limit) {
+        throw new TemplateTooLargeException(StudyTemplateValidationService.TOO_LARGE_MESSAGE);
+      }
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilter.java
@@ -38,7 +38,7 @@ public class TemplateSizeLimitFilter implements ContainerRequestFilter {
    * epilogue. Generous, since the file limit is what a client is told about and this only has to
    * leave a template of the largest allowed size room to arrive.
    */
-  private static final int ENVELOPE_ALLOWANCE = 8 * 1024;
+  private static final long ENVELOPE_ALLOWANCE = 8 * 1024;
 
   static final long MAX_REQUEST_BYTES =
       StudyTemplateValidationService.MAX_TEMPLATE_BYTES + ENVELOPE_ALLOWANCE;

--- a/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimited.java
+++ b/src/main/java/org/broadinstitute/consent/http/filters/TemplateSizeLimited.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.consent.http.filters;
+
+import jakarta.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Binds {@link TemplateSizeLimitFilter} to a template upload endpoint, so the request is bounded
+ * before Jersey reads the body rather than after. Carried by the filter as well as by the methods
+ * it guards, which is what makes the binding take effect.
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface TemplateSizeLimited {}

--- a/src/main/java/org/broadinstitute/consent/http/mappers/TemplateTooLargeExceptionMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/mappers/TemplateTooLargeExceptionMapper.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.consent.http.mappers;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
+import org.broadinstitute.consent.http.models.Error;
+
+/**
+ * Answers a refused upload with 413 wherever the refusal is raised: from the validator, inside the
+ * resource method, or from the bounded entity stream a request filter installs, which throws while
+ * Jersey is still reading the body and so never reaches the resource's own catch.
+ */
+public class TemplateTooLargeExceptionMapper implements ExceptionMapper<TemplateTooLargeException> {
+
+  @Override
+  public Response toResponse(TemplateTooLargeException exception) {
+    return tooLarge(exception.getMessage());
+  }
+
+  /** The one 413 the template uploads answer with, whichever layer decided to refuse. */
+  public static Response tooLarge(String message) {
+    return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+        .type(MediaType.APPLICATION_JSON)
+        .entity(new Error(message, Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()))
+        .build();
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/StudyDatasetDraftReference.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/StudyDatasetDraftReference.java
@@ -1,8 +1,7 @@
 package org.broadinstitute.consent.http.models.dto.registration.template;
 
 /**
- * The draft a valid template produced. The type is carried alongside the id because a client must
- * know what kind of document it is about to load rather than inferring one from the id or the route
- * that produced it.
+ * The draft a valid template produced. The type travels with the id so a client knows what document
+ * it is about to load rather than inferring it.
  */
 public record StudyDatasetDraftReference(String id, String draftType) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/StudyDatasetDraftReference.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/StudyDatasetDraftReference.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.consent.http.models.dto.registration.template;
+
+/**
+ * The draft a valid template produced. The type is carried alongside the id because a client must
+ * know what kind of document it is about to load rather than inferring one from the id or the route
+ * that produced it.
+ */
+public record StudyDatasetDraftReference(String id, String draftType) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
@@ -1,14 +1,13 @@
 package org.broadinstitute.consent.http.models.dto.registration.template;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 
 /**
  * The wire response of the template-validation endpoint, discriminated by {@code valid}. Both
  * branches carry an error list, so a caller can read it without checking which branch it has, and
  * an absent field means no value: that is how a client tells an unlocated error from one on row 1.
+ * Gson writes every JSON entity here and skips nulls by default; no annotation holds that up.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TemplateValidationResponse(
     boolean valid,
     List<TemplateValidationError> errors,
@@ -16,7 +15,7 @@ public record TemplateValidationResponse(
     StudyDatasetDraftReference draft) {
 
   public TemplateValidationResponse {
-    errors = List.copyOf(errors);
+    errors = errors == null ? List.of() : List.copyOf(errors);
   }
 
   public static TemplateValidationResponse valid(StudyDatasetDraftReference draft) {

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
@@ -4,14 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 
 /**
- * The wire response of the template-validation endpoint, discriminated by {@code valid}: a valid
- * template carries the draft it created and no errors, an invalid one carries its errors and no
- * draft. Both branches carry an error list so a caller can read it without checking which branch it
- * has.
- *
- * <p>A field with no value is absent rather than null, which is how a client tells an error with no
- * location from one on row 1. Responses are written by {@code JerseyGsonProvider}, which omits
- * nulls; the Jackson annotation says the same for any caller that maps this with an ObjectMapper.
+ * The wire response of the template-validation endpoint, discriminated by {@code valid}. Both
+ * branches carry an error list, so a caller can read it without checking which branch it has, and
+ * an absent field means no value: that is how a client tells an unlocated error from one on row 1.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record TemplateValidationResponse(

--- a/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponse.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.consent.http.models.dto.registration.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * The wire response of the template-validation endpoint, discriminated by {@code valid}: a valid
+ * template carries the draft it created and no errors, an invalid one carries its errors and no
+ * draft. Both branches carry an error list so a caller can read it without checking which branch it
+ * has.
+ *
+ * <p>A field with no value is absent rather than null, which is how a client tells an error with no
+ * location from one on row 1. Responses are written by {@code JerseyGsonProvider}, which omits
+ * nulls; the Jackson annotation says the same for any caller that maps this with an ObjectMapper.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TemplateValidationResponse(
+    boolean valid,
+    List<TemplateValidationError> errors,
+    boolean truncated,
+    StudyDatasetDraftReference draft) {
+
+  public TemplateValidationResponse {
+    errors = List.copyOf(errors);
+  }
+
+  public static TemplateValidationResponse valid(StudyDatasetDraftReference draft) {
+    return new TemplateValidationResponse(true, List.of(), false, draft);
+  }
+
+  public static TemplateValidationResponse invalid(
+      List<TemplateValidationError> errors, boolean truncated) {
+    return new TemplateValidationResponse(false, errors, truncated, null);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DatasetResource.java
@@ -75,7 +75,7 @@ public class DatasetResource extends Resource {
   private final ElasticSearchService elasticSearchService;
 
   private final GCSService gcsService;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
   private final StudyRegistrationRequestValidator createValidator =
       new StudyRegistrationRequestValidator();
 
@@ -86,13 +86,15 @@ public class DatasetResource extends Resource {
       DatasetRegistrationService datasetRegistrationService,
       ElasticSearchService elasticSearchService,
       TDRService tdrService,
-      GCSService gcsService) {
+      GCSService gcsService,
+      ObjectMapper objectMapper) {
     this.datasetService = datasetService;
     this.userService = userService;
     this.datasetRegistrationService = datasetRegistrationService;
     this.gcsService = gcsService;
     this.elasticSearchService = elasticSearchService;
     this.tdrService = tdrService;
+    this.objectMapper = objectMapper;
   }
 
   @POST

--- a/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
@@ -51,7 +51,7 @@ public class DraftResource extends Resource {
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/v1")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response getDrafts(@Auth DuosUser duosUser) {
     try {
       User user = duosUser.getUser();
@@ -66,7 +66,7 @@ public class DraftResource extends Resource {
   @Consumes({MediaType.APPLICATION_JSON})
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/v1")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response createDraftRegistration(@Auth DuosUser duosUser, String json) {
     try {
       User user = duosUser.getUser();
@@ -82,7 +82,7 @@ public class DraftResource extends Resource {
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/v1/{draftUUID}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response getDraftDocument(
       @Auth DuosUser duosUser, @PathParam("draftUUID") String draftUUID) {
     try {
@@ -99,7 +99,7 @@ public class DraftResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Consumes({MediaType.APPLICATION_JSON})
   @Path("/v1/{draftUUID}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response updateDraft(
       @Auth DuosUser duosUser, @PathParam("draftUUID") String draftUUID, String json) {
     try {
@@ -117,7 +117,7 @@ public class DraftResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Consumes({MediaType.TEXT_PLAIN})
   @Path("/v1/{draftUUID}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response patchDraftName(
       @Auth DuosUser duosUser, @PathParam("draftUUID") String draftUUID, String name) {
     try {
@@ -134,7 +134,7 @@ public class DraftResource extends Resource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/v1/{draftUUID}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response deleteDraft(@Auth DuosUser duosUser, @PathParam("draftUUID") String draftUUID) {
     try {
       User user = duosUser.getUser();
@@ -149,7 +149,7 @@ public class DraftResource extends Resource {
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   @Path("/v1/{draftUUID}/attachments")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response getAttachments(
       @Auth DuosUser duosUser, @PathParam("draftUUID") String draftUUID) {
     try {
@@ -165,7 +165,7 @@ public class DraftResource extends Resource {
   @Produces({MediaType.APPLICATION_JSON})
   @Consumes({MediaType.MULTIPART_FORM_DATA})
   @Path("/v1/{draftUUID}/attachments")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response addAttachments(
       @Auth DuosUser duosUser,
       @PathParam("draftUUID") String draftUUID,
@@ -184,7 +184,7 @@ public class DraftResource extends Resource {
   @GET
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/v1/{draftUUID}/attachments/{fileId}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response getAttachment(
       @Auth DuosUser duosUser,
       @PathParam("draftUUID") String draftUUID,
@@ -223,7 +223,7 @@ public class DraftResource extends Resource {
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/v1/{draftUUID}/attachments/{fileId}")
-  @RolesAllowed({ADMIN, DATASUBMITTER})
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   public Response deleteDraftAttachment(
       @Auth DuosUser duosUser,
       @PathParam("draftUUID") String draftUUID,

--- a/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/DraftResource.java
@@ -73,7 +73,8 @@ public class DraftResource extends Resource {
       DraftInterface draft = new DraftStudyDataset(json, user);
       draftService.insertDraft(draft);
       URI uri = getDraftURI(draft);
-      return Response.created(uri).entity(json).build();
+      // The stored document, not the posted one: the write drops what Postgres cannot hold.
+      return Response.created(uri).entity(draft.getJson()).build();
     } catch (Exception e) {
       return createExceptionResponse(e);
     }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -41,9 +41,9 @@ public class StudyDatasetTemplateResource extends Resource {
   }
 
   /**
-   * A template that fails validation is a completed result rather than a failed request, answered
-   * 200 with the errors to fix; a valid one is a 201 at the draft it created. Only an unusable
-   * request — no file, more than one, or one too large to read — is a failure.
+   * A failed validation is a completed result, answered 200 with the errors to fix; a valid one is
+   * a 201 at the draft it created. Only an unusable request — no file, more than one, or one too
+   * large to read — is a failure.
    */
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
+import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
+import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+
+/**
+ * Study/dataset template validation. Typed rather than generic so this validator does not become
+ * the implied one for every draft type a later ticket adds.
+ */
+@Path("api/draft/v1/study-dataset")
+public class StudyDatasetTemplateResource extends Resource {
+
+  private static final String FILE_PART = "file";
+
+  private final StudyDatasetTemplateService templateService;
+
+  @Inject
+  public StudyDatasetTemplateResource(StudyDatasetTemplateService templateService) {
+    this.templateService = templateService;
+  }
+
+  /**
+   * A template that fails validation is a completed result rather than a failed request: it answers
+   * 200 with {@code valid: false} and the errors the producer has to fix. Only the request itself
+   * being unusable — no file, more than one, or one too large to read — is a failure.
+   */
+  @POST
+  @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/template-validation")
+  @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  public Response validateTemplate(@Auth DuosUser duosUser, FormDataMultiPart multipart) {
+    try {
+      byte[] template = readTemplate(multipart);
+      if (template.length > StudyTemplateValidationService.MAX_TEMPLATE_BYTES) {
+        return tooLarge();
+      }
+      TemplateValidationResponse response =
+          templateService.validateAndCreateDraft(
+              new ByteArrayInputStream(template), duosUser.getUser());
+      return Response.ok().entity(response).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /** Reads one byte beyond the limit, which is all it takes to know the file exceeds it. */
+  private byte[] readTemplate(FormDataMultiPart multipart) throws IOException {
+    List<FormDataBodyPart> parts = multipart == null ? List.of() : multipart.getFields(FILE_PART);
+    if (parts == null || parts.isEmpty()) {
+      throw new BadRequestException(
+          "A template file is required in the '%s' part".formatted(FILE_PART));
+    }
+    if (parts.size() > 1) {
+      throw new BadRequestException("Only one template file may be uploaded at a time");
+    }
+    FormDataBodyPart part = parts.getFirst();
+    validateFileDetails(part.getContentDisposition());
+    try (InputStream content = part.getValueAs(InputStream.class)) {
+      return content.readNBytes(StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1);
+    }
+  }
+
+  private static Response tooLarge() {
+    return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+        .type(MediaType.APPLICATION_JSON)
+        .entity(
+            new Error(
+                StudyTemplateValidationService.TOO_LARGE_MESSAGE,
+                Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()))
+        .build();
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -39,9 +39,8 @@ public class StudyDatasetTemplateResource extends Resource {
   }
 
   /**
-   * A template that fails validation is a completed result rather than a failed request: it answers
-   * 200 with {@code valid: false} and the errors the producer has to fix. Only the request itself
-   * being unusable — no file, more than one, or one too large to read — is a failure.
+   * A template that fails validation is a completed result rather than a failed request. Only an
+   * unusable request — no file, more than one, or one too large to read — is a failure.
    */
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -73,9 +72,8 @@ public class StudyDatasetTemplateResource extends Resource {
     if (parts.size() > 1) {
       throw new BadRequestException("Only one template file may be uploaded at a time");
     }
-    FormDataBodyPart part = parts.getFirst();
-    validateFileDetails(part.getContentDisposition());
-    try (InputStream content = part.getValueAs(InputStream.class)) {
+    // The name is never used, so there is no stored name for a traversal check to protect.
+    try (InputStream content = parts.getFirst().getValueAs(InputStream.class)) {
       return content.readNBytes(StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1);
     }
   }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -16,8 +16,9 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
+import org.broadinstitute.consent.http.filters.TemplateSizeLimited;
+import org.broadinstitute.consent.http.mappers.TemplateTooLargeExceptionMapper;
 import org.broadinstitute.consent.http.models.DuosUser;
-import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.dto.registration.template.StudyDatasetDraftReference;
 import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
 import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
@@ -50,9 +51,11 @@ public class StudyDatasetTemplateResource extends Resource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/template-validation")
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @TemplateSizeLimited
   @Timed
   public Response validateTemplate(@Auth DuosUser duosUser, FormDataMultiPart multipart) {
-    // Streamed rather than buffered here: the size limit has one owner, the validator.
+    // Streamed rather than buffered here: the validator owns the limit on the file, and the
+    // request it arrived in was bounded before this was called.
     try (InputStream template = templatePart(multipart)) {
       TemplateValidationResponse response =
           templateService.validateAndCreateDraft(template, duosUser.getUser());
@@ -60,7 +63,7 @@ public class StudyDatasetTemplateResource extends Resource {
           ? Response.created(draftUri(response.draft())).entity(response).build()
           : Response.ok().entity(response).build();
     } catch (TemplateTooLargeException e) {
-      return tooLarge(e);
+      return TemplateTooLargeExceptionMapper.tooLarge(e.getMessage());
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
@@ -82,12 +85,5 @@ public class StudyDatasetTemplateResource extends Resource {
   /** The path DraftResource creates a draft at, so the two agree on where this one lives. */
   private static URI draftUri(StudyDatasetDraftReference draft) {
     return UriBuilder.fromPath("/api/draft/v1/%s".formatted(draft.id())).build();
-  }
-
-  private static Response tooLarge(TemplateTooLargeException e) {
-    return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
-        .type(MediaType.APPLICATION_JSON)
-        .entity(new Error(e.getMessage(), Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()))
-        .build();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -11,15 +11,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
-import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
 import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
-import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 
@@ -50,22 +47,19 @@ public class StudyDatasetTemplateResource extends Resource {
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
   @Timed
   public Response validateTemplate(@Auth DuosUser duosUser, FormDataMultiPart multipart) {
-    try {
-      byte[] template = readTemplate(multipart);
-      if (template.length > StudyTemplateValidationService.MAX_TEMPLATE_BYTES) {
-        return tooLarge();
-      }
-      TemplateValidationResponse response =
-          templateService.validateAndCreateDraft(
-              new ByteArrayInputStream(template), duosUser.getUser());
-      return Response.ok().entity(response).build();
+    // Streamed rather than buffered here: the size limit has one owner, the validator.
+    try (InputStream template = templatePart(multipart)) {
+      return Response.ok()
+          .entity(templateService.validateAndCreateDraft(template, duosUser.getUser()))
+          .build();
+    } catch (TemplateTooLargeException e) {
+      return tooLarge(e);
     } catch (Exception e) {
       return createExceptionResponse(e);
     }
   }
 
-  /** Reads one byte beyond the limit, which is all it takes to know the file exceeds it. */
-  private byte[] readTemplate(FormDataMultiPart multipart) throws IOException {
+  private InputStream templatePart(FormDataMultiPart multipart) {
     List<FormDataBodyPart> parts = multipart == null ? List.of() : multipart.getFields(FILE_PART);
     if (parts == null || parts.isEmpty()) {
       throw new BadRequestException(
@@ -75,18 +69,13 @@ public class StudyDatasetTemplateResource extends Resource {
       throw new BadRequestException("Only one template file may be uploaded at a time");
     }
     // The name is never used, so there is no stored name for a traversal check to protect.
-    try (InputStream content = parts.getFirst().getValueAs(InputStream.class)) {
-      return content.readNBytes(StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1);
-    }
+    return parts.getFirst().getValueAs(InputStream.class);
   }
 
-  private static Response tooLarge() {
+  private static Response tooLarge(TemplateTooLargeException e) {
     return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
         .type(MediaType.APPLICATION_JSON)
-        .entity(
-            new Error(
-                StudyTemplateValidationService.TOO_LARGE_MESSAGE,
-                Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()))
+        .entity(new Error(e.getMessage(), Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()))
         .build();
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -82,8 +82,11 @@ public class StudyDatasetTemplateResource extends Resource {
     return parts.getFirst().getValueAs(InputStream.class);
   }
 
-  /** The path DraftResource creates a draft at, so the two agree on where this one lives. */
+  /** Built from DraftResource's own annotations, so a path change there cannot strand this one. */
   private static URI draftUri(StudyDatasetDraftReference draft) {
-    return UriBuilder.fromPath("/api/draft/v1/%s".formatted(draft.id())).build();
+    return UriBuilder.fromPath("/")
+        .path(DraftResource.class)
+        .path(DraftResource.class, "getDraftDocument")
+        .build(draft.id());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -11,11 +11,15 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.List;
 import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.models.dto.registration.template.StudyDatasetDraftReference;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
 import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -37,8 +41,9 @@ public class StudyDatasetTemplateResource extends Resource {
   }
 
   /**
-   * A template that fails validation is a completed result rather than a failed request. Only an
-   * unusable request — no file, more than one, or one too large to read — is a failure.
+   * A template that fails validation is a completed result rather than a failed request, answered
+   * 200 with the errors to fix; a valid one is a 201 at the draft it created. Only an unusable
+   * request — no file, more than one, or one too large to read — is a failure.
    */
   @POST
   @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -49,9 +54,11 @@ public class StudyDatasetTemplateResource extends Resource {
   public Response validateTemplate(@Auth DuosUser duosUser, FormDataMultiPart multipart) {
     // Streamed rather than buffered here: the size limit has one owner, the validator.
     try (InputStream template = templatePart(multipart)) {
-      return Response.ok()
-          .entity(templateService.validateAndCreateDraft(template, duosUser.getUser()))
-          .build();
+      TemplateValidationResponse response =
+          templateService.validateAndCreateDraft(template, duosUser.getUser());
+      return response.valid()
+          ? Response.created(draftUri(response.draft())).entity(response).build()
+          : Response.ok().entity(response).build();
     } catch (TemplateTooLargeException e) {
       return tooLarge(e);
     } catch (Exception e) {
@@ -70,6 +77,11 @@ public class StudyDatasetTemplateResource extends Resource {
     }
     // The name is never used, so there is no stored name for a traversal check to protect.
     return parts.getFirst().getValueAs(InputStream.class);
+  }
+
+  /** The path DraftResource creates a draft at, so the two agree on where this one lives. */
+  private static URI draftUri(StudyDatasetDraftReference draft) {
+    return UriBuilder.fromPath("/api/draft/v1/%s".formatted(draft.id())).build();
   }
 
   private static Response tooLarge(TemplateTooLargeException e) {

--- a/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResource.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import io.dropwizard.auth.Auth;
 import jakarta.annotation.security.RolesAllowed;
@@ -47,6 +48,7 @@ public class StudyDatasetTemplateResource extends Resource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/template-validation")
   @RolesAllowed({ADMIN, CHAIRPERSON, DATASUBMITTER})
+  @Timed
   public Response validateTemplate(@Auth DuosUser duosUser, FormDataMultiPart multipart) {
     try {
       byte[] template = readTemplate(multipart);

--- a/src/main/java/org/broadinstitute/consent/http/service/DraftService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DraftService.java
@@ -59,8 +59,8 @@ public class DraftService implements ConsentLogger {
   public StreamingOutput draftAsJson(DraftInterface draft) {
     Gson gson = GsonUtil.buildGson();
     JsonObject meta = gson.toJsonTree(draft).getAsJsonObject();
-    // Taken from the draft rather than left to whatever its class happens to serialize, so every
-    // draft type names itself and no client has to infer one from the UUID or the route.
+    // Taken from the draft rather than from whatever its class serializes, so every type reports
+    // itself and no client has to infer one from the UUID or the route.
     meta.addProperty("draftType", draft.getType().getValue());
     return output -> {
       output.write("{ \"document\":".getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/org/broadinstitute/consent/http/service/DraftService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DraftService.java
@@ -1,10 +1,12 @@
 package org.broadinstitute.consent.http.service;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -56,12 +58,16 @@ public class DraftService implements ConsentLogger {
 
   public StreamingOutput draftAsJson(DraftInterface draft) {
     Gson gson = GsonUtil.buildGson();
+    JsonObject meta = gson.toJsonTree(draft).getAsJsonObject();
+    // Taken from the draft rather than left to whatever its class happens to serialize, so every
+    // draft type names itself and no client has to infer one from the UUID or the route.
+    meta.addProperty("draftType", draft.getType().getValue());
     return output -> {
-      output.write("{ \"document\":".getBytes());
-      output.write(draft.getJson().getBytes());
-      output.write(", \"meta\":".getBytes());
-      output.write(gson.toJson(draft).getBytes());
-      output.write("}".getBytes());
+      output.write("{ \"document\":".getBytes(StandardCharsets.UTF_8));
+      output.write(draft.getJson().getBytes(StandardCharsets.UTF_8));
+      output.write(", \"meta\":".getBytes(StandardCharsets.UTF_8));
+      output.write(gson.toJson(meta).getBytes(StandardCharsets.UTF_8));
+      output.write("}".getBytes(StandardCharsets.UTF_8));
     };
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAO.java
@@ -15,6 +15,7 @@ import org.broadinstitute.consent.http.enumeration.UserRoles;
 import org.broadinstitute.consent.http.models.DraftInterface;
 import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.util.NulCharacters;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.jdbi.v3.core.Jdbi;
 
@@ -37,10 +38,10 @@ public class DraftServiceDAO {
           handle.getConnection().setAutoCommit(false);
           try {
             draftDAO.insert(
-                draft.getName(),
+                NulCharacters.stripFrom(draft.getName()),
                 draft.getCreateDate().toInstant(),
                 draft.getCreateUser().getUserId(),
-                draft.getJson(),
+                NulCharacters.stripFromJsonText(draft.getJson()),
                 draft.getUUID(),
                 draft.getType().getValue());
           } catch (Exception e) {
@@ -60,10 +61,10 @@ public class DraftServiceDAO {
           handle.getConnection().setAutoCommit(false);
           try {
             draftDAO.updateDraftByDraftUUID(
-                draft.getName(),
+                NulCharacters.stripFrom(draft.getName()),
                 draft.getUpdateDate().toInstant(),
                 draft.getUpdateUser().getUserId(),
-                draft.getJson(),
+                NulCharacters.stripFromJsonText(draft.getJson()),
                 draft.getUUID(),
                 draft.getType().getValue());
           } catch (Exception e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAO.java
@@ -33,15 +33,16 @@ public class DraftServiceDAO {
   }
 
   public void insertDraft(DraftInterface draft) throws SQLException, BadRequestException {
+    strip(draft);
     jdbi.useHandle(
         handle -> {
           handle.getConnection().setAutoCommit(false);
           try {
             draftDAO.insert(
-                NulCharacters.stripFrom(draft.getName()),
+                draft.getName(),
                 draft.getCreateDate().toInstant(),
                 draft.getCreateUser().getUserId(),
-                NulCharacters.stripFromJsonText(draft.getJson()),
+                draft.getJson(),
                 draft.getUUID(),
                 draft.getType().getValue());
           } catch (Exception e) {
@@ -56,15 +57,16 @@ public class DraftServiceDAO {
   public DraftInterface updateDraft(DraftInterface draft, User user) throws SQLException {
     draft.setUpdateUser(user);
     draft.setUpdateDate(new Date());
+    strip(draft);
     jdbi.useHandle(
         handle -> {
           handle.getConnection().setAutoCommit(false);
           try {
             draftDAO.updateDraftByDraftUUID(
-                NulCharacters.stripFrom(draft.getName()),
+                draft.getName(),
                 draft.getUpdateDate().toInstant(),
                 draft.getUpdateUser().getUserId(),
-                NulCharacters.stripFromJsonText(draft.getJson()),
+                draft.getJson(),
                 draft.getUUID(),
                 draft.getType().getValue());
           } catch (Exception e) {
@@ -75,6 +77,12 @@ public class DraftServiceDAO {
           handle.commit();
         });
     return getAuthorizedDraft(draft.getUUID(), user);
+  }
+
+  /** Drops what Postgres will not store, so the draft a caller holds matches the row written. */
+  private static void strip(DraftInterface draft) {
+    draft.setName(NulCharacters.stripFrom(draft.getName()));
+    draft.setJson(NulCharacters.stripFromJsonText(draft.getJson()));
   }
 
   public DraftInterface getAuthorizedDraft(UUID draftUUID, User user)

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
@@ -40,8 +40,7 @@ public class StudyDatasetTemplateService {
       return TemplateValidationResponse.invalid(result.errors(), result.truncated());
     }
 
-    // The injected mapper is the one the registration endpoint reads with, so the document the user
-    // edits there is the one validated here.
+    // The injected mapper is the registration endpoint's, so the user edits what was validated.
     DraftInterface draft =
         new DraftStudyDataset(objectMapper.writeValueAsString(result.registration()), user);
     draftService.insertDraft(draft);

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
@@ -38,7 +38,7 @@ public class StudyDatasetTemplateService {
     }
 
     // Serialized with the mapper the registration endpoint reads, so the document the user edits
-    // and submits is the one this validated.
+    // there is the one validated here.
     DraftInterface draft =
         new DraftStudyDataset(objectMapper.writeValueAsString(result.registration()), user);
     draftService.insertDraft(draft);

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
@@ -21,13 +21,16 @@ public class StudyDatasetTemplateService {
 
   private final StudyTemplateValidationService validationService;
   private final DraftService draftService;
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
 
   @Inject
   public StudyDatasetTemplateService(
-      StudyTemplateValidationService validationService, DraftService draftService) {
+      StudyTemplateValidationService validationService,
+      DraftService draftService,
+      ObjectMapper objectMapper) {
     this.validationService = validationService;
     this.draftService = draftService;
+    this.objectMapper = objectMapper;
   }
 
   public TemplateValidationResponse validateAndCreateDraft(InputStream content, User user)
@@ -37,8 +40,8 @@ public class StudyDatasetTemplateService {
       return TemplateValidationResponse.invalid(result.errors(), result.truncated());
     }
 
-    // Serialized with the mapper the registration endpoint reads, so the document the user edits
-    // there is the one validated here.
+    // The injected mapper is the one the registration endpoint reads with, so the document the user
+    // edits there is the one validated here.
     DraftInterface draft =
         new DraftStudyDataset(objectMapper.writeValueAsString(result.registration()), user);
     draftService.insertDraft(draft);

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateService.java
@@ -1,0 +1,48 @@
+package org.broadinstitute.consent.http.service.studytemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import java.io.InputStream;
+import java.sql.SQLException;
+import org.broadinstitute.consent.http.models.DraftInterface;
+import org.broadinstitute.consent.http.models.DraftStudyDataset;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dto.registration.template.StudyDatasetDraftReference;
+import org.broadinstitute.consent.http.models.dto.registration.template.StudyTemplateValidationResult;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
+import org.broadinstitute.consent.http.service.DraftService;
+
+/**
+ * Turns an uploaded study template into a draft. Validation owns whether the template is usable;
+ * this only decides what happens next, so an invalid template reaches no database write at all.
+ */
+public class StudyDatasetTemplateService {
+
+  private final StudyTemplateValidationService validationService;
+  private final DraftService draftService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Inject
+  public StudyDatasetTemplateService(
+      StudyTemplateValidationService validationService, DraftService draftService) {
+    this.validationService = validationService;
+    this.draftService = draftService;
+  }
+
+  public TemplateValidationResponse validateAndCreateDraft(InputStream content, User user)
+      throws SQLException, JsonProcessingException {
+    StudyTemplateValidationResult result = validationService.validate(content);
+    if (!result.valid()) {
+      return TemplateValidationResponse.invalid(result.errors(), result.truncated());
+    }
+
+    // Serialized with the mapper the registration endpoint reads, so the document the user edits
+    // and submits is the one this validated.
+    DraftInterface draft =
+        new DraftStudyDataset(objectMapper.writeValueAsString(result.registration()), user);
+    draftService.insertDraft(draft);
+    return TemplateValidationResponse.valid(
+        new StudyDatasetDraftReference(draft.getUUID().toString(), draft.getType().getValue()));
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationService.java
@@ -35,7 +35,11 @@ import org.broadinstitute.consent.http.models.dto.registration.template.Template
  */
 public class StudyTemplateValidationService {
 
-  static final int MAX_TEMPLATE_BYTES = 5 * 1024 * 1024;
+  public static final int MAX_TEMPLATE_BYTES = 5 * 1024 * 1024;
+
+  /** Shared with the resource, which rejects an oversized upload before this service reads it. */
+  public static final String TOO_LARGE_MESSAGE = "Template file must be no larger than 5 MiB";
+
   static final int MAX_ERRORS = 100;
 
   /**
@@ -112,7 +116,7 @@ public class StudyTemplateValidationService {
       return null;
     }
     if (bytes.length > MAX_TEMPLATE_BYTES) {
-      errors.message("Template file must be no larger than 5 MiB");
+      errors.message(TOO_LARGE_MESSAGE);
       return null;
     }
     String csv;

--- a/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
 import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequest;
 import org.broadinstitute.consent.http.models.dto.registration.template.StudyTemplateValidationResult;
 import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationError;
@@ -37,7 +38,7 @@ public class StudyTemplateValidationService {
 
   public static final int MAX_TEMPLATE_BYTES = 5 * 1024 * 1024;
 
-  /** Shared with the resource, which rejects an oversized upload before this service reads it. */
+  /** The limit is enforced here alone; the resource turns this into a 413. */
   public static final String TOO_LARGE_MESSAGE = "Template file must be no larger than 5 MiB";
 
   static final int MAX_ERRORS = 100;
@@ -106,7 +107,10 @@ public class StudyTemplateValidationService {
     return errors.isEmpty() ? StudyTemplateValidationResult.valid(registration) : failed(errors);
   }
 
-  /** Returns the template text with any leading BOM removed, or {@code null} when unusable. */
+  /**
+   * Returns the template text with any leading BOM removed, or {@code null} when unusable. Reads
+   * one byte beyond the limit, which is all it takes to know the file exceeds it.
+   */
   private static String readTemplate(InputStream content, TemplateErrors errors) {
     byte[] bytes;
     try {
@@ -116,8 +120,7 @@ public class StudyTemplateValidationService {
       return null;
     }
     if (bytes.length > MAX_TEMPLATE_BYTES) {
-      errors.message(TOO_LARGE_MESSAGE);
-      return null;
+      throw new TemplateTooLargeException(TOO_LARGE_MESSAGE);
     }
     String csv;
     try {

--- a/src/main/java/org/broadinstitute/consent/http/util/NulCharacters.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/NulCharacters.java
@@ -35,27 +35,40 @@ public final class NulCharacters {
     int index = 0;
     while (index < json.length()) {
       char character = json.charAt(index);
-      if (character != '\\') {
-        if (character != '\0') {
-          stripped.append(character);
-        }
-        index++;
-        continue;
-      }
-      int runStart = index;
-      while (index < json.length() && json.charAt(index) == '\\') {
-        index++;
-      }
-      int run = index - runStart;
-      stripped.repeat('\\', run - run % 2);
-      if (run % 2 == 1) {
-        if (json.startsWith(ESCAPE_BODY, index)) {
-          index += ESCAPE_BODY.length();
-        } else {
-          stripped.append('\\');
-        }
-      }
+      index =
+          character == '\\'
+              ? appendBackslashRun(json, index, stripped)
+              : appendPlainCharacter(character, index, stripped);
     }
     return stripped.toString();
+  }
+
+  /**
+   * Appends what a run of backslashes keeps and returns where it left off. An even run is escaped
+   * backslashes and nothing more; the odd one out escapes whatever follows, so it goes only when
+   * what follows is the escape.
+   */
+  private static int appendBackslashRun(String json, int start, StringBuilder stripped) {
+    int index = start;
+    while (index < json.length() && json.charAt(index) == '\\') {
+      index++;
+    }
+    int run = index - start;
+    stripped.repeat('\\', run - run % 2);
+    if (run % 2 == 0) {
+      return index;
+    }
+    if (json.startsWith(ESCAPE_BODY, index)) {
+      return index + ESCAPE_BODY.length();
+    }
+    stripped.append('\\');
+    return index;
+  }
+
+  private static int appendPlainCharacter(char character, int index, StringBuilder stripped) {
+    if (character != '\0') {
+      stripped.append(character);
+    }
+    return index + 1;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/util/NulCharacters.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/NulCharacters.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.consent.http.util;
+
+/**
+ * Removes the one character Postgres will not store. A {@code text} column rejects U+0000 outright
+ * and a {@code jsonb} value rejects the six-character escape that denotes it, so both are dropped
+ * here, in Java, before a value is bound: a SQL substitution cannot tell a real escape from the
+ * literal text of one, and it never sees the values bound alongside the document.
+ */
+public final class NulCharacters {
+
+  /** What follows the backslash that escapes a U+0000 in a JSON document. */
+  private static final String ESCAPE_BODY = "u0000";
+
+  private NulCharacters() {}
+
+  /** Drops every U+0000 from a plain value, such as the name a draft is listed under. */
+  public static String stripFrom(String text) {
+    if (text == null || text.indexOf('\0') < 0) {
+      return text;
+    }
+    return text.replace("\0", "");
+  }
+
+  /**
+   * Drops both forms a U+0000 takes in a JSON document: the escape that denotes it, and the
+   * character itself should one arrive raw. The parity of a backslash run decides whether its last
+   * backslash escapes what follows or is escaped text in its own right, so each run is measured
+   * rather than peeked at, and an escaped backslash before the escape keeps both of its own.
+   */
+  public static String stripFromJsonText(String json) {
+    if (json == null || (json.indexOf('\0') < 0 && !json.contains("\\" + ESCAPE_BODY))) {
+      return json;
+    }
+    StringBuilder stripped = new StringBuilder(json.length());
+    int index = 0;
+    while (index < json.length()) {
+      char character = json.charAt(index);
+      if (character != '\\') {
+        if (character != '\0') {
+          stripped.append(character);
+        }
+        index++;
+        continue;
+      }
+      int runStart = index;
+      while (index < json.length() && json.charAt(index) == '\\') {
+        index++;
+      }
+      int run = index - runStart;
+      stripped.repeat('\\', run - run % 2);
+      if (run % 2 == 1) {
+        if (json.startsWith(ESCAPE_BODY, index)) {
+          index += ESCAPE_BODY.length();
+        } else {
+          stripped.append('\\');
+        }
+      }
+    }
+    return stripped.toString();
+  }
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -631,6 +631,8 @@ paths:
     $ref: './paths/documentFileById.yaml'
   /api/draft/v1:
     $ref: './paths/draftIndex.yaml'
+  /api/draft/v1/study-dataset/template-validation:
+    $ref: './paths/draftStudyDatasetTemplateValidation.yaml'
   /api/draft/v1/{draftUUID}:
     $ref: './paths/draftDocumentIndex.yaml'
   /api/draft/v1/{draftUUID}/attachments:

--- a/src/main/resources/assets/paths/draftIndex.yaml
+++ b/src/main/resources/assets/paths/draftIndex.yaml
@@ -38,7 +38,7 @@ post:
     - Draft
   responses:
     201:
-      description: Successfully created draft instance
+      description: Successfully created draft instance.  The body is the document as stored, less any U+0000 it carried.
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
+++ b/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
@@ -1,0 +1,71 @@
+post:
+  summary: Validate a study/dataset template
+  operationId: apiDraftV1StudyDatasetTemplateValidationPost
+  description: >-
+    Validates one filled-in v1 study template and, when it is valid, creates a
+    StudyDatasetSubmissionV1 draft owned by the caller holding the registration-shaped document.
+    An invalid template creates nothing and is reported as a completed result with HTTP 200 and
+    valid false, including an empty file, one that is not UTF-8, and one that is not valid CSV.
+    Only an unusable request fails: no file part, more than one, or a file over the 5 MiB limit.
+  tags:
+    - Draft
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            file:
+              description: The filled-in template, a UTF-8 CSV of no more than 5 MiB.
+              type: string
+              contentMediaType: text/csv
+          required:
+            - file
+  responses:
+    200:
+      description: The template was validated. A valid one carries the draft it created.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/TemplateValidationResponse.yaml'
+          examples:
+            valid:
+              summary: A valid template
+              value:
+                valid: true
+                errors: []
+                truncated: false
+                draft:
+                  id: c2e4583a-20b9-4705-8280-e6a5753f10c9
+                  draftType: StudyDatasetSubmissionV1
+            invalid:
+              summary: A template with errors
+              value:
+                valid: false
+                truncated: false
+                errors:
+                  - row: 3
+                    column: value
+                    message: Study Name is required
+                  - message: At least one Dataset is required
+    400:
+      description: No file part was supplied, or more than one was.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    401:
+      description: User not authorized to validate a template
+    413:
+      description: The file is larger than the 5 MiB template limit.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'

--- a/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
+++ b/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
@@ -50,7 +50,9 @@ post:
                     message: Study Name is required
                   - message: At least one Dataset is required
     400:
-      description: No file part was supplied, or more than one was.
+      description: >-
+        No file part was supplied, more than one was, or the draft the template produced could not
+        be written.
       content:
         application/json:
           schema:
@@ -65,6 +67,12 @@ post:
             $ref: '../schemas/ErrorResponse.yaml'
     429:
       description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: The template could not be validated.
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
+++ b/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
@@ -75,7 +75,9 @@ post:
     401:
       description: User not authorized to validate a template
     413:
-      description: The file is larger than the 5 MiB template limit.
+      description: >-
+        The file is larger than the 5 MiB template limit, or the request declares more
+        than the limit plus its multipart envelope and is refused before the body is read.
       content:
         application/json:
           schema:

--- a/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
+++ b/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
@@ -3,10 +3,11 @@ post:
   operationId: apiDraftV1StudyDatasetTemplateValidationPost
   description: >-
     Validates one filled-in v1 study template and, when it is valid, creates a
-    StudyDatasetSubmissionV1 draft owned by the caller holding the registration-shaped document.
-    An invalid template creates nothing and is reported as a completed result with HTTP 200 and
-    valid false, including an empty file, one that is not UTF-8, and one that is not valid CSV.
-    Only an unusable request fails: no file part, more than one, or a file over the 5 MiB limit.
+    StudyDatasetSubmissionV1 draft owned by the caller holding the registration-shaped document,
+    answered 201 at the draft it created. An invalid template creates nothing and is reported as a
+    completed result with HTTP 200 and valid false, including an empty file, one that is not UTF-8,
+    and one that is not valid CSV. Only an unusable request fails: no file part, more than one, or a
+    file over the 5 MiB limit.
   tags:
     - Draft
   requestBody:
@@ -24,7 +25,31 @@ post:
             - file
   responses:
     200:
-      description: The template was validated. A valid one carries the draft it created.
+      description: The template was validated and has errors to fix. Nothing was created.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/TemplateValidationResponse.yaml'
+          examples:
+            invalid:
+              summary: A template with errors
+              value:
+                valid: false
+                truncated: false
+                errors:
+                  - row: 3
+                    column: value
+                    message: Study Name is required
+                  - message: At least one Dataset is required
+    201:
+      description: The template was valid and the draft it produced was created.
+      headers:
+        Location:
+          description: The created draft, at the path the draft endpoints serve it from.
+          schema:
+            type: string
+            format: uri-reference
+            example: /api/draft/v1/c2e4583a-20b9-4705-8280-e6a5753f10c9
       content:
         application/json:
           schema:
@@ -39,16 +64,6 @@ post:
                 draft:
                   id: c2e4583a-20b9-4705-8280-e6a5753f10c9
                   draftType: StudyDatasetSubmissionV1
-            invalid:
-              summary: A template with errors
-              value:
-                valid: false
-                truncated: false
-                errors:
-                  - row: 3
-                    column: value
-                    message: Study Name is required
-                  - message: At least one Dataset is required
     400:
       description: >-
         No file part was supplied, more than one was, or the draft the template produced could not

--- a/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
+++ b/src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml
@@ -73,7 +73,13 @@ post:
           schema:
             $ref: '../schemas/ErrorResponse.yaml'
     401:
-      description: User not authorized to validate a template
+      description: Caller is unauthenticated.
+    403:
+      description: Caller holds no role permitted to validate a template.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
     413:
       description: >-
         The file is larger than the 5 MiB template limit, or the request declares more

--- a/src/main/resources/assets/schemas/Draft.yaml
+++ b/src/main/resources/assets/schemas/Draft.yaml
@@ -1,5 +1,12 @@
 type: object
 properties:
+  name:
+    type: string
+    description: A friendly name to describe the saved draft.
+  draftType:
+    type: string
+    enum: [StudyDatasetSubmissionV1]
+    description: The document type of the draft, which a client must use rather than inferring one from the UUID or the route that loaded it.
   storedFiles:
     type: array
     description: Uploaded files associated with the draft.

--- a/src/main/resources/assets/schemas/StudyDatasetDraftReference.yaml
+++ b/src/main/resources/assets/schemas/StudyDatasetDraftReference.yaml
@@ -1,0 +1,14 @@
+type: object
+description: The draft a valid template created.
+properties:
+  id:
+    type: string
+    format: uuid
+    description: The draft UUID, to be loaded through /api/draft/v1/{draftUUID}.
+  draftType:
+    type: string
+    enum: [StudyDatasetSubmissionV1]
+    description: The document type of the draft. A client must not infer it from the id or route.
+required:
+  - id
+  - draftType

--- a/src/main/resources/assets/schemas/TemplateValidationError.yaml
+++ b/src/main/resources/assets/schemas/TemplateValidationError.yaml
@@ -1,0 +1,17 @@
+type: object
+description: One independently actionable study-template validation error.
+properties:
+  row:
+    type: integer
+    description: >-
+      The one-based physical line the record starts on, counting the CSV header as row 1, so it
+      matches the line the producer sees in their editor. Absent when no row is at fault.
+  column:
+    type: string
+    enum: [templateVersion, recordType, recordId, parentRecordId, field, value]
+    description: The header the offending cell falls under. Absent when no single cell is at fault.
+  message:
+    type: string
+    description: What to fix. Never quotes the contents of a value cell.
+required:
+  - message

--- a/src/main/resources/assets/schemas/TemplateValidationResponse.yaml
+++ b/src/main/resources/assets/schemas/TemplateValidationResponse.yaml
@@ -1,0 +1,25 @@
+type: object
+description: >-
+  The outcome of validating one uploaded study template, discriminated by valid. A template that
+  fails validation is a completed result rather than a failed request, so it is returned with HTTP
+  200 and rendered separately from request failures.
+properties:
+  valid:
+    type: boolean
+    description: Whether the template produced a draft.
+  errors:
+    type: array
+    description: Every independently actionable error found, empty when the template is valid.
+    items:
+      $ref: './TemplateValidationError.yaml'
+  truncated:
+    type: boolean
+    description: >-
+      Whether the error cap was reached and the file has further problems beyond those reported. The
+      final error says so as well, so a client that ignores this field still tells the producer.
+  draft:
+    $ref: './StudyDatasetDraftReference.yaml'
+required:
+  - valid
+  - errors
+  - truncated

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -205,6 +205,25 @@ class DraftDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testInsertKeepsAnEscapedBackslashBeforeTheEscape() {
+    // The value is a backslash followed by the literal text u0000; stripping from the second
+    // backslash leaves JSON the cast rejects.
+    String jsonText = "{\"name\": \"Greg\\\\u0000\"}";
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);
+    draftDAO.insert(
+        draft.getName(),
+        draft.getCreateDate().toInstant(),
+        user.getUserId(),
+        jsonText,
+        draft.getUUID(),
+        draft.getType().getValue());
+
+    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
+    assertEquals(jsonText, returnedDraft.getJson());
+  }
+
+  @Test
   void testFindByUserOperations() {
     User user1 = createUser();
     User user2 = createUser();

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -160,8 +160,7 @@ class DraftDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertStripsTheUnsupportedUnicodeEscape() {
-    // The six-character escape a JSON document carries, which jsonb rejects. The character itself
-    // cannot reach a bound parameter, and the template parser rejects one before it gets here.
+    // The escape a JSON document carries; the character itself never reaches a bound parameter.
     String jsonText = "{\"name\": \"Greg\\u0000\"}";
     User user = createUser();
     DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);
@@ -181,7 +180,6 @@ class DraftDAOTest extends DAOTestHelper {
 
   @Test
   void testUpdateStripsTheUnsupportedUnicodeEscape() {
-    // A draft is meant to be edited and saved, so the update path is as exposed as the insert.
     User user = createUser();
     DraftStudyDataset draft = new DraftStudyDataset("{\"name\": \"Greg\"}", user);
     draftDAO.insert(

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.storage.BlobId;
@@ -32,6 +33,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DraftDAOTest extends DAOTestHelper {
+
+  /** What a JSON document holds where a U+0000 was; Postgres rejects it inside a jsonb value. */
+  private static final String UNSUPPORTED_UNICODE_ESCAPE = "\\u0000";
 
   @Test
   void testInsertOperation() {
@@ -152,6 +156,54 @@ class DraftDAOTest extends DAOTestHelper {
 
     returnedDraft = draftDAO.findDraftById(uuid);
     assertEquals(user2.getUserId(), returnedDraft.getUpdateUser().getUserId());
+  }
+
+  @Test
+  void testInsertStripsTheUnsupportedUnicodeEscape() {
+    // The six-character escape a JSON document carries, which jsonb rejects. The character itself
+    // cannot reach a bound parameter, and the template parser rejects one before it gets here.
+    String jsonText = "{\"name\": \"Greg\\u0000\"}";
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);
+    draftDAO.insert(
+        draft.getName(),
+        draft.getCreateDate().toInstant(),
+        user.getUserId(),
+        jsonText,
+        draft.getUUID(),
+        draft.getType().getValue());
+
+    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
+    assertFalse(Objects.isNull(returnedDraft));
+    assertFalse(returnedDraft.getJson().contains(UNSUPPORTED_UNICODE_ESCAPE));
+    assertTrue(returnedDraft.getJson().contains("Greg"));
+  }
+
+  @Test
+  void testUpdateStripsTheUnsupportedUnicodeEscape() {
+    // A draft is meant to be edited and saved, so the update path is as exposed as the insert.
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset("{\"name\": \"Greg\"}", user);
+    draftDAO.insert(
+        draft.getName(),
+        draft.getCreateDate().toInstant(),
+        user.getUserId(),
+        draft.getJson(),
+        draft.getUUID(),
+        draft.getType().getValue());
+
+    draftDAO.updateDraftByDraftUUID(
+        draft.getName(),
+        new Date().toInstant(),
+        user.getUserId(),
+        "{\"name\": \"Bob\\u0000\"}",
+        draft.getUUID(),
+        draft.getType().getValue());
+
+    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
+    assertFalse(Objects.isNull(returnedDraft));
+    assertFalse(returnedDraft.getJson().contains(UNSUPPORTED_UNICODE_ESCAPE));
+    assertTrue(returnedDraft.getJson().contains("Bob"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -206,8 +206,7 @@ class DraftDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertKeepsAnEscapedBackslashBeforeTheEscape() {
-    // The value is a backslash followed by the literal text u0000; stripping from the second
-    // backslash leaves JSON the cast rejects.
+    // Stripping from the second backslash of an escaped one leaves JSON the cast rejects.
     String jsonText = "{\"name\": \"Greg\\\\u0000\"}";
     User user = createUser();
     DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);

--- a/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DraftDAOTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.storage.BlobId;
@@ -33,9 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DraftDAOTest extends DAOTestHelper {
-
-  /** What a JSON document holds where a U+0000 was; Postgres rejects it inside a jsonb value. */
-  private static final String UNSUPPORTED_UNICODE_ESCAPE = "\\u0000";
 
   @Test
   void testInsertOperation() {
@@ -156,70 +152,6 @@ class DraftDAOTest extends DAOTestHelper {
 
     returnedDraft = draftDAO.findDraftById(uuid);
     assertEquals(user2.getUserId(), returnedDraft.getUpdateUser().getUserId());
-  }
-
-  @Test
-  void testInsertStripsTheUnsupportedUnicodeEscape() {
-    // The escape a JSON document carries; the character itself never reaches a bound parameter.
-    String jsonText = "{\"name\": \"Greg\\u0000\"}";
-    User user = createUser();
-    DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);
-    draftDAO.insert(
-        draft.getName(),
-        draft.getCreateDate().toInstant(),
-        user.getUserId(),
-        jsonText,
-        draft.getUUID(),
-        draft.getType().getValue());
-
-    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
-    assertFalse(Objects.isNull(returnedDraft));
-    assertFalse(returnedDraft.getJson().contains(UNSUPPORTED_UNICODE_ESCAPE));
-    assertTrue(returnedDraft.getJson().contains("Greg"));
-  }
-
-  @Test
-  void testUpdateStripsTheUnsupportedUnicodeEscape() {
-    User user = createUser();
-    DraftStudyDataset draft = new DraftStudyDataset("{\"name\": \"Greg\"}", user);
-    draftDAO.insert(
-        draft.getName(),
-        draft.getCreateDate().toInstant(),
-        user.getUserId(),
-        draft.getJson(),
-        draft.getUUID(),
-        draft.getType().getValue());
-
-    draftDAO.updateDraftByDraftUUID(
-        draft.getName(),
-        new Date().toInstant(),
-        user.getUserId(),
-        "{\"name\": \"Bob\\u0000\"}",
-        draft.getUUID(),
-        draft.getType().getValue());
-
-    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
-    assertFalse(Objects.isNull(returnedDraft));
-    assertFalse(returnedDraft.getJson().contains(UNSUPPORTED_UNICODE_ESCAPE));
-    assertTrue(returnedDraft.getJson().contains("Bob"));
-  }
-
-  @Test
-  void testInsertKeepsAnEscapedBackslashBeforeTheEscape() {
-    // Stripping from the second backslash of an escaped one leaves JSON the cast rejects.
-    String jsonText = "{\"name\": \"Greg\\\\u0000\"}";
-    User user = createUser();
-    DraftStudyDataset draft = new DraftStudyDataset(jsonText, user);
-    draftDAO.insert(
-        draft.getName(),
-        draft.getCreateDate().toInstant(),
-        user.getUserId(),
-        jsonText,
-        draft.getUUID(),
-        draft.getType().getValue());
-
-    DraftInterface returnedDraft = draftDAO.findDraftById(draft.getUUID());
-    assertEquals(jsonText, returnedDraft.getJson());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilterTest.java
@@ -70,22 +70,22 @@ class TemplateSizeLimitFilterTest {
   }
 
   @Test
-  void testFilterBoundsABodyThatDeclaresNoLength() throws IOException {
+  void testFilterBoundsABodyThatDeclaresNoLength() {
     // Chunked, or lying: there is no length to refuse on, so the stream itself has to stop.
     InputStream bounded =
         boundedStreamOver(new byte[(int) TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1], null);
 
     TemplateTooLargeException e =
-        assertThrows(TemplateTooLargeException.class, () -> bounded.readAllBytes());
+        assertThrows(TemplateTooLargeException.class, bounded::readAllBytes);
     assertEquals(StudyTemplateValidationService.TOO_LARGE_MESSAGE, e.getMessage());
   }
 
   @Test
-  void testFilterBoundsABodyThatUnderstatesItsLength() throws IOException {
+  void testFilterBoundsABodyThatUnderstatesItsLength() {
     InputStream bounded =
         boundedStreamOver(new byte[(int) TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1], "10");
 
-    assertThrows(TemplateTooLargeException.class, () -> bounded.readAllBytes());
+    assertThrows(TemplateTooLargeException.class, bounded::readAllBytes);
   }
 
   @Test
@@ -95,6 +95,60 @@ class TemplateSizeLimitFilterTest {
 
     assertEquals(new String(body), new String(bounded.readAllBytes()));
     assertEquals(-1, bounded.read());
+  }
+
+  @Test
+  void testFilterTreatsAHeaderItCannotReadAsNoLength() {
+    // Blank, or not a number: there is nothing to refuse on, so only the stream bound applies.
+    for (String header : new String[] {"   ", "not-a-number"}) {
+      ContainerRequestContext request = requestOfDeclaredLength(header);
+      when(request.getEntityStream()).thenReturn(InputStream.nullInputStream());
+
+      filter.filter(request);
+
+      verify(request, never()).abortWith(any());
+      verify(request).setEntityStream(any());
+    }
+  }
+
+  @Test
+  void testTheBoundedStreamCountsABodyReadOneByteAtATime() {
+    InputStream bounded = boundedStreamOver(oversizeBody(), null);
+
+    assertThrows(TemplateTooLargeException.class, () -> readEveryByte(bounded));
+  }
+
+  @Test
+  void testTheBoundedStreamCountsBytesSkippedRatherThanRead() {
+    // Skipping past the cap consumes the body just as reading it does.
+    InputStream bounded = boundedStreamOver(oversizeBody(), null);
+
+    assertThrows(
+        TemplateTooLargeException.class,
+        () -> bounded.skip(TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1));
+  }
+
+  @Test
+  void testTheBoundedStreamPassesASkipWithinTheCapThrough() throws IOException {
+    byte[] body = "1,study\n2,Greg".getBytes();
+    InputStream bounded = boundedStreamOver(body, Integer.toString(body.length));
+
+    assertEquals(2, bounded.skip(2));
+    assertEquals("study", new String(bounded.readNBytes(5)));
+
+    // Nothing left to skip, so nothing is counted against the cap.
+    bounded.readAllBytes();
+    assertEquals(0, bounded.skip(1));
+  }
+
+  private static void readEveryByte(InputStream stream) throws IOException {
+    while (stream.read() != -1) {
+      // Counted a byte at a time, which is the read the array overload does not cover.
+    }
+  }
+
+  private static byte[] oversizeBody() {
+    return new byte[(int) TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1];
   }
 
   /** The stream the filter installs over a body, read back for the assertions above. */

--- a/src/test/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilterTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/filters/TemplateSizeLimitFilterTest.java
@@ -1,0 +1,117 @@
+package org.broadinstitute.consent.http.filters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
+import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TemplateSizeLimitFilterTest {
+
+  private final TemplateSizeLimitFilter filter = new TemplateSizeLimitFilter();
+
+  @Test
+  void testFilterRefusesADeclaredLengthPastTheCap() {
+    ContainerRequestContext request =
+        requestOfDeclaredLength(Long.toString(TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1));
+
+    filter.filter(request);
+
+    ArgumentCaptor<Response> refusal = ArgumentCaptor.forClass(Response.class);
+    verify(request).abortWith(refusal.capture());
+    assertEquals(
+        Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode(), refusal.getValue().getStatus());
+    assertEquals(
+        new Error(
+            StudyTemplateValidationService.TOO_LARGE_MESSAGE,
+            Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()),
+        refusal.getValue().getEntity());
+    // Refused on the header alone: the body was never asked for, which is the point of the guard.
+    verify(request, never()).getEntityStream();
+  }
+
+  @Test
+  void testFilterRefusesALengthNoIntCouldHold() {
+    // The multi-gigabyte upload the guard exists for, whose header overflows an int parse.
+    ContainerRequestContext request = requestOfDeclaredLength("5000000000");
+
+    filter.filter(request);
+
+    verify(request).abortWith(any(Response.class));
+  }
+
+  @Test
+  void testFilterAdmitsADeclaredLengthWithinTheCap() {
+    ContainerRequestContext request =
+        requestOfDeclaredLength(Long.toString(TemplateSizeLimitFilter.MAX_REQUEST_BYTES));
+    when(request.getEntityStream()).thenReturn(InputStream.nullInputStream());
+
+    filter.filter(request);
+
+    verify(request, never()).abortWith(any());
+    verify(request).setEntityStream(any());
+  }
+
+  @Test
+  void testFilterBoundsABodyThatDeclaresNoLength() throws IOException {
+    // Chunked, or lying: there is no length to refuse on, so the stream itself has to stop.
+    InputStream bounded =
+        boundedStreamOver(new byte[(int) TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1], null);
+
+    TemplateTooLargeException e =
+        assertThrows(TemplateTooLargeException.class, () -> bounded.readAllBytes());
+    assertEquals(StudyTemplateValidationService.TOO_LARGE_MESSAGE, e.getMessage());
+  }
+
+  @Test
+  void testFilterBoundsABodyThatUnderstatesItsLength() throws IOException {
+    InputStream bounded =
+        boundedStreamOver(new byte[(int) TemplateSizeLimitFilter.MAX_REQUEST_BYTES + 1], "10");
+
+    assertThrows(TemplateTooLargeException.class, () -> bounded.readAllBytes());
+  }
+
+  @Test
+  void testTheBoundedStreamPassesABodyWithinTheCapThrough() throws IOException {
+    byte[] body = "1,study\n2,Greg".getBytes();
+    InputStream bounded = boundedStreamOver(body, Integer.toString(body.length));
+
+    assertEquals(new String(body), new String(bounded.readAllBytes()));
+    assertEquals(-1, bounded.read());
+  }
+
+  /** The stream the filter installs over a body, read back for the assertions above. */
+  private InputStream boundedStreamOver(byte[] body, String declaredLength) {
+    ContainerRequestContext request = requestOfDeclaredLength(declaredLength);
+    when(request.getEntityStream()).thenReturn(new ByteArrayInputStream(body));
+
+    filter.filter(request);
+
+    ArgumentCaptor<InputStream> installed = ArgumentCaptor.forClass(InputStream.class);
+    verify(request).setEntityStream(installed.capture());
+    return installed.getValue();
+  }
+
+  private ContainerRequestContext requestOfDeclaredLength(String declaredLength) {
+    ContainerRequestContext request = mock(ContainerRequestContext.class);
+    when(request.getHeaderString(HttpHeaders.CONTENT_LENGTH)).thenReturn(declaredLength);
+    return request;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/mappers/TemplateTooLargeExceptionMapperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/mappers/TemplateTooLargeExceptionMapperTest.java
@@ -1,0 +1,28 @@
+package org.broadinstitute.consent.http.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
+import org.broadinstitute.consent.http.models.Error;
+import org.junit.jupiter.api.Test;
+
+class TemplateTooLargeExceptionMapperTest {
+
+  private final TemplateTooLargeExceptionMapper mapper = new TemplateTooLargeExceptionMapper();
+
+  @Test
+  void testToResponseAnswersARefusalWith413() {
+    // The mapped path, which the resource's own catch never sees: a refusal raised from the
+    // bounded stream while Jersey is still reading reaches the client only through here.
+    Response response = mapper.toResponse(new TemplateTooLargeException("Template is too large"));
+
+    assertEquals(Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode(), response.getStatus());
+    assertEquals(MediaType.APPLICATION_JSON_TYPE, response.getMediaType());
+    assertEquals(
+        new Error(
+            "Template is too large", Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()),
+        response.getEntity());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
@@ -28,8 +28,7 @@ class TemplateValidationResponseExamplesTest {
     JsonNode documented =
         new YAMLMapper()
             .readTree(SPEC.toFile())
-            // requiredAt, not at: a missing pointer round-trips to JSON null through Gson, and
-            // would pass the assertion below while documenting nothing.
+            // requiredAt, not at: a missing pointer round-trips to JSON null through Gson.
             .requiredAt(
                 "/post/responses/%s/content/application~1json/examples/%s/value"
                     .formatted(status, example));

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
@@ -1,0 +1,44 @@
+package org.broadinstitute.consent.http.models.dto.registration.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The OpenAPI examples are the only hand-written copy of the wire shape, so they are read back
+ * through the response type: an example that survives a rename of a field it does not mention would
+ * document an endpoint that no longer exists.
+ */
+class TemplateValidationResponseExamplesTest {
+
+  private static final Path SPEC =
+      Path.of("src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml");
+
+  @ParameterizedTest
+  @ValueSource(strings = {"valid", "invalid"})
+  void testDocumentedExampleMatchesTheResponseModel(String example) throws IOException {
+    JsonNode documented =
+        new YAMLMapper()
+            .readTree(SPEC.toFile())
+            .at(
+                "/post/responses/200/content/application~1json/examples/%s/value"
+                    .formatted(example));
+    assertNotNull(documented);
+
+    TemplateValidationResponse parsed =
+        GsonUtil.getInstance().fromJson(documented.toString(), TemplateValidationResponse.class);
+
+    assertEquals(
+        JsonParser.parseString(documented.toString()),
+        JsonParser.parseString(GsonUtil.getInstance().toJson(parsed)),
+        example);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * The OpenAPI examples are the only hand-written copy of the wire shape, so they are read back
@@ -22,16 +22,17 @@ class TemplateValidationResponseExamplesTest {
       Path.of("src/main/resources/assets/paths/draftStudyDatasetTemplateValidation.yaml");
 
   @ParameterizedTest
-  @ValueSource(strings = {"valid", "invalid"})
-  void testDocumentedExampleMatchesTheResponseModel(String example) throws IOException {
+  @CsvSource({"201,valid", "200,invalid"})
+  void testDocumentedExampleMatchesTheResponseModel(String status, String example)
+      throws IOException {
     JsonNode documented =
         new YAMLMapper()
             .readTree(SPEC.toFile())
             // requiredAt, not at: a missing pointer round-trips to JSON null through Gson, and
             // would pass the assertion below while documenting nothing.
             .requiredAt(
-                "/post/responses/200/content/application~1json/examples/%s/value"
-                    .formatted(example));
+                "/post/responses/%s/content/application~1json/examples/%s/value"
+                    .formatted(status, example));
 
     TemplateValidationResponse parsed =
         GsonUtil.getInstance().fromJson(documented.toString(), TemplateValidationResponse.class);

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseExamplesTest.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.consent.http.models.dto.registration.template;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
@@ -28,10 +27,11 @@ class TemplateValidationResponseExamplesTest {
     JsonNode documented =
         new YAMLMapper()
             .readTree(SPEC.toFile())
-            .at(
+            // requiredAt, not at: a missing pointer round-trips to JSON null through Gson, and
+            // would pass the assertion below while documenting nothing.
+            .requiredAt(
                 "/post/responses/200/content/application~1json/examples/%s/value"
                     .formatted(example));
-    assertNotNull(documented);
 
     TemplateValidationResponse parsed =
         GsonUtil.getInstance().fromJson(documented.toString(), TemplateValidationResponse.class);

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
@@ -8,10 +8,8 @@ import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 
 /**
- * The wire shape of the validation response, serialized the way the application serializes it:
- * every JSON entity goes through {@code JerseyGsonProvider}. A client distinguishes an error with
- * no location from one at row 1 by the absence of the field, so the omissions are the contract as
- * much as the values are.
+ * The wire shape, serialized the way the application serializes it: every JSON entity goes through
+ * {@code JerseyGsonProvider}. What is omitted is as much the contract as what is present.
  */
 class TemplateValidationResponseTest {
 

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
@@ -34,6 +34,16 @@ class TemplateValidationResponseTest {
   }
 
   @Test
+  void testAResponseWithoutAnErrorListReadsAsHavingNone() {
+    // A body omitting errors deserializes with a null list, which List.copyOf would NPE on.
+    TemplateValidationResponse response =
+        GsonUtil.getInstance()
+            .fromJson("{\"valid\":true,\"truncated\":false}", TemplateValidationResponse.class);
+
+    assertEquals(List.of(), response.errors());
+  }
+
+  @Test
   void testValidResponseCarriesAnEmptyErrorListAndTheTypedDraft() {
     TemplateValidationResponse response =
         TemplateValidationResponse.valid(

--- a/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/dto/registration/template/TemplateValidationResponseTest.java
@@ -1,0 +1,53 @@
+package org.broadinstitute.consent.http.models.dto.registration.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.broadinstitute.consent.http.enumeration.DraftType;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The wire shape of the validation response, serialized the way the application serializes it:
+ * every JSON entity goes through {@code JerseyGsonProvider}. A client distinguishes an error with
+ * no location from one at row 1 by the absence of the field, so the omissions are the contract as
+ * much as the values are.
+ */
+class TemplateValidationResponseTest {
+
+  @Test
+  void testInvalidResponseOmitsTheDraftAndUnknownLocations() {
+    TemplateValidationResponse response =
+        TemplateValidationResponse.invalid(
+            List.of(
+                TemplateValidationError.at(3, "value", "Study Name is required"),
+                TemplateValidationError.at(4, "Row must have 6 columns but has 5"),
+                TemplateValidationError.of("At least one Dataset is required")),
+            true);
+
+    assertEquals(
+        """
+        {"valid":false,"errors":[\
+        {"row":3,"column":"value","message":"Study Name is required"},\
+        {"row":4,"message":"Row must have 6 columns but has 5"},\
+        {"message":"At least one Dataset is required"}],\
+        "truncated":true}""",
+        GsonUtil.getInstance().toJson(response));
+  }
+
+  @Test
+  void testValidResponseCarriesAnEmptyErrorListAndTheTypedDraft() {
+    TemplateValidationResponse response =
+        TemplateValidationResponse.valid(
+            new StudyDatasetDraftReference(
+                "c2e4583a-20b9-4705-8280-e6a5753f10c9",
+                DraftType.STUDY_DATASET_SUBMISSION_V1.getValue()));
+
+    assertEquals(
+        """
+        {"valid":true,"errors":[],"truncated":false,\
+        "draft":{"id":"c2e4583a-20b9-4705-8280-e6a5753f10c9",\
+        "draftType":"StudyDatasetSubmissionV1"}}""",
+        GsonUtil.getInstance().toJson(response));
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DatasetResourceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
@@ -108,7 +109,8 @@ class DatasetResourceTest extends AbstractTestHelper {
             datasetRegistrationService,
             elasticSearchService,
             tdrService,
-            gcsService);
+            gcsService,
+            new ObjectMapper());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -11,24 +9,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
-import jakarta.ws.rs.PATCH;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -125,25 +114,9 @@ class DraftResourceTest {
 
   @Test
   void testEveryDraftEndpointAdmitsTheSameThreeRoles() {
-    // Asserted over every endpoint rather than one at a time, so an endpoint added later cannot
-    // be left out or left unguarded. Per-draft ownership is enforced in DraftServiceDAO.
-    Set<Class<? extends Annotation>> httpMethods =
-        Set.of(GET.class, POST.class, PUT.class, PATCH.class, DELETE.class);
-    List<Method> endpoints =
-        Arrays.stream(DraftResource.class.getDeclaredMethods())
-            .filter(method -> httpMethods.stream().anyMatch(method::isAnnotationPresent))
-            .toList();
-
-    assertFalse(endpoints.isEmpty());
-    endpoints.forEach(
-        endpoint -> {
-          RolesAllowed roles = endpoint.getAnnotation(RolesAllowed.class);
-          assertNotNull(roles, endpoint.getName());
-          assertEquals(
-              Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER),
-              Set.of(roles.value()),
-              endpoint.getName());
-        });
+    // Per-draft ownership is enforced in DraftServiceDAO.
+    EndpointRoles.assertEveryEndpointAdmits(
+        DraftResource.class, Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -9,15 +11,24 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -110,6 +121,30 @@ class DraftResourceTest {
     initResource();
     Response response = resource.getDraftDocument(duosUser, UUID.randomUUID().toString());
     assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+  }
+
+  @Test
+  void testEveryDraftEndpointAdmitsTheSameThreeRoles() {
+    // Chairpersons register studies, so they get the drafts that back one. Asserted over every
+    // endpoint rather than one at a time, so an endpoint added later cannot be left out or left
+    // unguarded; per-draft ownership is enforced separately, in DraftServiceDAO.
+    Set<Class<? extends Annotation>> httpMethods =
+        Set.of(GET.class, POST.class, PUT.class, PATCH.class, DELETE.class);
+    List<Method> endpoints =
+        Arrays.stream(DraftResource.class.getDeclaredMethods())
+            .filter(method -> httpMethods.stream().anyMatch(method::isAnnotationPresent))
+            .toList();
+
+    assertFalse(endpoints.isEmpty());
+    endpoints.forEach(
+        endpoint -> {
+          RolesAllowed roles = endpoint.getAnnotation(RolesAllowed.class);
+          assertNotNull(roles, endpoint.getName());
+          assertEquals(
+              Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER),
+              Set.of(roles.value()),
+              endpoint.getName());
+        });
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
@@ -125,9 +125,8 @@ class DraftResourceTest {
 
   @Test
   void testEveryDraftEndpointAdmitsTheSameThreeRoles() {
-    // Chairpersons register studies, so they get the drafts that back one. Asserted over every
-    // endpoint rather than one at a time, so an endpoint added later cannot be left out or left
-    // unguarded; per-draft ownership is enforced separately, in DraftServiceDAO.
+    // Asserted over every endpoint rather than one at a time, so an endpoint added later cannot
+    // be left out or left unguarded. Per-draft ownership is enforced in DraftServiceDAO.
     Set<Class<? extends Annotation>> httpMethods =
         Set.of(GET.class, POST.class, PUT.class, PATCH.class, DELETE.class);
     List<Method> endpoints =

--- a/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/DraftResourceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.resources;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -90,6 +91,24 @@ class DraftResourceTest {
     Response response = resource.createDraftRegistration(duosUser, draft);
     assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
     assertEquals(draft, response.getEntity().toString());
+  }
+
+  @Test
+  void testCreateDraftRegistrationReturnsTheDocumentAsStored() throws SQLException {
+    String stored = "{\"studyName\": \"Greg\"}";
+    // In two pieces so the compiler leaves the escape as the text a document carries.
+    String posted = "{\"studyName\": \"Greg" + "\\" + "u0000\"}";
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(0, DraftInterface.class).setJson(stored);
+              return null;
+            })
+        .when(draftService)
+        .insertDraft(any());
+    initResource();
+    Response response = resource.createDraftRegistration(duosUser, posted);
+    assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    assertEquals(stored, response.getEntity().toString());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/EndpointRoles.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/EndpointRoles.java
@@ -16,10 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Shared so the set of HTTP methods scanned cannot drift between resources: a copy filtering fewer
- * of them would stop covering an endpoint added with another verb.
- */
+/** Shared so a copy filtering fewer verbs cannot quietly stop covering an endpoint. */
 final class EndpointRoles {
 
   private static final Set<Class<? extends Annotation>> HTTP_METHODS =

--- a/src/test/java/org/broadinstitute/consent/http/resources/EndpointRoles.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/EndpointRoles.java
@@ -1,0 +1,45 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Shared so the set of HTTP methods scanned cannot drift between resources: a copy filtering fewer
+ * of them would stop covering an endpoint added with another verb.
+ */
+final class EndpointRoles {
+
+  private static final Set<Class<? extends Annotation>> HTTP_METHODS =
+      Set.of(GET.class, POST.class, PUT.class, PATCH.class, DELETE.class);
+
+  private EndpointRoles() {}
+
+  /** Asserts over every endpoint, so one added later cannot be left out or left unguarded. */
+  static void assertEveryEndpointAdmits(Class<?> resource, Set<String> expectedRoles) {
+    List<Method> endpoints =
+        Arrays.stream(resource.getDeclaredMethods())
+            .filter(method -> HTTP_METHODS.stream().anyMatch(method::isAnnotationPresent))
+            .toList();
+
+    assertFalse(endpoints.isEmpty(), resource.getSimpleName());
+    endpoints.forEach(
+        endpoint -> {
+          RolesAllowed roles = endpoint.getAnnotation(RolesAllowed.class);
+          assertNotNull(roles, endpoint.getName());
+          assertEquals(expectedRoles, Set.of(roles.value()), endpoint.getName());
+        });
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -1,0 +1,169 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.DraftType;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dto.registration.template.StudyDatasetDraftReference;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
+import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
+import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyDatasetTemplateResourceTest {
+
+  @Mock private StudyDatasetTemplateService templateService;
+
+  @Mock private DuosUser duosUser;
+
+  @Mock private User user;
+
+  @Mock private FormDataMultiPart multipart;
+
+  private StudyDatasetTemplateResource resource;
+
+  private void initResource() {
+    resource = new StudyDatasetTemplateResource(templateService);
+  }
+
+  @Test
+  void testValidateTemplateReturnsTheValidationResult() throws Exception {
+    TemplateValidationResponse validated =
+        TemplateValidationResponse.valid(
+            new StudyDatasetDraftReference(
+                UUID.randomUUID().toString(), DraftType.STUDY_DATASET_SUBMISSION_V1.getValue()));
+    FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
+    when(duosUser.getUser()).thenReturn(user);
+    when(multipart.getFields("file")).thenReturn(List.of(part));
+    when(templateService.validateAndCreateDraft(any(), any())).thenReturn(validated);
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, multipart);
+
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(validated, response.getEntity());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"no multipart", "no file part", "empty file part"})
+  void testValidateTemplateRejectsAMissingFilePart(String shape) throws Exception {
+    FormDataMultiPart body = multipart;
+    switch (shape) {
+      case "no multipart" -> body = null;
+      case "no file part" -> when(multipart.getFields("file")).thenReturn(null);
+      default -> when(multipart.getFields("file")).thenReturn(List.of());
+    }
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, body);
+
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus(), shape);
+    verify(templateService, never()).validateAndCreateDraft(any(), any());
+  }
+
+  @Test
+  void testValidateTemplateRejectsMoreThanOneFilePart() throws Exception {
+    // Neither part is read: the request is unusable before their content matters.
+    when(multipart.getFields("file"))
+        .thenReturn(List.of(mock(FormDataBodyPart.class), mock(FormDataBodyPart.class)));
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, multipart);
+
+    assertEquals(HttpStatusCodes.STATUS_CODE_BAD_REQUEST, response.getStatus());
+    verify(templateService, never()).validateAndCreateDraft(any(), any());
+  }
+
+  @Test
+  void testValidateTemplateRejectsAnOversizedFile() throws Exception {
+    // A request failure rather than a validation result: the browser reports it the same way it
+    // reports its own pre-check, and the producer has no cell to fix.
+    byte[] oversized = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1];
+    FormDataBodyPart part = filePart(oversized);
+    when(multipart.getFields("file")).thenReturn(List.of(part));
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, multipart);
+
+    assertEquals(Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode(), response.getStatus());
+    assertEquals(
+        new Error(
+            StudyTemplateValidationService.TOO_LARGE_MESSAGE,
+            Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()),
+        response.getEntity());
+    verify(templateService, never()).validateAndCreateDraft(any(), any());
+  }
+
+  @Test
+  void testValidateTemplateReportsAFailedDraftWrite() throws Exception {
+    FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
+    when(duosUser.getUser()).thenReturn(user);
+    when(multipart.getFields("file")).thenReturn(List.of(part));
+    when(templateService.validateAndCreateDraft(any(), any()))
+        .thenThrow(new SQLException("insert failed"));
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, multipart);
+
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testEveryEndpointAdmitsTheRolesTheDraftEndpointsDo() {
+    List<Method> endpoints =
+        Arrays.stream(StudyDatasetTemplateResource.class.getDeclaredMethods())
+            .filter(method -> method.isAnnotationPresent(POST.class))
+            .toList();
+
+    assertFalse(endpoints.isEmpty());
+    endpoints.forEach(
+        endpoint -> {
+          RolesAllowed roles = endpoint.getAnnotation(RolesAllowed.class);
+          assertNotNull(roles, endpoint.getName());
+          assertEquals(
+              Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER),
+              Set.of(roles.value()),
+              endpoint.getName());
+        });
+  }
+
+  private static FormDataBodyPart filePart(byte[] content) {
+    FormDataBodyPart part = mock(FormDataBodyPart.class);
+    ContentDisposition disposition =
+        ContentDisposition.type("form-data").fileName("template.csv").build();
+    when(part.getContentDisposition()).thenReturn(disposition);
+    when(part.getValueAs(InputStream.class)).thenReturn(new ByteArrayInputStream(content));
+    return part;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -30,7 +30,6 @@ import org.broadinstitute.consent.http.models.dto.registration.template.StudyDat
 import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
 import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
 import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
-import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.junit.jupiter.api.Test;
@@ -107,8 +106,7 @@ class StudyDatasetTemplateResourceTest {
 
   @Test
   void testValidateTemplateRejectsAnOversizedFile() throws Exception {
-    // A request failure rather than a validation result: the browser reports it the same way it
-    // reports its own pre-check, and the producer has no cell to fix.
+    // A request failure rather than a validation result: there is no cell for the producer to fix.
     byte[] oversized = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1];
     FormDataBodyPart part = filePart(oversized);
     when(multipart.getFields("file")).thenReturn(List.of(part));
@@ -160,9 +158,6 @@ class StudyDatasetTemplateResourceTest {
 
   private static FormDataBodyPart filePart(byte[] content) {
     FormDataBodyPart part = mock(FormDataBodyPart.class);
-    ContentDisposition disposition =
-        ContentDisposition.type("form-data").fileName("template.csv").build();
-    when(part.getContentDisposition()).thenReturn(disposition);
     when(part.getValueAs(InputStream.class)).thenReturn(new ByteArrayInputStream(content));
     return part;
   }

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -23,6 +24,7 @@ import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.models.dto.registration.template.StudyDatasetDraftReference;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationError;
 import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
 import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
 import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
@@ -53,11 +55,13 @@ class StudyDatasetTemplateResourceTest {
   }
 
   @Test
-  void testValidateTemplateReturnsTheValidationResult() throws Exception {
+  void testValidateTemplateCreatesTheDraftItHandsBack() throws Exception {
+    // The location is the path DraftResource creates the same row at, so a client can follow it.
+    String draftId = UUID.randomUUID().toString();
     TemplateValidationResponse validated =
         TemplateValidationResponse.valid(
             new StudyDatasetDraftReference(
-                UUID.randomUUID().toString(), DraftType.STUDY_DATASET_SUBMISSION_V1.getValue()));
+                draftId, DraftType.STUDY_DATASET_SUBMISSION_V1.getValue()));
     FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
     when(duosUser.getUser()).thenReturn(user);
     when(multipart.getFields("file")).thenReturn(List.of(part));
@@ -66,8 +70,28 @@ class StudyDatasetTemplateResourceTest {
 
     Response response = resource.validateTemplate(duosUser, multipart);
 
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    assertEquals("/api/draft/v1/%s".formatted(draftId), response.getLocation().toString());
     assertEquals(validated, response.getEntity());
+  }
+
+  @Test
+  void testValidateTemplateReturnsAnInvalidTemplateAsACompletedResult() throws Exception {
+    // Nothing was created, so there is nothing to point at: the errors are the result.
+    TemplateValidationResponse invalid =
+        TemplateValidationResponse.invalid(
+            List.of(TemplateValidationError.of("Study Name is required")), false);
+    FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
+    when(duosUser.getUser()).thenReturn(user);
+    when(multipart.getFields("file")).thenReturn(List.of(part));
+    when(templateService.validateAndCreateDraft(any(), any())).thenReturn(invalid);
+    initResource();
+
+    Response response = resource.validateTemplate(duosUser, multipart);
+
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertNull(response.getLocation());
+    assertEquals(invalid, response.getEntity());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -135,6 +136,20 @@ class StudyDatasetTemplateResourceTest {
     Response response = resource.validateTemplate(duosUser, multipart);
 
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testTemplateValidationKeepsTheTypedPathItsClientCallsAgainst() throws NoSuchMethodException {
+    // duos-ui calls this URL literally, so a rename would compile, pass, and 404 the page.
+    assertEquals(
+        "api/draft/v1/study-dataset",
+        StudyDatasetTemplateResource.class.getAnnotation(Path.class).value());
+    assertEquals(
+        "/template-validation",
+        StudyDatasetTemplateResource.class
+            .getDeclaredMethod("validateTemplate", DuosUser.class, FormDataMultiPart.class)
+            .getAnnotation(Path.class)
+            .value());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -1,8 +1,6 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -10,20 +8,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.enumeration.DraftType;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
 import org.broadinstitute.consent.http.models.DuosUser;
 import org.broadinstitute.consent.http.models.Error;
 import org.broadinstitute.consent.http.models.User;
@@ -106,11 +101,13 @@ class StudyDatasetTemplateResourceTest {
   }
 
   @Test
-  void testValidateTemplateRejectsAnOversizedFile() throws Exception {
-    // A request failure rather than a validation result: there is no cell for the producer to fix.
-    byte[] oversized = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1];
-    FormDataBodyPart part = filePart(oversized);
+  void testValidateTemplateReportsAnOversizedFileAsTooLarge() throws Exception {
+    // The validator owns the limit; this pins that its refusal reaches the client as a 413.
+    FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
+    when(duosUser.getUser()).thenReturn(user);
     when(multipart.getFields("file")).thenReturn(List.of(part));
+    when(templateService.validateAndCreateDraft(any(), any()))
+        .thenThrow(new TemplateTooLargeException(StudyTemplateValidationService.TOO_LARGE_MESSAGE));
     initResource();
 
     Response response = resource.validateTemplate(duosUser, multipart);
@@ -121,7 +118,6 @@ class StudyDatasetTemplateResourceTest {
             StudyTemplateValidationService.TOO_LARGE_MESSAGE,
             Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()),
         response.getEntity());
-    verify(templateService, never()).validateAndCreateDraft(any(), any());
   }
 
   @Test
@@ -154,21 +150,9 @@ class StudyDatasetTemplateResourceTest {
 
   @Test
   void testEveryEndpointAdmitsTheRolesTheDraftEndpointsDo() {
-    List<Method> endpoints =
-        Arrays.stream(StudyDatasetTemplateResource.class.getDeclaredMethods())
-            .filter(method -> method.isAnnotationPresent(POST.class))
-            .toList();
-
-    assertFalse(endpoints.isEmpty());
-    endpoints.forEach(
-        endpoint -> {
-          RolesAllowed roles = endpoint.getAnnotation(RolesAllowed.class);
-          assertNotNull(roles, endpoint.getName());
-          assertEquals(
-              Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER),
-              Set.of(roles.value()),
-              endpoint.getName());
-        });
+    EndpointRoles.assertEveryEndpointAdmits(
+        StudyDatasetTemplateResource.class,
+        Set.of(Resource.ADMIN, Resource.CHAIRPERSON, Resource.DATASUBMITTER));
   }
 
   private static FormDataBodyPart filePart(byte[] content) {

--- a/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/StudyDatasetTemplateResourceTest.java
@@ -126,7 +126,8 @@ class StudyDatasetTemplateResourceTest {
 
   @Test
   void testValidateTemplateReportsAnOversizedFileAsTooLarge() throws Exception {
-    // The validator owns the limit; this pins that its refusal reaches the client as a 413.
+    // The validator owns the limit on the file; this pins that its refusal reaches the client
+    // as a 413, as the request guard's refusal does.
     FormDataBodyPart part = filePart("1,study".getBytes(StandardCharsets.UTF_8));
     when(duosUser.getUser()).thenReturn(user);
     when(multipart.getFields("file")).thenReturn(List.of(part));

--- a/src/test/java/org/broadinstitute/consent/http/resources/TemplateSizeLimitEndpointTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/TemplateSizeLimitEndpointTest.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.dropwizard.auth.AuthValueFactoryProvider;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import org.broadinstitute.consent.http.filters.TemplateSizeLimitFilter;
+import org.broadinstitute.consent.http.mappers.TemplateTooLargeExceptionMapper;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Error;
+import org.broadinstitute.consent.http.service.studytemplate.StudyDatasetTemplateService;
+import org.broadinstitute.consent.http.service.studytemplate.StudyTemplateValidationService;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Pins the size limit to the endpoint through a request Jersey routes itself. The filter is
+ * name-bound rather than called by the resource, and a binding that does not take effect fails
+ * silently -- a unit test on the filter cannot tell that apart from one that works.
+ */
+@ExtendWith(DropwizardExtensionsSupport.class)
+class TemplateSizeLimitEndpointTest {
+
+  private static final String PATH = "/api/draft/v1/study-dataset/template-validation";
+
+  /** Past the cap, and past an int, as the header of a multi-gigabyte upload would be. */
+  private static final String OVERSIZE_LENGTH = "5000000000";
+
+  private static final StudyDatasetTemplateService TEMPLATE_SERVICE =
+      mock(StudyDatasetTemplateService.class);
+
+  private static final ResourceExtension RESOURCE =
+      ResourceExtension.builder()
+          .addResource(new StudyDatasetTemplateResource(TEMPLATE_SERVICE))
+          .addProvider(TemplateSizeLimitFilter.class)
+          .addProvider(TemplateTooLargeExceptionMapper.class)
+          .addProvider(MultiPartFeature.class)
+          .addProvider(new AuthValueFactoryProvider.Binder<>(DuosUser.class))
+          .build();
+
+  @Test
+  void testAnUploadDeclaringMoreThanTheCapIsRefusedOnItsHeaderAlone() throws IOException {
+    Response response = post(OVERSIZE_LENGTH);
+
+    assertEquals(Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode(), response.getStatus());
+    assertEquals(
+        new Error(
+            StudyTemplateValidationService.TOO_LARGE_MESSAGE,
+            Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode()),
+        response.readEntity(Error.class));
+    // Nothing downstream ran: not the authentication the endpoint requires, not the service.
+    verifyNoInteractions(TEMPLATE_SERVICE);
+  }
+
+  @Test
+  void testAnUploadWithinTheCapIsNotRefusedByTheGuard() throws IOException {
+    // Nothing authenticates this request, so it fails further along; what this pins is that the
+    // guard let it through rather than refusing every upload that declares a length.
+    Response response = post("64");
+
+    assertNotEquals(Response.Status.REQUEST_ENTITY_TOO_LARGE.getStatusCode(), response.getStatus());
+  }
+
+  private Response post(String declaredLength) throws IOException {
+    try (FormDataMultiPart multipart = new FormDataMultiPart()) {
+      multipart.bodyPart(
+          new FormDataBodyPart(
+              FormDataContentDisposition.name("file").fileName("template.csv").build(),
+              "1,study".getBytes(),
+              MediaType.APPLICATION_OCTET_STREAM_TYPE));
+      return RESOURCE
+          .target(PATH)
+          .register(MultiPartFeature.class)
+          .request()
+          .header(HttpHeaders.CONTENT_LENGTH, declaredLength)
+          .post(Entity.entity(multipart, multipart.getMediaType()));
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/DraftServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DraftServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.BlobId;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
@@ -179,6 +180,21 @@ class DraftServiceTest {
         gson.fromJson(byteArrayOutputStream.toString(), StreamingDeserializer.class);
     assertEquals(draft.getCreateDate().getTime(), streamedData.meta.getCreateDate().getTime());
     assertEquals("{}", streamedData.document.toString());
+  }
+
+  @Test
+  void testStreamingOutputNamesTheDraftType() throws Exception {
+    StreamingOutput output = draftService.draftAsJson(draft);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    output.write(byteArrayOutputStream);
+    byteArrayOutputStream.close();
+
+    JsonObject streamed =
+        GsonUtil.buildGson()
+            .fromJson(byteArrayOutputStream.toString(StandardCharsets.UTF_8), JsonObject.class);
+    assertEquals(
+        DraftType.STUDY_DATASET_SUBMISSION_V1.getValue(),
+        streamed.getAsJsonObject("meta").get("draftType").getAsString());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -117,11 +117,11 @@ class DraftServiceDAOTest extends DAOTestHelper {
     // Reaching the draft endpoints does not make a chairperson an owner.
     User owner = createUser();
     User chairperson = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
-    DraftInterface draft = createDraft(owner, 1);
+    UUID draftUUID = createDraft(owner, 1).getUUID();
 
     assertThrows(
         NotAuthorizedException.class,
-        () -> draftServiceDAO.getAuthorizedDraft(draft.getUUID(), chairperson));
+        () -> draftServiceDAO.getAuthorizedDraft(draftUUID, chairperson));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -114,8 +114,7 @@ class DraftServiceDAOTest extends DAOTestHelper {
 
   @Test
   void testChairpersonCannotReadAnotherUsersDraft() throws SQLException {
-    // Chairpersons reach the draft endpoints, which does not make one an owner: only the creator
-    // and an admin may read a draft.
+    // Reaching the draft endpoints does not make a chairperson an owner.
     User owner = createUser();
     User chairperson = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
     DraftInterface draft = createDraft(owner, 1);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -113,6 +113,29 @@ class DraftServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testChairpersonCannotReadAnotherUsersDraft() throws SQLException {
+    // Chairpersons reach the draft endpoints, which does not make one an owner: only the creator
+    // and an admin may read a draft.
+    User owner = createUser();
+    User chairperson = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+    DraftInterface draft = createDraft(owner, 1);
+
+    assertThrows(
+        NotAuthorizedException.class,
+        () -> draftServiceDAO.getAuthorizedDraft(draft.getUUID(), chairperson));
+  }
+
+  @Test
+  void testChairpersonCanReadTheirOwnDraft() throws SQLException {
+    User chairperson = createUserWithRole(UserRoles.CHAIRPERSON.getRoleId());
+    DraftInterface draft = createDraft(chairperson, 1);
+
+    assertEquals(
+        draft.getUUID(),
+        draftServiceDAO.getAuthorizedDraft(draft.getUUID(), chairperson).getUUID());
+  }
+
+  @Test
   void testDeleteDraft() throws Exception {
     User user = createUser();
     createDraft(user, 3);

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -1,10 +1,13 @@
 package org.broadinstitute.consent.http.service.dao;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,6 +54,11 @@ class DraftServiceDAOTest extends DAOTestHelper {
   private static GCSService gcsService;
   private static DraftServiceDAO draftServiceDAO;
 
+  /** The escape a JSON document carries where a U+0000 was, built so the compiler leaves it be. */
+  private static final String NUL_ESCAPE = "\\" + "u0000";
+
+  private static final String BACKSLASH = "\\";
+
   @BeforeEach
   void beforeEachTestSetup() throws IOException {
     gcsService = Mockito.mock(GCSService.class);
@@ -79,6 +87,58 @@ class DraftServiceDAOTest extends DAOTestHelper {
     User user = createUser();
     DraftStudyDataset draft = new DraftStudyDataset("Hello world!", user);
     assertThrows(BadRequestException.class, () -> draftServiceDAO.insertDraft(draft));
+  }
+
+  @Test
+  void testCreateDraftStripsTheEscapeFromTheDocumentAndFromTheNameItYields() {
+    // The name is decoded from this same document, so it arrives holding the character itself.
+    Mockito.reset(gcsService);
+    String json = "{\"studyName\": \"Greg" + NUL_ESCAPE + "\"}";
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset(json, user);
+    assertDoesNotThrow(() -> draftServiceDAO.insertDraft(draft));
+
+    DraftInterface storedDraft = draftDAO.findDraftById(draft.getUUID());
+    assertThat(storedDraft.getJson(), not(containsString(NUL_ESCAPE)));
+    assertThat(storedDraft.getJson(), containsString("Greg"));
+    assertEquals("Greg", storedDraft.getName());
+  }
+
+  @Test
+  void testCreateDraftKeepsAnEscapedBackslashBeforeTheEscape() {
+    // Two backslashes are an escaped one, so u0000 after them is text and stays as written.
+    Mockito.reset(gcsService);
+    String json = "{\"studyName\": \"Greg" + BACKSLASH.repeat(2) + "u0000\"}";
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset(json, user);
+    assertDoesNotThrow(() -> draftServiceDAO.insertDraft(draft));
+
+    assertEquals(json, draftDAO.findDraftById(draft.getUUID()).getJson());
+  }
+
+  @Test
+  void testCreateDraftStripsTheEscapeAnOddBackslashRunEnds() {
+    // Three: an escaped backslash, then the escape. Only the escape and its own backslash go.
+    Mockito.reset(gcsService);
+    String json = "{\"studyName\": \"Greg" + BACKSLASH.repeat(3) + "u0000\"}";
+    User user = createUser();
+    DraftStudyDataset draft = new DraftStudyDataset(json, user);
+    assertDoesNotThrow(() -> draftServiceDAO.insertDraft(draft));
+
+    DraftInterface storedDraft = draftDAO.findDraftById(draft.getUUID());
+    assertEquals("{\"studyName\": \"Greg" + BACKSLASH.repeat(2) + "\"}", storedDraft.getJson());
+    assertEquals("Greg" + BACKSLASH, storedDraft.getName());
+  }
+
+  @Test
+  void testUpdateDraftStripsTheCharacterFromARenamedDraft() throws SQLException {
+    // The rename endpoint takes its body as text, which can carry the character with no escaping.
+    User user = createUser();
+    DraftInterface draft = createDraft(user, 1);
+    draft.setName("Renamed\0");
+
+    DraftInterface updatedDraft = draftServiceDAO.updateDraft(draft, user);
+    assertEquals("Renamed", updatedDraft.getName());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -102,6 +102,9 @@ class DraftServiceDAOTest extends DAOTestHelper {
     assertThat(storedDraft.getJson(), not(containsString(NUL_ESCAPE)));
     assertThat(storedDraft.getJson(), containsString("Greg"));
     assertEquals("Greg", storedDraft.getName());
+    // The draft matches the row, so the response the resource builds from it does too.
+    assertEquals(storedDraft.getJson(), draft.getJson());
+    assertEquals(storedDraft.getName(), draft.getName());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
 import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
@@ -53,8 +54,12 @@ class StudyDatasetTemplateRegistrationContractTest {
 
   @Test
   void testAValidatedTemplateDocumentIsAcceptedByTheRegistrationEndpoint() throws Exception {
+    // One mapper for both sides, as the injector supplies: two of its own could not catch the
+    // drift between them this contract exists to rule out.
+    ObjectMapper objectMapper = new ObjectMapper();
     StudyDatasetTemplateService templateService =
-        new StudyDatasetTemplateService(new StudyTemplateValidationService(), draftService);
+        new StudyDatasetTemplateService(
+            new StudyTemplateValidationService(), draftService, objectMapper);
     templateService.validateAndCreateDraft(fixture(), user);
 
     ArgumentCaptor<DraftInterface> captor = ArgumentCaptor.forClass(DraftInterface.class);
@@ -75,7 +80,8 @@ class StudyDatasetTemplateRegistrationContractTest {
             datasetRegistrationService,
             elasticSearchService,
             tdrService,
-            gcsService);
+            gcsService,
+            objectMapper);
 
     try (Response response =
         registrationResource.createDatasetRegistration(duosUser, null, document)) {

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
@@ -1,0 +1,93 @@
+package org.broadinstitute.consent.http.service.studytemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.core.Response;
+import java.io.InputStream;
+import java.util.List;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DraftInterface;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.Study;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.resources.DatasetResource;
+import org.broadinstitute.consent.http.service.DatasetRegistrationService;
+import org.broadinstitute.consent.http.service.DatasetService;
+import org.broadinstitute.consent.http.service.DraftService;
+import org.broadinstitute.consent.http.service.ElasticSearchService;
+import org.broadinstitute.consent.http.service.TDRService;
+import org.broadinstitute.consent.http.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The document a validated template persists is the one the study registration endpoint has to
+ * accept once the user has reviewed it, so it is posted to that endpoint here rather than only
+ * checked against the validator it shares.
+ */
+@ExtendWith(MockitoExtension.class)
+class StudyDatasetTemplateRegistrationContractTest {
+
+  private static final String MINIMAL_VALID = "fixtures/study-template/v1/valid/minimal-valid.csv";
+
+  @Mock private DraftService draftService;
+  @Mock private DatasetService datasetService;
+  @Mock private DatasetRegistrationService datasetRegistrationService;
+  @Mock private ElasticSearchService elasticSearchService;
+  @Mock private TDRService tdrService;
+  @Mock private UserService userService;
+  @Mock private GCSService gcsService;
+
+  private final User user = new User();
+  private final DuosUser duosUser = new DuosUser(new AuthUser().setEmail("test@test.com"), user);
+
+  @Test
+  void testAValidatedTemplateDocumentIsAcceptedByTheRegistrationEndpoint() throws Exception {
+    StudyDatasetTemplateService templateService =
+        new StudyDatasetTemplateService(new StudyTemplateValidationService(), draftService);
+    templateService.validateAndCreateDraft(fixture(), user);
+
+    ArgumentCaptor<DraftInterface> captor = ArgumentCaptor.forClass(DraftInterface.class);
+    verify(draftService).insertDraft(captor.capture());
+    String document = captor.getValue().getJson();
+
+    Study study = new Study();
+    study.setStudyId(1);
+    Dataset dataset = new Dataset();
+    dataset.setStudyId(study.getStudyId());
+    when(datasetRegistrationService.createDatasetsFromRegistration(any(), any(), any()))
+        .thenReturn(List.of(dataset));
+    when(datasetService.findStudy(anyInt())).thenReturn(study);
+    DatasetResource registrationResource =
+        new DatasetResource(
+            datasetService,
+            userService,
+            datasetRegistrationService,
+            elasticSearchService,
+            tdrService,
+            gcsService);
+
+    try (Response response =
+        registrationResource.createDatasetRegistration(duosUser, null, document)) {
+      // A 400 here would mean the document could not be deserialized or failed the endpoint's own
+      // validation, which is the failure this contract exists to rule out.
+      assertEquals(HttpStatusCodes.STATUS_CODE_CREATED, response.getStatus());
+    }
+  }
+
+  private static InputStream fixture() {
+    return StudyDatasetTemplateRegistrationContractTest.class
+        .getClassLoader()
+        .getResourceAsStream(MINIMAL_VALID);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateRegistrationContractTest.java
@@ -54,8 +54,7 @@ class StudyDatasetTemplateRegistrationContractTest {
 
   @Test
   void testAValidatedTemplateDocumentIsAcceptedByTheRegistrationEndpoint() throws Exception {
-    // One mapper for both sides, as the injector supplies: two of its own could not catch the
-    // drift between them this contract exists to rule out.
+    // One mapper for both sides, as the injector supplies: two would hide the drift between them.
     ObjectMapper objectMapper = new ObjectMapper();
     StudyDatasetTemplateService templateService =
         new StudyDatasetTemplateService(

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceDAOTest.java
@@ -51,7 +51,8 @@ class StudyDatasetTemplateServiceDAOTest extends DAOTestHelper {
         new DraftServiceDAO(jdbi, new DraftFileStorageServiceDAO(jdbi, gcsService));
     draftService = new DraftService(jdbi, draftServiceDAO, gcsService);
     templateService =
-        new StudyDatasetTemplateService(new StudyTemplateValidationService(), draftService);
+        new StudyDatasetTemplateService(
+            new StudyTemplateValidationService(), draftService, new ObjectMapper());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceDAOTest.java
@@ -1,0 +1,109 @@
+package org.broadinstitute.consent.http.service.studytemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonObject;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.broadinstitute.consent.http.cloudstore.GCSService;
+import org.broadinstitute.consent.http.db.DAOTestHelper;
+import org.broadinstitute.consent.http.enumeration.DraftType;
+import org.broadinstitute.consent.http.models.DraftInterface;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequestValidator;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
+import org.broadinstitute.consent.http.service.DraftService;
+import org.broadinstitute.consent.http.service.dao.DraftFileStorageServiceDAO;
+import org.broadinstitute.consent.http.service.dao.DraftServiceDAO;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * The seam between validation and the draft endpoints, against a real database: every part of this
+ * is unit tested, but only here does one uploaded template become a row that the draft endpoints
+ * can hand back.
+ */
+class StudyDatasetTemplateServiceDAOTest extends DAOTestHelper {
+
+  private static final String MINIMAL_VALID = "fixtures/study-template/v1/valid/minimal-valid.csv";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private DraftService draftService;
+  private StudyDatasetTemplateService templateService;
+
+  @BeforeEach
+  void beforeEachTestSetup() {
+    GCSService gcsService = Mockito.mock(GCSService.class);
+    DraftServiceDAO draftServiceDAO =
+        new DraftServiceDAO(jdbi, new DraftFileStorageServiceDAO(jdbi, gcsService));
+    draftService = new DraftService(jdbi, draftServiceDAO, gcsService);
+    templateService =
+        new StudyDatasetTemplateService(new StudyTemplateValidationService(), draftService);
+  }
+
+  @Test
+  void testValidTemplateBecomesADraftItsOwnerCanLoad() throws Exception {
+    User owner = createUser();
+
+    TemplateValidationResponse response = templateService.validateAndCreateDraft(fixture(), owner);
+
+    assertTrue(response.valid(), response.errors().toString());
+    assertEquals(DraftType.STUDY_DATASET_SUBMISSION_V1.getValue(), response.draft().draftType());
+
+    UUID draftUUID = UUID.fromString(response.draft().id());
+    DraftInterface persisted = draftService.getAuthorizedDraft(draftUUID, owner);
+    assertEquals(owner.getUserId(), persisted.getCreateUser().getUserId());
+    assertEquals("Synthetic Minimal Study", persisted.getName());
+
+    // What the draft endpoint hands duos-ui: the document it must map, and the type it must check
+    // before mapping it.
+    JsonObject detail =
+        GsonUtil.buildGson().fromJson(read(draftService.draftAsJson(persisted)), JsonObject.class);
+    assertEquals(
+        DraftType.STUDY_DATASET_SUBMISSION_V1.getValue(),
+        detail.getAsJsonObject("meta").get("draftType").getAsString());
+
+    StudyRegistrationRequest document =
+        OBJECT_MAPPER.readValue(
+            detail.getAsJsonObject("document").toString(), StudyRegistrationRequest.class);
+    assertEquals(List.of(), new StudyRegistrationRequestValidator().collectViolations(document));
+    assertEquals("Synthetic Minimal Study", document.getStudyName());
+  }
+
+  @Test
+  void testADraftFromATemplateStaysWithItsOwner() throws Exception {
+    User owner = createUser();
+    User other = createUser();
+
+    TemplateValidationResponse response = templateService.validateAndCreateDraft(fixture(), owner);
+
+    UUID draftUUID = UUID.fromString(response.draft().id());
+    assertThrows(
+        NotAuthorizedException.class, () -> draftService.getAuthorizedDraft(draftUUID, other));
+  }
+
+  private static InputStream fixture() {
+    return StudyDatasetTemplateServiceDAOTest.class
+        .getClassLoader()
+        .getResourceAsStream(MINIMAL_VALID);
+  }
+
+  private static String read(StreamingOutput output) throws IOException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    output.write(bytes);
+    return bytes.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
@@ -1,0 +1,142 @@
+package org.broadinstitute.consent.http.service.studytemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.broadinstitute.consent.http.enumeration.DraftType;
+import org.broadinstitute.consent.http.models.DraftInterface;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
+import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
+import org.broadinstitute.consent.http.models.dto.registration.ConsentGroupRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequest;
+import org.broadinstitute.consent.http.models.dto.registration.StudyRegistrationRequestValidator;
+import org.broadinstitute.consent.http.models.dto.registration.template.StudyTemplateValidationResult;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationError;
+import org.broadinstitute.consent.http.models.dto.registration.template.TemplateValidationResponse;
+import org.broadinstitute.consent.http.service.DraftService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StudyDatasetTemplateServiceTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Mock private StudyTemplateValidationService validationService;
+
+  @Mock private DraftService draftService;
+
+  private final User user = new User();
+
+  private StudyDatasetTemplateService service() {
+    return new StudyDatasetTemplateService(validationService, draftService);
+  }
+
+  @Test
+  void testValidateAndCreateDraft_writesNothingForAnInvalidTemplate() throws Exception {
+    List<TemplateValidationError> errors =
+        List.of(TemplateValidationError.at(2, "value", "Study Name is required"));
+    when(validationService.validate(any()))
+        .thenReturn(StudyTemplateValidationResult.invalid(errors, true));
+
+    TemplateValidationResponse response = service().validateAndCreateDraft(template(), user);
+
+    assertFalse(response.valid());
+    assertEquals(errors, response.errors());
+    assertTrue(response.truncated());
+    assertNull(response.draft());
+    verify(draftService, never()).insertDraft(any());
+  }
+
+  @Test
+  void testValidateAndCreateDraft_createsOneTypedDraftForAValidTemplate() throws Exception {
+    when(validationService.validate(any()))
+        .thenReturn(StudyTemplateValidationResult.valid(registration()));
+
+    TemplateValidationResponse response = service().validateAndCreateDraft(template(), user);
+
+    ArgumentCaptor<DraftInterface> captor = ArgumentCaptor.forClass(DraftInterface.class);
+    verify(draftService).insertDraft(captor.capture());
+    DraftInterface draft = captor.getValue();
+    assertTrue(response.valid());
+    assertEquals(List.of(), response.errors());
+    assertEquals(draft.getUUID().toString(), response.draft().id());
+    assertEquals(DraftType.STUDY_DATASET_SUBMISSION_V1.getValue(), response.draft().draftType());
+  }
+
+  @Test
+  void testValidateAndCreateDraft_persistsADocumentTheRegistrationEndpointAccepts()
+      throws Exception {
+    when(validationService.validate(any()))
+        .thenReturn(StudyTemplateValidationResult.valid(registration()));
+
+    service().validateAndCreateDraft(template(), user);
+
+    ArgumentCaptor<DraftInterface> captor = ArgumentCaptor.forClass(DraftInterface.class);
+    verify(draftService).insertDraft(captor.capture());
+    // The document a user edits and posts back is read the same way the registration endpoint
+    // reads its payload, so a draft cannot be structurally unusable there.
+    StudyRegistrationRequest persisted =
+        OBJECT_MAPPER.readValue(captor.getValue().getJson(), StudyRegistrationRequest.class);
+    assertEquals(List.of(), new StudyRegistrationRequestValidator().collectViolations(persisted));
+    assertEquals("Synthetic Minimal Study", persisted.getStudyName());
+    assertEquals(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL,
+        persisted.getNihAnvilUse());
+    assertEquals(
+        AccessManagement.OPEN, persisted.getConsentGroups().getFirst().getAccessManagement());
+    assertEquals("Synthetic Minimal Study", captor.getValue().getName());
+  }
+
+  @Test
+  void testValidateAndCreateDraft_createsADistinctDraftPerRequest() throws Exception {
+    when(validationService.validate(any()))
+        .thenReturn(StudyTemplateValidationResult.valid(registration()));
+    StudyDatasetTemplateService service = service();
+
+    TemplateValidationResponse first = service.validateAndCreateDraft(template(), user);
+    TemplateValidationResponse second = service.validateAndCreateDraft(template(), user);
+
+    verify(draftService, times(2)).insertDraft(any());
+    assertNotEquals(first.draft().id(), second.draft().id());
+  }
+
+  private static InputStream template() {
+    return new ByteArrayInputStream("templateVersion".getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static StudyRegistrationRequest registration() {
+    StudyRegistrationRequest registration = new StudyRegistrationRequest();
+    registration.setStudyName("Synthetic Minimal Study");
+    registration.setStudyDescription("A synthetic study used only for contract tests.");
+    registration.setDataTypes(List.of("Genomic"));
+    registration.setPublicVisibility(true);
+    registration.setNihAnvilUse(
+        NihAnvilUse.I_AM_NOT_NHGRI_FUNDED_AND_DO_NOT_PLAN_TO_STORE_DATA_IN_AN_VIL);
+    registration.setPiName("Synthetic Investigator");
+
+    ConsentGroupRequest consentGroup = new ConsentGroupRequest();
+    consentGroup.setConsentGroupName("Synthetic Open Dataset");
+    consentGroup.setAccessManagement(AccessManagement.OPEN);
+    consentGroup.setNumberOfParticipants(10);
+    registration.setConsentGroups(List.of(consentGroup));
+    return registration;
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
@@ -79,6 +79,7 @@ class StudyDatasetTemplateServiceTest {
     assertEquals(List.of(), response.errors());
     assertEquals(draft.getUUID().toString(), response.draft().id());
     assertEquals(DraftType.STUDY_DATASET_SUBMISSION_V1.getValue(), response.draft().draftType());
+    assertEquals(user, draft.getCreateUser());
   }
 
   @Test
@@ -91,8 +92,8 @@ class StudyDatasetTemplateServiceTest {
 
     ArgumentCaptor<DraftInterface> captor = ArgumentCaptor.forClass(DraftInterface.class);
     verify(draftService).insertDraft(captor.capture());
-    // The document a user edits and posts back is read the same way the registration endpoint
-    // reads its payload, so a draft cannot be structurally unusable there.
+    // Read the way the registration endpoint reads its payload, so a draft cannot be unusable
+    // there.
     StudyRegistrationRequest persisted =
         OBJECT_MAPPER.readValue(captor.getValue().getJson(), StudyRegistrationRequest.class);
     assertEquals(List.of(), new StudyRegistrationRequestValidator().collectViolations(persisted));

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyDatasetTemplateServiceTest.java
@@ -46,7 +46,7 @@ class StudyDatasetTemplateServiceTest {
   private final User user = new User();
 
   private StudyDatasetTemplateService service() {
-    return new StudyDatasetTemplateService(validationService, draftService);
+    return new StudyDatasetTemplateService(validationService, draftService, new ObjectMapper());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationServiceTest.java
@@ -400,8 +400,7 @@ class StudyTemplateValidationServiceTest {
 
   @Test
   void testValidate_readsAFileAtExactlyTheSizeLimit() {
-    // The boundary the read-one-byte-extra trick exists to get right: a file this size is read and
-    // validated rather than rejected or truncated to fit.
+    // The boundary the read-one-byte-extra trick exists to get right: read, not rejected.
     byte[] atTheLimit = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES];
 
     StudyTemplateValidationResult result = service.validate(new ByteArrayInputStream(atTheLimit));

--- a/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/studytemplate/StudyTemplateValidationServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.broadinstitute.consent.http.exceptions.TemplateTooLargeException;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.AccessManagement;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.ConsentGroup.DataLocation;
 import org.broadinstitute.consent.http.models.dataset_registration_v1.DatasetRegistrationSchemaV1.NihAnvilUse;
@@ -386,13 +388,30 @@ class StudyTemplateValidationServiceTest {
 
   @Test
   void testValidate_rejectsFileOverTheSizeLimit() {
+    // A failed request rather than a validation result: there is no cell for the producer to fix.
     byte[] oversized = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES + 1];
+    InputStream content = new ByteArrayInputStream(oversized);
 
-    StudyTemplateValidationResult result = service.validate(new ByteArrayInputStream(oversized));
+    TemplateTooLargeException thrown =
+        assertThrows(TemplateTooLargeException.class, () -> service.validate(content));
 
-    assertEquals(
-        List.of(TemplateValidationError.of("Template file must be no larger than 5 MiB")),
-        result.errors());
+    assertEquals(StudyTemplateValidationService.TOO_LARGE_MESSAGE, thrown.getMessage());
+  }
+
+  @Test
+  void testValidate_readsAFileAtExactlyTheSizeLimit() {
+    // The boundary the read-one-byte-extra trick exists to get right: a file this size is read and
+    // validated rather than rejected or truncated to fit.
+    byte[] atTheLimit = new byte[StudyTemplateValidationService.MAX_TEMPLATE_BYTES];
+
+    StudyTemplateValidationResult result = service.validate(new ByteArrayInputStream(atTheLimit));
+
+    assertFalse(result.errors().isEmpty());
+    assertFalse(
+        result
+            .errors()
+            .contains(
+                TemplateValidationError.of(StudyTemplateValidationService.TOO_LARGE_MESSAGE)));
   }
 
   // ── Scalar conversion ────────────────────────────────────────────────────

--- a/src/test/java/org/broadinstitute/consent/http/util/NulCharactersTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/NulCharactersTest.java
@@ -75,6 +75,12 @@ class NulCharactersTest {
   }
 
   @Test
+  void testStripFromJsonTextKeepsABackslashRunTheTextEndsOn() {
+    // The scan leaves the run because the text ran out, not because a non-backslash stopped it.
+    assertEquals(BACKSLASH, NulCharacters.stripFromJsonText("\0" + BACKSLASH));
+  }
+
+  @Test
   void testStripFromJsonTextLeavesADocumentWithoutOneAlone() {
     String json = "{\"n\": \"Greg\"}";
     assertSame(json, NulCharacters.stripFromJsonText(json));

--- a/src/test/java/org/broadinstitute/consent/http/util/NulCharactersTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/NulCharactersTest.java
@@ -1,0 +1,90 @@
+package org.broadinstitute.consent.http.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class NulCharactersTest {
+
+  /**
+   * The escape as it appears in a document, built rather than written out: the compiler decodes a
+   * source-level escape into the character itself, comments included.
+   */
+  private static final String ESCAPE = "\\" + "u0000";
+
+  private static final String BACKSLASH = "\\";
+
+  @Test
+  void testStripFromDropsTheCharacter() {
+    assertEquals("Greg", NulCharacters.stripFrom("Greg\0"));
+    assertEquals("Greg", NulCharacters.stripFrom("\0G\0r\0e\0g\0"));
+  }
+
+  @Test
+  void testStripFromLeavesAValueWithoutOneAlone() {
+    String name = "Greg";
+    assertSame(name, NulCharacters.stripFrom(name));
+    assertNull(NulCharacters.stripFrom(null));
+  }
+
+  @Test
+  void testStripFromJsonTextDropsTheEscape() {
+    assertEquals(
+        "{\"n\": \"Greg\"}", NulCharacters.stripFromJsonText("{\"n\": \"Greg" + ESCAPE + "\"}"));
+  }
+
+  @Test
+  void testStripFromJsonTextDropsAdjacentEscapes() {
+    assertEquals(
+        "{\"n\": \"Greg\"}",
+        NulCharacters.stripFromJsonText("{\"n\": \"" + ESCAPE + "Greg" + ESCAPE + ESCAPE + "\"}"));
+  }
+
+  @Test
+  void testStripFromJsonTextKeepsAnEvenBackslashRun() {
+    // Two backslashes are an escaped backslash, so what follows them is the literal text u0000.
+    String json = "{\"n\": \"Greg" + BACKSLASH.repeat(2) + "u0000\"}";
+    assertEquals(json, NulCharacters.stripFromJsonText(json));
+
+    String longerRun = "{\"n\": \"Greg" + BACKSLASH.repeat(4) + "u0000\"}";
+    assertEquals(longerRun, NulCharacters.stripFromJsonText(longerRun));
+  }
+
+  @Test
+  void testStripFromJsonTextKeepsTheBackslashesAnOddRunEscapes() {
+    // Three: an escaped backslash, then the escape. Only the escape and its own backslash go.
+    assertEquals(
+        "{\"n\": \"Greg" + BACKSLASH.repeat(2) + "\"}",
+        NulCharacters.stripFromJsonText("{\"n\": \"Greg" + BACKSLASH.repeat(3) + "u0000\"}"));
+    assertEquals(
+        "{\"n\": \"Greg" + BACKSLASH.repeat(4) + "\"}",
+        NulCharacters.stripFromJsonText("{\"n\": \"Greg" + BACKSLASH.repeat(5) + "u0000\"}"));
+  }
+
+  @Test
+  void testStripFromJsonTextKeepsEveryOtherEscape() {
+    String json = "{\"n\": \"a" + BACKSLASH + "nb" + BACKSLASH + "u0001c" + BACKSLASH + "\\\"d\"}";
+    assertEquals(json, NulCharacters.stripFromJsonText(json));
+  }
+
+  @Test
+  void testStripFromJsonTextDropsTheRawCharacter() {
+    assertEquals("{\"n\": \"Greg\"}", NulCharacters.stripFromJsonText("{\"n\": \"Greg\0\"}"));
+  }
+
+  @Test
+  void testStripFromJsonTextLeavesADocumentWithoutOneAlone() {
+    String json = "{\"n\": \"Greg\"}";
+    assertSame(json, NulCharacters.stripFromJsonText(json));
+    assertNull(NulCharacters.stripFromJsonText(null));
+  }
+
+  @Test
+  void testStripFromJsonTextLeavesTextThatIsNotJsonAlone() {
+    // The cast, not this, is what refuses a document; a body it cannot parse arrives unchanged.
+    assertSame("Hello world!", NulCharacters.stripFromJsonText("Hello world!"));
+    assertEquals(BACKSLASH, NulCharacters.stripFromJsonText(BACKSLASH + "\0"));
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3871

Security risk: **low** — adds an authenticated endpoint that accepts a CSV and writes one draft the caller owns. Parsing was reviewed in DT-3870; this adds the request boundary around it: `Admin`, `Chairperson`, and `DataSubmitter` only, the same roles as study registration, with per-draft ownership unchanged in `DraftServiceDAO`. Uploads are bounded at 5 MiB as they are read, no uploaded content is logged, and the draft writes strip the U+0000 escape that `jsonb` rejects. Chairpersons gain reach to the draft endpoints, not to anyone else's drafts — two tests pin that.

### Summary

Ticket 3 of the study-template workflow planned in duos-ui at `docs/plans/study-template-validation-workflow.md`. Adds `POST /api/draft/v1/study-dataset/template-validation`: one CSV in, either the errors to fix or a `StudyDatasetSubmissionV1` draft holding the registration-shaped document. Typed rather than generic, so this validator does not become the implied one for whatever draft type comes next. This unblocks [DT-1854](https://github.com/DataBiosphere/duos-ui/pull/3872), which is built against this contract and cannot be released before it.

**An invalid template is a completed result; a valid one is a creation.** Errors answer 200 with `valid: false`, which is what lets duos-ui render row and column context on the page rather than as a toast. A valid template answers 201 with a `Location` for the draft it created, as `DraftResource.createDraftRegistration` does for the same row. Only an unusable request fails: no file part, more than one, or one over 5 MiB. duos-ui needs no change for the 201 — `fetchMultipart` gates on `res.ok`, and callers discriminate on the body's `valid`.

**The two decisions the ticket left open are settled here.** `truncated` reaches the wire — duos-ui already renders a notice for it. Oversize is a request failure (413) while an empty, non-UTF-8, or malformed file stays a validation result, since only the latter is something the producer edits. `docs/study-template-v1.md`, the OpenAPI spec, and the plan in duos-ui now all describe that same boundary; `docs/API_GUIDELINES.md` gains 413, which its status-code list did not have.

Fifteen commits, each reviewable on its own. The first eight build the endpoint:

- **`4375dbc6` the U+0000 guard.** `jsonb` rejects the escape, and `DraftDAO` was the only JSON write in this area without the `regexp_replace` the data access request statements have carried since the 2025 migration. Both the insert and the update path get it — a draft is meant to be edited and saved. No read-side guard is needed: a stored row cannot hold the escape, because writing one would have failed.
- **`ceb2642d` `meta.draftType`.** `DraftStudyDataset` holds its type in a private static field, which Gson skips, so the draft detail response carried everything about a draft except what kind it is. It is read from the draft rather than from whatever the class serializes, so a later draft type reports itself for free.
- **`d6f71d31` chairpersons on the draft endpoints.** The upload page admits them; without this they would hit a 403 the moment a validated template produced a draft.
- **`890c4e97` the endpoint**, with **`990ed50f`, `76eca217`, `7d23061d`, `9cb249f2`** closing the gaps found reviewing it: the seam between validation and the draft endpoints proven against a real database, the persisted document posted to the real registration endpoint, the OpenAPI examples read back through the response model, and the endpoint timed and its path pinned.

The last seven answer review, and each is worth reading on its own:

- **`c76bed24` one verb set for the role scan.** The two copies of the reflective role assertion had already drifted — the template resource filtered `POST` alone, so an endpoint added there with another verb would have slipped past the check written to be exhaustive.
- **`946aa12a` the U+0000 strip spares an escaped backslash.** The pattern matched a literal backslash followed by `u0000`, which is right for a serialized U+0000 but also matches the tail of an already-escaped backslash: the strip started at the second backslash and took the following character with it, and where that left an escape the parser rejects, the `::jsonb` cast failed and `DraftServiceDAO` reported a 400 blaming the caller's JSON for a document the server serialized itself. A negative lookbehind fixes it; without it the new test fails with Postgres's own `invalid input syntax for type json`.
- **`66231888` one owner for the size limit.** It was enforced twice with different outcomes — the resource read a byte past it and answered 413, then handed the validator a stream that could no longer exceed it, so the validator's own check could never fire. The validator owns it now and the resource streams the part straight through, which drops a full second copy of the upload and moves the read that can fail mid-upload into the one place that already reports a read failure as a validation error.
- **`97b55684` one `ObjectMapper`.** The claim that the draft is written with the mapper the registration endpoint reads was held up by nothing: this service, `DatasetResource`, and the contract test each built their own. They agreed only because all were unconfigured. One binding supplies both sides, and the contract test uses the single instance.
- **`9b54566d`, `34a73346` the response model and its spec test.** The spec-drift test could not fail on a missing pointer, which is the case it exists to catch; it reads the pointer as required now. `@JsonInclude` was dead — Gson writes every JSON entity here — and a null error list NPE'd where an empty one is meant.
- **`40d062eb` 201 at the created draft**, per `docs/API_GUIDELINES.md` and the sibling endpoint that writes the same row.

Two things review raised that are deliberately not fixed here. `DataAccessRequestDAO` carries the same U+0000 pattern in four statements, where it has shipped since the 2025 migration; fixing it is its own change against its own tests. And `DraftServiceDAO.insertDraft` wraps every write failure in `BadRequestException`, so a server-side failure reads as a 400 — pre-existing behaviour on a shared path, now described in the spec's 400 text rather than changed underneath its other callers.

Still worth a reviewer's eye:

- **The uploaded filename is not validated.** Every other multipart endpoint here calls `validateFileDetails`, which protects a *stored* name; this endpoint reads the bytes and drops the part, so there is no stored name for a traversal check to protect. It rejects any name outside ASCII — `études.csv` fails — which a producer could neither predict nor understand. Its size cap was vacuous too, since a multipart part usually reports its size as `-1`; the bounded read is the real limit.
- **413, not 400, for an oversized upload,** and raised as a typed exception the resource maps itself rather than through a global `createExceptionResponse` entry that would change behaviour for unrelated code.
- **An empty file answers 200 `valid: false`**, not 400. The acceptance criterion grouped it with the request failures; it is file content, and "Template file is empty" belongs on the page with the other content errors. The AC has been updated to match.
- **Responses are serialized by Gson, not Jackson** — `JerseyGsonProvider` writes every JSON entity. The wire shape is therefore pinned by a test against the bytes rather than by annotations, because an *absent* `row` is how a client tells an unlocated error from one on row 1.

### Testing

`Tests run: 267` green across the twelve suites this touches, including two database-backed classes against a real Postgres container. JaCoCo reports 100% line and branch coverage on every new class. `spotless:check` clean and the OpenAPI generator validation passes.

The tests that would catch a regression rather than restate the code:

- The U+0000 tests fail without the guard with Postgres's own `ERROR: unsupported Unicode escape sequence`, and the new escaped-backslash test fails against the previous pattern with `ERROR: invalid input syntax for type json` — the 400 the review predicted.
- `StudyDatasetTemplateServiceDAOTest` runs the canonical fixture through validation and `DraftService` against a real database, then asserts what duos-ui receives: `meta.draftType`, a document that deserializes into `StudyRegistrationRequest` with no violations, a name taken from the study, and a second user refused.
- `StudyDatasetTemplateRegistrationContractTest` posts the persisted document to a real `DatasetResource.createDatasetRegistration` and asserts 201, both sides sharing the one mapper the injector supplies. Replacing the document with `{}` turns it into a 400.
- `TemplateValidationResponseExamplesTest` round-trips the 200 and 201 examples through the response model; renaming `draftType` in an example, or moving one to a status it no longer answers, fails it.
- The size limit is pinned on both sides of the boundary: a file of exactly 5 MiB is read and validated, one byte more is refused, so flipping the comparison or dropping the extra byte from the read cannot pass.
- The role and path assertions cover every endpoint on both resources through one shared helper, so an endpoint added later cannot be left unguarded whatever verb it carries, and the URL duos-ui calls literally cannot be renamed silently.

Not covered, deliberately: `@RolesAllowed` is asserted reflectively, as everywhere else in this repo — proving Jersey enforces it needs a `ResourceExtension` harness with an auth filter, which is worth doing once across all resources rather than for one endpoint.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-1854]: https://broadworkbench.atlassian.net/browse/DT-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
