### PR TITLE
[DT-4030] Stop double-unescaping DAR data on read

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelper.java
@@ -7,7 +7,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.text.StringEscapeUtils;
 import org.broadinstitute.consent.http.models.DataAccessRequestData;
 import org.broadinstitute.consent.http.util.ConsentLogger;
 import org.jdbi.v3.core.result.RowView;
@@ -105,25 +104,20 @@ public interface RowMapperHelper extends ConsentLogger {
     return false;
   }
 
-  static String unescapeJava(String value) {
-    return StringEscapeUtils.unescapeJava(StringEscapeUtils.unescapeJava(value));
-  }
-
+  /**
+   * Parses the column as Postgres returns it: {@code data} is jsonb, so it is valid JSON already.
+   * Unescaping it first turned an escaped quote in free text into a bare one and broke the parse.
+   */
   default DataAccessRequestData translate(String darDataString) {
-    DataAccessRequestData data = null;
-    if (Objects.nonNull(darDataString)) {
-      // Handle nested quotes
-      String quoteFixedDataString = darDataString.replace("\\\\\"", "'");
-      // Inserted json data ends up double-escaped via standard jdbi insert.
-      String escapedDataString = unescapeJava(quoteFixedDataString);
-      try {
-        data = DataAccessRequestData.fromString(escapedDataString);
-      } catch (JsonSyntaxException | NullPointerException e) {
-        logDebug("Unable to parse Data Access Request; error: %s".formatted(e.getMessage()));
-        throw e;
-      }
+    if (Objects.isNull(darDataString)) {
+      return null;
     }
-    return data;
+    try {
+      return DataAccessRequestData.fromString(darDataString);
+    } catch (JsonSyntaxException e) {
+      logDebug("Unable to parse Data Access Request; error: %s".formatted(e.getMessage()));
+      throw e;
+    }
   }
 
   default void setStringFieldValue(

--- a/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DataAccessRequestDAOTest.java
@@ -47,6 +47,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DataAccessRequestDAOTest extends DAOTestHelper {
 
+  /** Free text the read path used to destroy: once unescaped, the quote ended the string early. */
+  private static final String QUOTED_FREE_TEXT =
+      "PI said \"no resale\" applies; see C:\\temp\\notes.";
+
   private static DataAccessRequestData createDataAccessRequestData() {
     DataAccessRequestData data = new DataAccessRequestData();
     data.setProjectTitle("Project Title: " + randomAlphabetic(50));
@@ -1693,6 +1697,61 @@ class DataAccessRequestDAOTest extends DAOTestHelper {
     dataAccessRequestDAO.insertDraftDataAccessRequest(
         referenceId, user.getUserId(), now, now, data);
     return dataAccessRequestDAO.findByReferenceId(referenceId);
+  }
+
+  private String insertDarWithQuotedFreeText(Integer collectionId, Integer userId) {
+    DataAccessRequestData data = createDataAccessRequestData();
+    data.setRus(QUOTED_FREE_TEXT);
+    data.setNonTechRus(QUOTED_FREE_TEXT);
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collectionId, referenceId, userId, now, now, now, data, randomAlphabetic(10));
+    return referenceId;
+  }
+
+  @Test
+  void testFindByReferenceIdKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    DataAccessRequest found = dataAccessRequestDAO.findByReferenceId(referenceId);
+
+    assertNotNull(found);
+    assertEquals(QUOTED_FREE_TEXT, found.getData().getRus());
+    assertEquals(QUOTED_FREE_TEXT, found.getData().getNonTechRus());
+  }
+
+  @Test
+  void testFindByReferenceIdsKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    List<DataAccessRequest> found = dataAccessRequestDAO.findByReferenceIds(List.of(referenceId));
+
+    assertEquals(1, found.size());
+    assertEquals(QUOTED_FREE_TEXT, found.getFirst().getData().getRus());
+  }
+
+  /** Covers the row reducer, which parses the same column on its own path. */
+  @Test
+  void testFindDARCollectionByCollectionIdKeepsQuotedFreeText() {
+    User user = createUserWithInstitution();
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(
+            "DAR-" + randomInt(1, 999999999), user.getUserId(), new Date());
+    String referenceId = insertDarWithQuotedFreeText(collectionId, user.getUserId());
+
+    DarCollection collection = darCollectionDAO.findDARCollectionByCollectionId(collectionId);
+
+    assertNotNull(collection);
+    assertEquals(QUOTED_FREE_TEXT, collection.getDars().get(referenceId).getData().getRus());
   }
 
   private Vote createFinalVote(Integer userId, Integer electionId) {

--- a/src/test/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelperTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/mapper/RowMapperHelperTest.java
@@ -1,0 +1,218 @@
+package org.broadinstitute.consent.http.db.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonSyntaxException;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.jdbi.v3.core.result.RowView;
+import org.junit.jupiter.api.Test;
+
+class RowMapperHelperTest {
+
+  /** Free text the read path used to destroy: once unescaped, the quote ended the string early. */
+  private static final String QUOTED_FREE_TEXT =
+      "PI said \"no resale\" applies; see C:\\temp\\notes.";
+
+  private static final String COLUMN = "user_id";
+
+  private final RowMapperHelper helper = new RowMapperHelper() {};
+
+  private static ResultSet resultSetWithColumn(String columnName) throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+    when(resultSet.getMetaData()).thenReturn(metaData);
+    when(metaData.getColumnCount()).thenReturn(1);
+    when(metaData.getColumnName(1)).thenReturn(columnName);
+    return resultSet;
+  }
+
+  @Test
+  void testTranslateKeepsQuotedFreeText() {
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setRus(QUOTED_FREE_TEXT);
+    data.setNonTechRus(QUOTED_FREE_TEXT);
+
+    DataAccessRequestData parsed = helper.translate(data.toString());
+
+    assertEquals(QUOTED_FREE_TEXT, parsed.getRus());
+    assertEquals(QUOTED_FREE_TEXT, parsed.getNonTechRus());
+  }
+
+  @Test
+  void testTranslateReturnsNullWithoutAValue() {
+    assertNull(helper.translate(null));
+  }
+
+  @Test
+  void testTranslateRejectsMalformedJson() {
+    assertThrows(JsonSyntaxException.class, () -> helper.translate("{\"rus\": \"unterminated"));
+  }
+
+  @Test
+  void testHasColumnForRowView() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(1);
+    assertTrue(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasColumnForRowViewWithoutAValue() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(null);
+    assertFalse(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasColumnForRowViewWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenThrow(new IllegalArgumentException());
+    assertFalse(helper.hasColumn(rowView, COLUMN, Integer.class));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowView() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(7);
+    assertTrue(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWithZero() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(0);
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWithoutAValue() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenReturn(null);
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForRowViewWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, Integer.class)).thenThrow(new IllegalArgumentException());
+    assertFalse(helper.hasNonZeroColumn(rowView, COLUMN));
+  }
+
+  @Test
+  void testHasOptionalColumn() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, String.class)).thenReturn("value");
+    assertEquals(Optional.of("value"), helper.hasOptionalColumn(rowView, COLUMN, String.class));
+  }
+
+  @Test
+  void testHasOptionalColumnWhenTheColumnIsAbsent() {
+    RowView rowView = mock(RowView.class);
+    when(rowView.getColumn(COLUMN, String.class)).thenThrow(new IllegalArgumentException());
+    assertEquals(Optional.empty(), helper.hasOptionalColumn(rowView, COLUMN, String.class));
+  }
+
+  @Test
+  void testHasColumnForResultSetMatchesCaseInsensitively() throws SQLException {
+    assertTrue(helper.hasColumn(resultSetWithColumn("USER_ID"), COLUMN));
+  }
+
+  @Test
+  void testHasColumnForResultSetWhenTheColumnIsAbsent() throws SQLException {
+    assertFalse(helper.hasColumn(resultSetWithColumn("other"), COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSet() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(3);
+    assertTrue(helper.hasNonZeroColumn(resultSet, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSetWithZero() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(0);
+    assertFalse(helper.hasNonZeroColumn(resultSet, COLUMN));
+  }
+
+  @Test
+  void testHasNonZeroColumnForResultSetWhenTheColumnIsAbsent() throws SQLException {
+    assertFalse(helper.hasNonZeroColumn(resultSetWithColumn("other"), COLUMN));
+  }
+
+  @Test
+  void testSetStringFieldValue() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getString(COLUMN)).thenReturn("value");
+    AtomicReference<String> set = new AtomicReference<>();
+
+    helper.setStringFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals("value", set.get());
+  }
+
+  @Test
+  void testSetStringFieldValueSkipsAnAbsentColumn() throws SQLException {
+    AtomicReference<String> set = new AtomicReference<>();
+
+    helper.setStringFieldValue(resultSetWithColumn("other"), COLUMN, set::set);
+
+    assertNull(set.get());
+  }
+
+  @Test
+  void testSetNonZeroFieldValue() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(9);
+    AtomicInteger set = new AtomicInteger();
+
+    helper.setNonZeroFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(9, set.get());
+  }
+
+  @Test
+  void testSetNonZeroFieldValueSkipsAZeroColumn() throws SQLException {
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getInt(COLUMN)).thenReturn(0);
+    AtomicInteger set = new AtomicInteger(-1);
+
+    helper.setNonZeroFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(-1, set.get());
+  }
+
+  @Test
+  void testSetDateFieldValue() throws SQLException {
+    java.sql.Date date = java.sql.Date.valueOf("2026-08-26");
+    ResultSet resultSet = resultSetWithColumn(COLUMN);
+    when(resultSet.getDate(COLUMN)).thenReturn(date);
+    AtomicReference<Date> set = new AtomicReference<>();
+
+    helper.setDateFieldValue(resultSet, COLUMN, set::set);
+
+    assertEquals(date, set.get());
+  }
+
+  @Test
+  void testSetDateFieldValueSkipsAnAbsentColumn() throws SQLException {
+    AtomicReference<Date> set = new AtomicReference<>();
+
+    helper.setDateFieldValue(resultSetWithColumn("other"), COLUMN, set::set);
+
+    assertNull(set.get());
+  }
+}


### PR DESCRIPTION
### Addresses

[DT-4030](https://broadworkbench.atlassian.net/browse/DT-4030). Surfaced by the [DT-3863](https://broadworkbench.atlassian.net/browse/DT-3863) recompute, not caused by it. Supersedes #3035, which GitHub never dispatched any Actions run for.

Security risk: low.

### Summary

`RowMapperHelper.translate` unescaped the JSON string Postgres returns before parsing it. `data_access_request.data` is `jsonb`, so that string is already valid JSON — unescaping it turned an escaped quote in free text into a bare one, ending the string early and leaving the object unterminated.

This parses the column as Postgres returns it. The write path needed no change: jdbi's `JsonArgumentFactory` bound to `::jsonb` already stores clean JSON, so the unescape could only ever damage data.

### Confirmed against prod

- **One DAR is unreadable.** `5b3b585fc3da7a0001352d53` fails with `MalformedJsonException: Unterminated object at line 3 column 292 path $.rus`. That single record also makes `GET /api/dar/v2` return 400 for every admin, and is why dataset 1 was the one failure when DT-3863's recompute ran.
- **One DAR is silently altered.** `c02b1671-84c6-43bb-aae7-29f25125df8f` stores a literal `\t` in three collaborator fields, which `unescapeJava` decoded to a tab on every read. The backslash is still in the database, so it has never been written back — but a save following a corrupted read would have persisted the tab. Read-only damage today, data loss on the next edit.
- **The stored data was never at fault.** The unreadable row's `rus` is valid `jsonb` holding a quote and a newline, and no row in the table carries the double-escape fingerprint (`\"` surviving into a decoded value).

### Review notes

- The legacy repair is removed rather than kept behind a fallback. No double-escaped rows survive, so no compensating migration is owed, and `jsonb` guarantees the raw value parses — a fallback would be dead code.
- The carried-over `NullPointerException` catch is dropped as unreachable: Gson returns null for a JSON null, and both `validateOntologyEntries` and `getOntologies` null-guard.

No API contract change, so `api-docs.yaml` is untouched.

### After deployment

Merging deploys to dev only; staging and prod are separate Sherlock promotions.

**dev and staging — one call each:** `POST /api/datause/legacy/recomputeMatches`. It re-reads every abstaining dataset reachable by a DAR, so `run.failed` measures the fix directly: 10 → 0 in dev, 18 → 0 in staging.

The dev figure is measured rather than predicted. Run against a dev database snapshot, same snapshot and same call with only the read path differing: `develop` returned `failed: 10` on the same ten dataset ids live dev reports, the fix returned `failed: 0` and rebuilt 510 DARs against 435. A remaining failure has a different cause and is worth reporting rather than retrying — this class never recovers on a rerun.

**prod — DT-3863 step 4:** thirteen of dataset 1's fourteen DARs have already been reprocessed under the corrected `SINGLE(HMB)`. The fourteenth, `5b3b585fc3da7a0001352d53`, returns 400 until this ships — afterwards a single `POST /api/match/reprocess/purpose/5b3b585fc3da7a0001352d53` completes step 4. The rebuilt matches should come back non-abstaining; V5 abstained on the old `MULTIPLE(HMB,OTHER)` shape, so a row still abstaining would mean something other than the Data Use is responsible.

`recomputeMatches` is not re-run in prod: the correction made dataset 1 canonical, so it is no longer a candidate.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-4030]: https://broadworkbench.atlassian.net/browse/DT-4030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3863]: https://broadworkbench.atlassian.net/browse/DT-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ