### PR TITLE
[DT-4030] Stop double-unescaping DAR data on read

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -7,7 +7,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.result.RowView;
@@ -105,25 +104,20 @@ public interface RowMapperHelper extends ConsentLogger {
     return false;
   }
 
-  static String unescapeJava(String value) {
-    return StringEscapeUtils.unescapeJava(StringEscapeUtils.unescapeJava(value));
-  }
-
+  /**
+   * Parses the column as Postgres returns it: {@code data} is jsonb, so it is valid JSON already.
+   * Unescaping it first turned an escaped quote in free text into a bare one and broke the parse.
+   */
   default DataAccessRequestData translate(String darDataString) {
-    DataAccessRequestData data = null;
-    if (Objects.nonNull(darDataString)) {
-      // Handle nested quotes
-      String quoteFixedDataString = darDataString.replace("\\\\\"", "'");
-      // Inserted json data ends up double-escaped via standard jdbi insert.
-      String escapedDataString = unescapeJava(quoteFixedDataString);
-      try {
-        data = DataAccessRequestData.fromString(escapedDataString);
-      } catch (JsonSyntaxException | NullPointerException e) {
-        logDebug("Unable to parse Data Access Request; error: %s".formatted(e.getMessage()));
-        throw e;
-      }
+    if (Objects.isNull(darDataString)) {
+      return null;
     }
-    return data;
+    try {
+      return DataAccessRequestData.fromString(darDataString);
+    } catch (JsonSyntaxException e) {
+      logDebug("Unable to parse Data Access Request; error: %s".formatted(e.getMessage()));
+      throw e;
+    }
   }
 
   default void setStringFieldValue(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -47,6 +47,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DataAccessRequestDAOTest extends DAOTestHelper {
 
+  /** Free text the read path used to destroy: once unescaped, the quote ended the string early. */
+  private static final String QUOTED_FREE_TEXT =
+      "PI said \"no resale\" applies; see C:\\temp\\notes.";
+
   private static DataAccessRequestData createDataAccessRequestData() {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
@@ -1693,6 +1697,61 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId, user.getUserId(), now, now, data);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
+  }
+
+  private String insertDarWithQuotedFreeText(Integer collectionId, Integer userId) {
+    DataAccessRequestData data = createDataAccessRequestData();
+    data.setRus(QUOTED_FREE_TEXT);
+    data.setNonTechRus(QUOTED_FREE_TEXT);
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collectionId, referenceId, userId, now, now, now, data, randomAlphabetic(10));
+    return referenceId;
+  }
+
+  @Test
+  void testFindByReferenceIdKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    DataAccessRequest found = dataAccessRequestDAO.findByReferenceId(referenceId);
+
+    assertNotNull(found);
+    assertEquals(QUOTED_FREE_TEXT, found.getData().getRus());
+    assertEquals(QUOTED_FREE_TEXT, found.getData().getNonTechRus());
+  }
+
+  @Test
+  void testFindByReferenceIdsKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    List<DataAccessRequest> found = dataAccessRequestDAO.findByReferenceIds(List.of(referenceId));
+
+    assertEquals(1, found.size());
+    assertEquals(QUOTED_FREE_TEXT, found.getFirst().getData().getRus());
+  }
+
+  /** Covers the row reducer, which parses the same column on its own path. */
+  @Test
+  void testFindDARCollectionByCollectionIdKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+
+    assertNotNull(collection);
+    assertEquals(QUOTED_FREE_TEXT, collection.getDars().get(referenceId).getData().getRus());
   }
 
   private Vote createFinalVote(Integer userId, Integer electionId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelperTest.java
@@ -1,0 +1,218 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonSyntaxException;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.jdbi.v3.core.result.RowView;
+import org.junit.jupiter.api.Test;
+
+class RowMapperHelperTest {
+
+  /** Free text the read path used to destroy: once unescaped, the quote ended the string early. */
+  private static final String QUOTED_FREE_TEXT =
+      "PI said \"no resale\" applies; see C:\\temp\\notes.";
+
+  private static final String COLUMN = "user_id";
+
+  private final RowMapperHelper helper = new RowMapperHelper() {};
+
+  private static ResultSet resultSetWithColumn(String columnName) throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+    when(resultSet.getMetaData()).thenReturn(metaData);
+    when(metaData.getColumnCount()).thenReturn(1);
+    when(metaData.getColumnName(1)).thenReturn(columnName);
+    return resultSet;
+  }
+
+  @Test
+  void testTranslateKeepsQuotedFreeText() {
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setRus(QUOTED_FREE_TEXT);
+    data.setNonTechRus(QUOTED_FREE_TEXT);
+
+    DataAccessRequestData parsed = helper.translate(data.toString());
+
+    assertEquals(QUOTED_FREE_TEXT, parsed.getRus());
+    assertEquals(QUOTED_FREE_TEXT, parsed.getNonTechRus());
+  }
+
+  @Test
+  void testTranslateReturnsNullWithoutAValue() {
+    assertNull(helper.translate(null));
+  }
+
+  @Test
+  void testTranslateRejectsMalformedJson() {
+    assertThrows(JsonSyntaxException.class, () -> helper.translate("{\"rus\": \"unterminated"));
+  }
+
+  @Test
+  void testHasColumnForRowView() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(1);
+    assertTrue(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasColumnForRowViewWithoutAValue() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(null);
+    assertFalse(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasColumnForRowViewWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenThrow(new IllegalArgumentException());
+    assertFalse(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowView() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(7);
+    assertTrue(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWithZero() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(0);
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWithoutAValue() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(null);
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenThrow(new IllegalArgumentException());
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasOptionalColumn() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, String.class)).thenReturn("value");
+    assertEquals(Optional.of("value"), helper.hasOptionalColumn(rowView, COLUMN, String.class));
+  }
+
+  @Test
+  void testHasOptionalColumnWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, String.class)).thenThrow(new IllegalArgumentException());
+    assertEquals(Optional.empty(), helper.hasOptionalColumn(rowView, COLUMN, String.class));
+  }
+
+  @Test
+  void testHasColumnForResultSetMatchesCaseInsensitively() throws SQLException {
+    assertTrue(helper.hasColumn(resultSetWithColumn("USER_ID"), COLUMN));
+  }
+
+  @Test
+  void testHasColumnForResultSetWhenTheColumnIsAbsent() throws SQLException {
+    assertFalse(helper.hasColumn(resultSetWithColumn("other"), COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSet() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(3);
+    assertTrue(helper.hasNonZeroColumn(resultSet, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSetWithZero() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(0);
+    assertFalse(helper.hasNonZeroColumn(resultSet, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSetWhenTheColumnIsAbsent() throws SQLException {
+    assertFalse(helper.hasNonZeroColumn(resultSetWithColumn("other"), COLUMN));
+  }
+
+  @Test
+  void testSetStringFieldValue() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getString(COLUMN)).thenReturn("value");
+    AtomicReference<String> set = new AtomicReference<>();
+
+    helper.setStringFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals("value", set.get());
+  }
+
+  @Test
+  void testSetStringFieldValueSkipsAnAbsentColumn() throws SQLException {
+    AtomicReference<String> set = new AtomicReference<>();
+
+    helper.setStringFieldValue(resultSetWithColumn("other"), COLUMN, set::set);
+
+    assertNull(set.get());
+  }
+
+  @Test
+  void testSetNonZeroFieldValue() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(9);
+    AtomicInteger set = new AtomicInteger();
+
+    helper.setNonZeroFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(9, set.get());
+  }
+
+  @Test
+  void testSetNonZeroFieldValueSkipsAZeroColumn() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(0);
+    AtomicInteger set = new AtomicInteger(-1);
+
+    helper.setNonZeroFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(-1, set.get());
+  }
+
+  @Test
+  void testSetDateFieldValue() throws SQLException {
+    java.sql.Date date = java.sql.Date.valueOf("2026-08-26");
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getDate(COLUMN)).thenReturn(date);
+    AtomicReference<Date> set = new AtomicReference<>();
+
+    helper.setDateFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(date, set.get());
+  }
+
+  @Test
+  void testSetDateFieldValueSkipsAnAbsentColumn() throws SQLException {
+    AtomicReference<Date> set = new AtomicReference<>();
+
+    helper.setDateFieldValue(resultSetWithColumn("other"), COLUMN, set::set);
+
+    assertNull(set.get());
+  }
+}


### PR DESCRIPTION
### Addresses

[DT-4030](https://broadworkbench.atlassian.net/browse/DT-4030). Surfaced by the [DT-3863](https://broadworkbench.atlassian.net/browse/DT-3863) recompute, not caused by it.

Security risk: low.

### Summary

`RowMapperHelper.translate` unescaped the JSON string Postgres returns before parsing it. `data_access_request.data` is `jsonb`, so that string is already valid JSON — unescaping turned an escaped quote in free text into a bare one, ending the string early. Any DAR whose research use statement contained a quote failed to deserialize, and one such DAR was enough to make `GET /api/dar/v2` return 400 for every admin and to make match recomputation skip datasets reachable only through it.

This parses the column as Postgres returns it. The write path needed no change — jdbi's `JsonArgumentFactory` bound to `::jsonb` already stores clean JSON, so the unescape could only damage data.

Two calls worth a reviewer's eye:

- The legacy repair is removed rather than kept behind a fallback. A fallback would be dead code: `jsonb` guarantees the raw value parses. Rows written double-escaped by the old path still parse; their text would show stray backslashes rather than failing. Cleaning those is a migration, and needs someone to confirm any still exist in prod.
- The carried-over `NullPointerException` catch is dropped as unreachable — Gson returns null for a JSON null, and `validateOntologyEntries` and `getOntologies` both null-guard.

No API contract change, so `api-docs.yaml` is untouched.

### Testing

`RowMapperHelper` at 100% instruction, branch, line and method coverage. Three DAO round-trips against real Postgres cover both parse paths, `DataAccessRequestMapper` and `DarCollectionReducer`; all three fail on the previous code with the production error verbatim. Nothing in the suite covered free text containing an escaped quote, which is why this survived.

Full suite: 4716 tests, 0 failures, 0 errors, 1 pre-existing skip. Spotless clean, synthetic data only, no `lenient()` stubbing.

### Follow-up

This unblocks DT-3863 step 4 but does not perform it. Dataset 1's stored matches still hold the pre-correction ABSTAIN, and nothing rebuilds them automatically: the record is canonical now, so `POST /api/datause/legacy/recomputeMatches` no longer treats it as a candidate.

Once this is on prod, an admin needs to:

1. Get the dataset's DAR reference ids. No endpoint returns this set: `GET /api/metrics/dar-summaries/{datasetId}` is the closest, but it counts approved collections only and collapses to one DAR per collection, which caps it at 7 of the 14. Query the database with the same filter `findDarReferenceIdsByDatasetId` uses (`./scripts/db-connect.sh prod`):

```sql
SELECT DISTINCT dd.reference_id
FROM dar_dataset dd
JOIN data_access_request dar ON dar.reference_id = dd.reference_id
WHERE dd.dataset_id = 1
  AND dar.submission_date IS NOT NULL
  AND (LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL);
```

2. Call `POST /api/match/reprocess/purpose/{referenceId}` once per reference id — 14 as of this writing — and check each returns 200. A 400 here means that DAR is still unreadable and this fix missed a case.
3. Confirm `GET /api/datause/legacy/noncanonical` still returns an empty list.

Skipping any reference id leaves that DAR on a stale abstain with nothing to flag it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-4030]: https://broadworkbench.atlassian.net/browse/DT-4030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3863]: https://broadworkbench.atlassian.net/browse/DT-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ