### PR TITLE
[DT-4036] Close liquibase startup connections

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -250,8 +250,8 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
   }
 
   private void initializeLiquibase(ConsentConfiguration config) throws LiquibaseException {
-    // Disable Liquibase's System.out logging.
-    // See https://github.com/liquibase/liquibase/issues/2396 for more info
+    // Route Liquibase UI output through LoggerUIService instead of writing to System.out.
+    // See https://github.com/liquibase/liquibase/issues/2396 for more info.
     try {
       Scope.child(
           Scope.Attr.ui,

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -142,7 +142,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     try {
       initializeLiquibase(config);
     } catch (LiquibaseException e) {
-      LOGGER.error(MessageFormat.format("Exception initializing liquibase: {0}", e));
+      LOGGER.error("Exception initializing liquibase", e);
     }
 
     final Injector injector = Guice.createInjector(new ConsentModule(config, env));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -16,10 +16,8 @@ import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.jdbi3.bundles.JdbiExceptionsBundle;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
-import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +32,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.ui.LoggerUIService;
-import liquibase.util.SmartMap;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.consent.http.authentication.AuthorizationHelper;
 import org.broadinstitute.consent.http.authentication.DuosUserAuthenticator;
@@ -144,7 +141,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
 
     try {
       initializeLiquibase(config);
-    } catch (LiquibaseException | SQLException e) {
+    } catch (LiquibaseException e) {
       LOGGER.error(MessageFormat.format("Exception initializing liquibase: {0}", e));
     }
 
@@ -252,28 +249,32 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     bootstrap.addBundle(new JdbiExceptionsBundle());
   }
 
-  private void initializeLiquibase(ConsentConfiguration config)
-      throws LiquibaseException, SQLException {
+  private void initializeLiquibase(ConsentConfiguration config) throws LiquibaseException {
     // Disable Liquibase's System.out logging.
     // See https://github.com/liquibase/liquibase/issues/2396 for more info
     try {
-      Field field = Scope.getCurrentScope().getClass().getDeclaredField("values");
-      field.setAccessible(true);
-      SmartMap values = ((SmartMap) field.get(Scope.getCurrentScope()));
-      values.set("ui", new LoggerUIService());
-    } catch (IllegalAccessException | NoSuchFieldException ignored) {
+      Scope.child(
+          Scope.Attr.ui,
+          new LoggerUIService(),
+          () -> {
+            try (Connection connection =
+                DriverManager.getConnection(
+                    config.getDataSourceFactory().getUrl(),
+                    config.getDataSourceFactory().getUser(),
+                    config.getDataSourceFactory().getPassword())) {
+              Database database =
+                  DatabaseFactory.getInstance()
+                      .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+              Liquibase liquibase =
+                  new Liquibase(liquibaseFile(), new ClassLoaderResourceAccessor(), database);
+              liquibase.update(new Contexts(), new LabelExpression());
+            }
+          });
+    } catch (LiquibaseException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new LiquibaseException("Unable to initialize Liquibase.", e);
     }
-    Connection connection =
-        DriverManager.getConnection(
-            config.getDataSourceFactory().getUrl(),
-            config.getDataSourceFactory().getUser(),
-            config.getDataSourceFactory().getPassword());
-    Database database =
-        DatabaseFactory.getInstance()
-            .findCorrectDatabaseImplementation(new JdbcConnection(connection));
-    Liquibase liquibase =
-        new Liquibase(liquibaseFile(), new ClassLoaderResourceAccessor(), database);
-    liquibase.update(new Contexts(), new LabelExpression());
   }
 
   private String liquibaseFile() {

--- a/src/test/java/org/broadinstitute/consent/http/ConsentApplicationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentApplicationTest.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.consent.http;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.dropwizard.db.DataSourceFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.exception.LiquibaseException;
+import org.broadinstitute.consent.http.configurations.ConsentConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConsentApplicationTest {
+
+  private static final String URL = "jdbc:postgresql://localhost:5432/consent";
+  private static final String USER = "consent";
+  private static final String PASSWORD = "password";
+
+  private final ConsentApplication consentApplication = new ConsentApplication();
+
+  @Mock private ConsentConfiguration configuration;
+  @Mock private DataSourceFactory dataSourceFactory;
+  @Mock private Connection connection;
+  @Mock private DatabaseFactory databaseFactory;
+  @Mock private Database database;
+
+  @BeforeEach
+  void setUp() {
+    when(configuration.getDataSourceFactory()).thenReturn(dataSourceFactory);
+    when(dataSourceFactory.getUrl()).thenReturn(URL);
+    when(dataSourceFactory.getUser()).thenReturn(USER);
+    when(dataSourceFactory.getPassword()).thenReturn(PASSWORD);
+  }
+
+  @Test
+  void initializeLiquibaseClosesConnectionAfterSuccessfulUpdate() throws Exception {
+    try (var mockedDriverManager = mockStatic(DriverManager.class);
+        var mockedDatabaseFactory = mockStatic(DatabaseFactory.class);
+        var mockedLiquibase = mockConstruction(Liquibase.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(URL, USER, PASSWORD))
+          .thenReturn(connection);
+      mockedDatabaseFactory.when(DatabaseFactory::getInstance).thenReturn(databaseFactory);
+      when(databaseFactory.findCorrectDatabaseImplementation(any())).thenReturn(database);
+
+      invokeInitializeLiquibase(configuration);
+
+      verify(mockedLiquibase.constructed().getFirst())
+          .update(any(Contexts.class), any(LabelExpression.class));
+      verify(connection).close();
+    }
+  }
+
+  @Test
+  void initializeLiquibaseClosesConnectionWhenUpdateFails() throws Exception {
+    LiquibaseException liquibaseException = new LiquibaseException("update failed");
+
+    try (var mockedDriverManager = mockStatic(DriverManager.class);
+        var mockedDatabaseFactory = mockStatic(DatabaseFactory.class);
+        var mockedLiquibase =
+            mockConstruction(
+                Liquibase.class,
+                (mock, context) -> {
+                  context.arguments();
+                  doThrow(liquibaseException)
+                      .when(mock)
+                      .update(any(Contexts.class), any(LabelExpression.class));
+                })) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(URL, USER, PASSWORD))
+          .thenReturn(connection);
+      mockedDatabaseFactory.when(DatabaseFactory::getInstance).thenReturn(databaseFactory);
+      when(databaseFactory.findCorrectDatabaseImplementation(any())).thenReturn(database);
+
+      LiquibaseException thrown =
+          assertThrows(LiquibaseException.class, () -> invokeInitializeLiquibase(configuration));
+
+      assertSame(liquibaseException, thrown);
+      verify(mockedLiquibase.constructed().getFirst())
+          .update(any(Contexts.class), any(LabelExpression.class));
+      verify(connection).close();
+    }
+  }
+
+  private void invokeInitializeLiquibase(ConsentConfiguration configuration) throws Exception {
+    Method method =
+        ConsentApplication.class.getDeclaredMethod(
+            "initializeLiquibase", ConsentConfiguration.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(consentApplication, configuration);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception exception) {
+        throw exception;
+      }
+      if (cause instanceof Error error) {
+        throw error;
+      }
+      throw new RuntimeException(cause);
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/ConsentApplicationTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/ConsentApplicationTest.java
@@ -79,7 +79,6 @@ class ConsentApplicationTest {
             mockConstruction(
                 Liquibase.class,
                 (mock, context) -> {
-                  context.arguments();
                   doThrow(liquibaseException)
                       .when(mock)
                       .update(any(Contexts.class), any(LabelExpression.class));


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-4036

### Summary
Closes a hole in application startup. When a new pod runs in a deployed environment, liquibase has already been run so there are no changesets to run. This is not true for local development. This PR closes the connections that liquibase consumes and returns them to the pool. Discovered while investigating https://broadworkbench.atlassian.net/browse/DT-4033

Additionally, adds a new set of tests for the main application covering the new work.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
