### PR TITLE
[DT-4010] Fix mutable state and mislabelled defaults in the match algorithm version

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
+++ b/src/main/java/org/broadinstitute/consent/http/enumeration/MatchAlgorithm.java
@@ -7,7 +7,7 @@ public enum MatchAlgorithm {
   V4("v4"),
   V5("v5");
 
-  String version;
+  private final String version;
 
   MatchAlgorithm(String version) {
     this.version = version;
@@ -15,9 +15,5 @@ public enum MatchAlgorithm {
 
   public String getVersion() {
     return version;
-  }
-
-  public void setVersion(String version) {
-    this.version = version;
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -153,18 +153,9 @@ public class Match {
     }
   }
 
-  public static Match matchFailure(String consentId, String purposeId, List<String> rationales) {
-    return new Match(consentId, purposeId, false, false, true, MatchAlgorithm.V4, rationales);
-  }
-
   public static Match matchFailure(
       String consentId, String purposeId, MatchAlgorithm algorithm, List<String> rationales) {
     return new Match(consentId, purposeId, false, false, true, algorithm, rationales);
-  }
-
-  public static Match matchSuccess(
-      String consentId, String purposeId, DataUseMatchResultType match, List<String> rationales) {
-    return matchSuccess(consentId, purposeId, match, MatchAlgorithm.V4, rationales);
   }
 
   public static Match matchSuccess(


### PR DESCRIPTION
### Addresses

[DT-4010](https://broadworkbench.atlassian.net/browse/DT-4010). Two defects found while reviewing [DT-3866](https://broadworkbench.atlassian.net/browse/DT-3866). Gated on nothing, so it ships ahead of [DT-4009](https://broadworkbench.atlassian.net/browse/DT-4009), which waits on the production legacy Data Use run.

Security risk: no.

### Summary

`MatchAlgorithm.version` was package-private and non-final with a public `setVersion`. Enum constants are JVM-wide singletons, so one `setVersion` call anywhere would have changed the version stamped on every subsequent match row for the life of the process. The field is now private and final and the setter is gone. Nothing called it.

The three-argument `matchFailure` and four-argument `matchSuccess` defaulted to `MatchAlgorithm.V4`. Neither had a caller in main or test — `MatchService` passes `V5` explicitly at both sites, and `MatchServiceTest` builds its fixture through the constructor with an explicit version string. A future caller would have stamped `v4` on a row produced by V5 logic. Both are deleted; the explicit-algorithm overloads already cover every real use, and no call site needed changing to make that possible.

### Review notes

`V1` through `V3` stay declared. Production still holds `v1` and `v2` rows — the premise of [DT-4008](https://broadworkbench.atlassian.net/browse/DT-4008) — and duos-ui matches on those literals. Nothing maps a persisted string back to the enum since `MatchReducer` reads it raw, so the constants carry no behaviour: they are the only in-code record of the vocabulary the data uses, and `MatchDAOTest` uses `V1` as its legacy-row fixture. They come out with the data, if ever.

`DataUseMatcherV4` also stays. `DataUseMatcherV5` delegates to it for the actual match once it has decided not to abstain, so despite the name it is live code, not a legacy version.

No API contract change, so `api-docs.yaml` is untouched — `MatchAlgorithm` is never serialized, and the `algorithmVersion` string field on `MatchResult.yaml` is unaffected.

No test changes: nothing referenced the deleted symbols, and both `MatchServiceTest` and `MatchDAOTest` use only `getVersion()`, which stays.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4010]: https://broadworkbench.atlassian.net/browse/DT-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3866]: https://broadworkbench.atlassian.net/browse/DT-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-4009]: https://broadworkbench.atlassian.net/browse/DT-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-4008]: https://broadworkbench.atlassian.net/browse/DT-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ