### PR TITLE
[DT-4013] Fix native thread leak in HttpClientUtil

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -23,10 +23,11 @@ import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -52,14 +53,20 @@ public class HttpClientUtil implements ConsentLogger {
     httpClient = HttpClients.createDefault();
     // Shared pool of daemon threads for request timeouts. A per-request pool leaks
     // threads because ScheduledThreadPoolExecutor core threads never terminate.
-    timeoutExecutor =
-        Executors.newScheduledThreadPool(
+    AtomicInteger threadNumber = new AtomicInteger(1);
+    ScheduledThreadPoolExecutor executor =
+        new ScheduledThreadPoolExecutor(
             configuration.getPoolSize(),
             runnable -> {
-              Thread thread = new Thread(runnable, "http-client-timeout");
+              Thread thread =
+                  new Thread(runnable, "http-client-timeout-" + threadNumber.getAndIncrement());
               thread.setDaemon(true);
               return thread;
             });
+    // Remove canceled timeout tasks from the queue at once. Without this policy, each
+    // canceled task holds its request reference until the full timeout delay elapses.
+    executor.setRemoveOnCancelPolicy(true);
+    timeoutExecutor = executor;
     CacheLoader<URI, SimpleResponse> loader =
         new CacheLoader<>() {
           @Override

--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.HttpClient;
@@ -44,9 +45,21 @@ public class HttpClientUtil implements ConsentLogger {
 
   private final HttpClient httpClient;
 
+  private final ScheduledExecutorService timeoutExecutor;
+
   public HttpClientUtil(ServicesConfiguration configuration) {
     this.configuration = configuration;
     httpClient = HttpClients.createDefault();
+    // Shared pool of daemon threads for request timeouts. A per-request pool leaks
+    // threads because ScheduledThreadPoolExecutor core threads never terminate.
+    timeoutExecutor =
+        Executors.newScheduledThreadPool(
+            configuration.getPoolSize(),
+            runnable -> {
+              Thread thread = new Thread(runnable, "http-client-timeout");
+              thread.setDaemon(true);
+              return thread;
+            });
     CacheLoader<URI, SimpleResponse> loader =
         new CacheLoader<>() {
           @Override
@@ -87,15 +100,20 @@ public class HttpClientUtil implements ConsentLogger {
    * @throws IOException The exception
    */
   public SimpleResponse getHttpResponse(HttpGet request) throws IOException {
-    final ScheduledExecutorService executor =
-        Executors.newScheduledThreadPool(configuration.getPoolSize());
-    executor.schedule(request::cancel, configuration.getTimeoutSeconds(), TimeUnit.SECONDS);
-    return httpClient.execute(
-        request,
-        httpResponse ->
-            new SimpleResponse(
-                httpResponse.getCode(),
-                IOUtils.toString(httpResponse.getEntity().getContent(), Charset.defaultCharset())));
+    ScheduledFuture<?> cancelTask =
+        timeoutExecutor.schedule(
+            request::cancel, configuration.getTimeoutSeconds(), TimeUnit.SECONDS);
+    try {
+      return httpClient.execute(
+          request,
+          httpResponse ->
+              new SimpleResponse(
+                  httpResponse.getCode(),
+                  IOUtils.toString(
+                      httpResponse.getEntity().getContent(), Charset.defaultCharset())));
+    } finally {
+      cancelTask.cancel(false);
+    }
   }
 
   public HttpRequest buildGetRequest(GenericUrl genericUrl, AuthUser authUser) throws Exception {

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -79,6 +80,25 @@ class HttpClientUtilTest extends WireMockTestHelper {
     wireMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
     SimpleResponse response = clientUtil.getHttpResponse(new HttpGet(statusUrl));
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.code());
+  }
+
+  /** Test that repeated requests do not leak timeout threads. */
+  @Test
+  void testGetHttpResponseDoesNotLeakThreads() throws Exception {
+    wireMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
+    long before = countTimeoutThreads();
+    for (int i = 0; i < 25; i++) {
+      clientUtil.getHttpResponse(new HttpGet(statusUrl));
+    }
+    long growth = countTimeoutThreads() - before;
+    // The shared pool holds at most the default pool size of 10 threads.
+    assertTrue(growth <= 10, "Timeout thread count grew by " + growth);
+  }
+
+  private long countTimeoutThreads() {
+    return Thread.getAllStackTraces().keySet().stream()
+        .filter(t -> t.getName().startsWith("http-client-timeout"))
+        .count();
   }
 
   @Test


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-4013

## Summary

Fixes the burst of `java.lang.OutOfMemoryError: unable to create native thread` errors seen in production ([DT-4013](https://broadworkbench.atlassian.net/browse/DT-4013)).

`HttpClientUtil.getHttpResponse` created a new `ScheduledThreadPoolExecutor` on every call and never shut it down. Core threads in these pools never terminate, so each call leaked at least one native thread. Status probes run this method through the health checks, so the leak grew steadily. The process eventually hit its thread limit, every `Thread.start()` failed, and the errors continued until the pod restarted.

## Changes

- Create one shared timeout executor in the constructor. Its daemon threads are named `http-client-timeout` for thread dumps.
- Cancel each scheduled timeout task once its request completes, so stale tasks do not sit in the queue.
- Add a regression test that runs 25 requests and asserts the timeout thread count does not grow past the configured pool size.

The fix keeps the existing cancel-based timeout design. It caps total request time, and callers depend on the `RequestFailedException` that cancellation produces.

## Testing

- `HttpClientUtilTest`: 5 tests pass, including the new leak regression test.
- To confirm in production after deploy: pod thread-count metrics must stay flat instead of growing steadily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DT-4013]: https://broadworkbench.atlassian.net/browse/DT-4013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ