### PR TITLE
[DT-4014] Ensure response object shape from new endpoint can be parsed.

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/health/SendGridHealthCheckTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.consent.http.health;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -89,6 +90,35 @@ class SendGridHealthCheckTest {
 
     HealthCheck.Result result = healthCheck.check();
     assertFalse(result.isHealthy());
+  }
+
+  @Test
+  void testCheckDegradedServiceRealPayload() throws Exception {
+    String statusJson =
+        """
+        {
+          "page": {
+            "id": "test-id",
+            "name": "EmailsRUs",
+            "url": "https://status.example.com",
+            "time_zone": "America/Los_Angeles",
+            "updated_at": "2026-08-24T10:38:01.801-07:00"
+          },
+          "status": {
+            "indicator": "minor",
+            "description": "Partially Degraded Service"
+          }
+        }
+        """;
+    when(response.code()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+    when(response.entity()).thenReturn(statusJson);
+    when(clientUtil.getCachedResponse(any())).thenReturn(response);
+    when(mailConfiguration.getSendGridStatusUrl()).thenReturn("http://localhost:8000");
+    healthCheck = new SendGridHealthCheck(clientUtil, mailConfiguration);
+
+    HealthCheck.Result result = healthCheck.check();
+    assertFalse(result.isHealthy());
+    assertEquals("SendGrid status is unhealthy: Partially Degraded Service", result.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-4014](https://broadworkbench.atlassian.net/browse/DT-4014)

### Summary

Validates that the shape of the response from the new mail endpoint continues to operate as expected.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
