### PR TITLE
[DT-4006] Query fix, tests, and future item.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -193,7 +193,9 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * LAST vote in the group of final votes for all data access elections. We need to group them due
    * to the case of multiple elections on a dar-dataset request. Election 1 may have been denied.
    * Election 2 may have been approved. Election 3 may have been denied again. When we partition
-   * over the election reference id, we'll get all final votes. The `LAST_VALUE` function selects
+   * over the election reference id and dataset id, we'll get all final votes for that one
+   * dar-dataset pair; the reference id must be part of the partition key so votes cast on other
+   * DARs for the same dataset cannot influence this DAR's result. The `LAST_VALUE` function selects
    * the last result in the partition, which would be `FALSE` in the example above. Outside the
    * JOIN, we filter on groupings where the final vote value is `TRUE` so the denied election in the
    * example would be filtered out.
@@ -209,7 +211,7 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
       INNER JOIN (
         SELECT DISTINCT e.reference_id, e.dataset_id, LAST_VALUE(v.vote)
         OVER(
-          PARTITION BY e.dataset_id
+          PARTITION BY e.reference_id, e.dataset_id
             ORDER BY v.create_date
             RANGE BETWEEN
               UNBOUNDED PRECEDING AND

--- a/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DataAccessRequestDAO.java
@@ -193,8 +193,8 @@ public interface DataAccessRequestDAO extends Transactional<DataAccessRequestDAO
    * LAST vote in the group of final votes for all data access elections. We need to group them due
    * to the case of multiple elections on a dar-dataset request. Election 1 may have been denied.
    * Election 2 may have been approved. Election 3 may have been denied again. When we partition
-   * over the election reference id and dataset id, we'll get all final votes for that one
-   * dar-dataset pair; the reference id must be part of the partition key so votes cast on other
+   * over the election reference ID and dataset ID, we'll get all final votes for that one
+   * DAR-dataset pair; the reference ID must be part of the partition key so votes cast on other
    * DARs for the same dataset cannot influence this DAR's result. The `LAST_VALUE` function selects
    * the last result in the partition, which would be `FALSE` in the example above. Outside the
    * JOIN, we filter on groupings where the final vote value is `TRUE` so the denied election in the

--- a/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/ElectionDAO.java
@@ -109,6 +109,25 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
       @BindList(value = "voteIds", onEmpty = EmptyHandling.NULL_STRING) List<Integer> voteIds,
       @Bind("electionType") String electionType);
 
+  /**
+   * Find the most recent election for each reference id and election type.
+   *
+   * <p><b>Caution: this returns one election per (reference id, election type), NOT one per
+   * dataset.</b> The partition key omits {@code dataset_id}, so a DAR spanning several datasets
+   * collapses to a single election and the elections on its other datasets are dropped. This is
+   * safe for the current caller only because {@code
+   * DarCollectionService#cancelDarCollectionAsResearcher} uses the result as an existence check
+   * ("are there any elections on this collection?"), and dropping rows cannot change whether the
+   * list is empty.
+   *
+   * <p>Any caller that iterates these results, counts them, or needs the latest election for each
+   * dataset on a DAR must add {@code e.dataset_id} to the partition key first. Compare {@link
+   * DarCollectionDAO} and {@link MatchDAO}, which partition by reference id and dataset id for
+   * exactly that reason.
+   *
+   * @param referenceIds The DAR reference UUIDs
+   * @return The latest election per reference id and election type
+   */
   @SqlQuery(
       """
       SELECT * FROM (
@@ -118,6 +137,9 @@ public interface ElectionDAO extends Transactional<ElectionDAO> {
                ELSE v.update_date
                END as final_vote_date,
            v.rationale final_rationale, MAX(e.election_id)
+           -- Note that `dataset_id` is intentionally absent from the partition key: this yields
+           -- one election per DAR and type, not one per dataset. Only valid for existence checks.
+           -- See the javadoc before reusing this query.
            OVER (PARTITION BY e.reference_id, e.election_type) AS latest
            FROM election e
            LEFT JOIN vote v ON e.election_id = v.election_id AND

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -717,6 +717,162 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
   }
 
   /**
+   * The final-vote window is partitioned by reference id AND dataset id. Partitioning by dataset id
+   * alone lets the most recent final vote anywhere in the system decide every DAR that touches that
+   * dataset, so an unrelated denial silently revokes approvals that were granted correctly.
+   */
+  @Test
+  void testFindDatasetApprovalsByDar_OtherDarDenialDoesNotRevokeApproval() {
+    Dataset dataset = createDARDAOTestDataset();
+    User user = createUserWithInstitution();
+    Date earlier = new Date(Instant.now().minus(2, ChronoUnit.DAYS).toEpochMilli());
+    Date later = new Date();
+
+    DataAccessRequest approvedDar = createDAR(user, dataset, "DAR-" + randomInt(100, 1000000));
+    Election approvedElection =
+        createDataAccessElection(approvedDar.getReferenceId(), dataset.getDatasetId());
+    Vote approvedVote =
+        createFinalVote(dataset.getCreateUserId(), approvedElection.getElectionId());
+    updateVote(
+        true,
+        "",
+        earlier,
+        approvedVote.getVoteId(),
+        false,
+        approvedElection.getElectionId(),
+        earlier,
+        false);
+
+    assertTrue(
+        dataAccessRequestDAO
+            .findDatasetApprovalsByDar(approvedDar.getReferenceId())
+            .contains(dataset.getDatasetId()));
+
+    // A separate DAR on the same dataset is denied more recently.
+    DataAccessRequest deniedDar = createDAR(user, dataset, "DAR-" + randomInt(100, 1000000));
+    Election deniedElection =
+        createDataAccessElection(deniedDar.getReferenceId(), dataset.getDatasetId());
+    Vote deniedVote = createFinalVote(dataset.getCreateUserId(), deniedElection.getElectionId());
+    updateVote(
+        false,
+        "",
+        later,
+        deniedVote.getVoteId(),
+        false,
+        deniedElection.getElectionId(),
+        later,
+        false);
+
+    assertTrue(
+        dataAccessRequestDAO
+            .findDatasetApprovalsByDar(approvedDar.getReferenceId())
+            .contains(dataset.getDatasetId()),
+        "A denial on a different DAR must not revoke this DAR's approval");
+    assertTrue(
+        dataAccessRequestDAO.findDatasetApprovalsByDar(deniedDar.getReferenceId()).isEmpty(),
+        "The denied DAR must have no approved datasets");
+  }
+
+  /**
+   * The inverse of {@link #testFindDatasetApprovalsByDar_OtherDarDenialDoesNotRevokeApproval()}: an
+   * approval granted to someone else must not confer access on a DAR that was denied.
+   */
+  @Test
+  void testFindDatasetApprovalsByDar_OtherDarApprovalDoesNotGrantApproval() {
+    Dataset dataset = createDARDAOTestDataset();
+    User user = createUserWithInstitution();
+    Date earlier = new Date(Instant.now().minus(2, ChronoUnit.DAYS).toEpochMilli());
+    Date later = new Date();
+
+    DataAccessRequest deniedDar = createDAR(user, dataset, "DAR-" + randomInt(100, 1000000));
+    Election deniedElection =
+        createDataAccessElection(deniedDar.getReferenceId(), dataset.getDatasetId());
+    Vote deniedVote = createFinalVote(dataset.getCreateUserId(), deniedElection.getElectionId());
+    updateVote(
+        false,
+        "",
+        earlier,
+        deniedVote.getVoteId(),
+        false,
+        deniedElection.getElectionId(),
+        earlier,
+        false);
+
+    // A separate DAR on the same dataset is approved more recently.
+    DataAccessRequest approvedDar = createDAR(user, dataset, "DAR-" + randomInt(100, 1000000));
+    Election approvedElection =
+        createDataAccessElection(approvedDar.getReferenceId(), dataset.getDatasetId());
+    Vote approvedVote =
+        createFinalVote(dataset.getCreateUserId(), approvedElection.getElectionId());
+    updateVote(
+        true,
+        "",
+        later,
+        approvedVote.getVoteId(),
+        false,
+        approvedElection.getElectionId(),
+        later,
+        false);
+
+    assertTrue(
+        dataAccessRequestDAO.findDatasetApprovalsByDar(deniedDar.getReferenceId()).isEmpty(),
+        "An approval on a different DAR must not grant this DAR access");
+    assertTrue(
+        dataAccessRequestDAO
+            .findDatasetApprovalsByDar(approvedDar.getReferenceId())
+            .contains(dataset.getDatasetId()));
+  }
+
+  /**
+   * Reproduces the production shape: a DAR approved on two datasets loses only the dataset that
+   * some other DAR later had denied, so the call returns one id instead of two.
+   */
+  @Test
+  void testFindDatasetApprovalsByDar_MultipleDatasetsSurviveOtherDarDenial() {
+    Dataset sharedDataset = createDARDAOTestDataset();
+    Dataset otherDataset = createDARDAOTestDataset();
+    User user = createUserWithInstitution();
+    Date earlier = new Date(Instant.now().minus(2, ChronoUnit.DAYS).toEpochMilli());
+    Date later = new Date();
+
+    DataAccessRequest dar = createDAR(user, sharedDataset, "DAR-" + randomInt(100, 1000000));
+    dataAccessRequestDAO.insertDARDatasetRelation(
+        dar.getReferenceId(), otherDataset.getDatasetId());
+
+    for (Dataset dataset : List.of(sharedDataset, otherDataset)) {
+      Election election = createDataAccessElection(dar.getReferenceId(), dataset.getDatasetId());
+      Vote vote = createFinalVote(dataset.getCreateUserId(), election.getElectionId());
+      updateVote(
+          true, "", earlier, vote.getVoteId(), false, election.getElectionId(), earlier, false);
+    }
+
+    assertEquals(2, dataAccessRequestDAO.findDatasetApprovalsByDar(dar.getReferenceId()).size());
+
+    // An unrelated DAR is denied on just one of the two datasets, more recently.
+    DataAccessRequest unrelatedDar =
+        createDAR(user, sharedDataset, "DAR-" + randomInt(100, 1000000));
+    Election unrelatedElection =
+        createDataAccessElection(unrelatedDar.getReferenceId(), sharedDataset.getDatasetId());
+    Vote unrelatedVote =
+        createFinalVote(sharedDataset.getCreateUserId(), unrelatedElection.getElectionId());
+    updateVote(
+        false,
+        "",
+        later,
+        unrelatedVote.getVoteId(),
+        false,
+        unrelatedElection.getElectionId(),
+        later,
+        false);
+
+    Set<Integer> approvals = dataAccessRequestDAO.findDatasetApprovalsByDar(dar.getReferenceId());
+    assertEquals(
+        2, approvals.size(), "Both approved datasets must survive an unrelated DAR's denial");
+    assertTrue(approvals.contains(sharedDataset.getDatasetId()));
+    assertTrue(approvals.contains(otherDataset.getDatasetId()));
+  }
+
+  /**
    * Tests the case where a user has been approved for access, then denied access, and that the user
    * does not show up as an approved user for the dataset.
    */


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-4006](https://broadworkbench.atlassian.net/browse/DT-4006)

### Summary

Fixes a cross-DAR data leak in `DataAccessRequestDAO#findDatasetApprovalsByDar` and adds
regression coverage, plus a documentation warning on a related query in `ElectionDAO`.

#### The bug

The window function that picks the last final vote for a dar-dataset pair was partitioned by
`e.dataset_id` alone:

```sql
PARTITION BY e.dataset_id
```

Because `reference_id` was missing from the partition key, all final votes on a dataset — across
*every* DAR in the system — landed in one partition, and `LAST_VALUE` returned whichever vote was
cast most recently anywhere. The result: one researcher's denial silently revoked another
researcher's correctly granted approval, and conversely an unrelated approval could make a denied
DAR look approved. The impact grows with dataset popularity, since every new election on a shared
dataset overwrites the outcome for all prior DARs on it.

#### The fix

```sql
PARTITION BY e.reference_id, e.dataset_id
```

Each dar-dataset pair now gets its own partition, so multi-election histories on a single request
still resolve correctly (the original intent of the `LAST_VALUE` logic) while votes on other DARs
are excluded. The Javadoc on the query was updated to explain why the reference id must be part
of the key.

#### Tests

Three new integration tests in `DataAccessRequestDAOTest`, each failing before the change:

- `..._OtherDarDenialDoesNotRevokeApproval` — a later denial on a different DAR must not strip an
  existing approval.
- `..._OtherDarApprovalDoesNotGrantApproval` — the inverse; a later approval elsewhere must not
  confer access on a denied DAR.
- `..._MultipleDatasetsSurviveOtherDarDenial` — reproduces the production shape, where a DAR
  approved on two datasets returned only one id after an unrelated denial on the shared dataset.

### Follow-up item (documentation only, no behavior change)

`ElectionDAO#findLastElectionsByReferenceIdsAndType` has the same partition-key shape
(`PARTITION BY e.reference_id, e.election_type`, no `dataset_id`), which collapses a multi-dataset
DAR to a single election. That is currently harmless: its only caller,
`DarCollectionService#cancelDarCollectionAsResearcher`, uses the result as an existence check, and
dropping rows cannot change whether the list is empty. Added Javadoc and an inline SQL comment so
the next caller that counts or iterates these results knows to add `dataset_id` to the partition
key first.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
