### PR TITLE
[DT-3873] Assert data submitters cannot read another user's draft

### DIFF
--- a/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/dao/DraftServiceDAOTest.java
@@ -198,6 +198,28 @@ class DraftServiceDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testDataSubmitterCannotReadAnotherUsersDraft() throws SQLException {
+    // The validation endpoint admits data submitters too, so this is asserted, not assumed.
+    User owner = createUser();
+    User dataSubmitter = createUserWithRole(UserRoles.DATASUBMITTER.getRoleId());
+    UUID draftUUID = createDraft(owner, 1).getUUID();
+
+    assertThrows(
+        NotAuthorizedException.class,
+        () -> draftServiceDAO.getAuthorizedDraft(draftUUID, dataSubmitter));
+  }
+
+  @Test
+  void testDataSubmitterCanReadTheirOwnDraft() throws SQLException {
+    User dataSubmitter = createUserWithRole(UserRoles.DATASUBMITTER.getRoleId());
+    DraftInterface draft = createDraft(dataSubmitter, 1);
+
+    assertEquals(
+        draft.getUUID(),
+        draftServiceDAO.getAuthorizedDraft(draft.getUUID(), dataSubmitter).getUUID());
+  }
+
+  @Test
   void testDeleteDraft() throws Exception {
     User user = createUser();
     createDraft(user, 3);


### PR DESCRIPTION
### Addresses

[DT-3873](https://broadworkbench.atlassian.net/browse/DT-3873).

Security risk: no. Test-only.

### Summary

Draft ownership was asserted for chairpersons only. The template-validation endpoint admits data submitters as well, so a template draft is reachable by that role and the case is worth asserting rather than inferring from the chairperson pair.

Adds the matching pair to `DraftServiceDAOTest`: a data submitter cannot read another user's draft, and can read their own.

### Also verified, no change

Nothing on the template path logs uploaded content — the `studytemplate` package, `DraftService`, and `DraftServiceDAO` have no log statements, and the one exception it throws carries a fixed constant.

`@Timed` gives latency and throughput but does not separate success from failure. `@ResponseMetered` would, but no resource in consent uses it, so adding it to one endpoint alone was left out of this PR. Recorded on the ticket as a repo-wide question.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-3873]: https://broadworkbench.atlassian.net/browse/DT-3873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ