### PR TITLE
Refactoring queries to reduce reliance on large cartesian products.

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DarCollectionSummaryDAO.java
@@ -23,6 +23,37 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
   @UseRowReducer(DarCollectionSummaryReducer.class)
   @SqlQuery(
       """
+      -- The main query walks latest_dar -> dar_dataset -> dac_datasets as a chain. Joining the
+      -- DAC's datasets directly to the collections (with the dataset/DAR link left for the WHERE
+      -- clause) crossed every DAC dataset with every collection before that link applied - a
+      -- cartesian product the planner cannot avoid here, since this query joins more relations
+      -- than join_collapse_limit and its jsonb/LOWER() predicates defeat row estimation.
+      WITH dac_datasets AS (
+        -- Datasets overseen by the DACs where the user holds this role.
+        SELECT DISTINCT d.dataset_id, dac.name AS dac_name
+        FROM user_role ur
+        INNER JOIN users dacUser ON dacUser.user_id = ur.user_id
+        INNER JOIN dac ON dac.dac_id = ur.dac_id AND dac.deleted IS NOT TRUE
+        INNER JOIN dataset d ON d.dac_id = dac.dac_id
+        WHERE ur.user_id = :currentUserId AND ur.role_id = :roleId AND ur.dac_id IS NOT NULL
+      ),
+      -- The most recent non-archived submission per collection
+      latest_dar AS (
+        SELECT DISTINCT ON (collection_id) *
+        FROM data_access_request
+        WHERE submission_date IS NOT NULL
+        AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
+        ORDER BY collection_id, submission_date DESC
+      ),
+      -- All non-archived submitted DARs per collection, pre-aggregated so the main query
+      -- does not need to fan out per DAR and re-collapse with a GROUP BY.
+      collection_reference_ids AS (
+        SELECT collection_id, ARRAY_AGG(reference_id) AS reference_ids
+        FROM data_access_request
+        WHERE submission_date IS NOT NULL
+        AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
+        GROUP BY collection_id
+      )
       SELECT c.collection_id as dar_collection_id, c.dar_code,
         latest_dar.submission_date, latest_dar.reference_id as latest_dar_reference_id,
         latest_dar.parent_id as latest_dar_parent_id,
@@ -37,37 +68,23 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         latest_dar.data ->> 'projectTitle' AS name,
         latest_dar.data ->> 'status' AS dar_status,
         latest_dar.data ->> 'closeoutSupplement' AS closeout,
-        dac.name AS dac_name,
-        ARRAY_AGG(dar_all.reference_id) AS reference_ids
-      FROM dar_collection c
+        d.dac_name AS dac_name,
+        cri.reference_ids AS reference_ids
+      FROM latest_dar
+      -- Restrict DARs to the datasets available to the DAC User
+      INNER JOIN dar_dataset dd
+        ON dd.reference_id = latest_dar.reference_id
+      INNER JOIN dac_datasets d
+        ON d.dataset_id = dd.dataset_id
+      INNER JOIN dar_collection c
+        ON c.collection_id = latest_dar.collection_id
       -- DAR Collection Researcher join
       INNER JOIN users researcher
         ON researcher.user_id = c.create_user_id
       LEFT JOIN institution i
         ON i.institution_id = researcher.institution_id
-      -- DAC User join
-      INNER JOIN users dacUser
-        ON dacUser.user_id = :currentUserId
-      INNER JOIN user_role ur
-        ON dacUser.user_id = ur.user_id AND ur.role_id = :roleId AND ur.dac_id IS NOT NULL
-      INNER JOIN dac dac
-        ON ur.dac_id = dac.dac_id AND dac.deleted IS NOT TRUE
-      -- Datasets available to DAC
-      INNER JOIN dataset d
-        ON d.dac_id = dac.dac_id
-      -- Restrict DARs to the most recent submission per collection
-      INNER JOIN (
-        SELECT DISTINCT ON (collection_id) *
-        FROM data_access_request
-        WHERE submission_date IS NOT NULL
-        AND (LOWER(data->>'status') != 'archived' OR data->>'status' IS NULL)
-        ORDER BY collection_id, submission_date DESC
-        ) latest_dar ON latest_dar.collection_id = c.collection_id
-      -- All DARs for the collection
-      INNER JOIN data_access_request dar_all
-        ON dar_all.collection_id = c.collection_id
-        AND dar_all.submission_date IS NOT NULL
-        AND (LOWER(dar_all.data->>'status') != 'archived' OR dar_all.data->>'status' IS NULL)
+      INNER JOIN collection_reference_ids cri
+        ON cri.collection_id = c.collection_id
       -- Most recent terminal or active Data Access Elections for DAC User datasets
       LEFT JOIN (
         SELECT election.*, MAX(election.election_id) OVER(PARTITION BY election.reference_id, election.dataset_id) AS latest
@@ -76,21 +93,12 @@ public interface DarCollectionSummaryDAO extends Transactional<DarCollectionSumm
         AND LOWER(election.status) IN ('open', 'closed', 'canceled')
       ) AS e
         ON e.reference_id = latest_dar.reference_id
-        AND e.dataset_id = d.dataset_id
+        AND e.dataset_id = dd.dataset_id
+        AND e.latest = e.election_id
       -- Votes for DAC User
       LEFT JOIN vote v
         ON e.election_id = v.election_id
         AND (LOWER(v.type) IN ('final', 'radar_approve') OR v.user_id = :currentUserId)
-      -- Restrict DARs to the datasets available to the DAC User
-      INNER JOIN dar_dataset dd
-        ON latest_dar.reference_id = dd.reference_id
-      WHERE dd.dataset_id = d.dataset_id
-        AND (e.latest = e.election_id OR e.election_id IS NULL)
-      GROUP BY
-        c.collection_id, c.dar_code, latest_dar.submission_date, latest_dar.reference_id, latest_dar.parent_id,
-        latest_dar.requires_so_approval, latest_dar.approving_so_id, latest_dar.approving_so_timestamp, researcher.display_name, i.institution_name,
-        e.election_id, e.status, e.reference_id, e.dataset_id, v.vote_id, dd.dataset_id, v.user_id,
-        v.vote, v.election_id, v.create_date, v.update_date, v.type, latest_dar.data, dac.name
       """)
   List<DarCollectionSummary> getDarCollectionSummariesForDACRole(
       @Bind("currentUserId") Integer currentUserId, @Bind("roleId") Integer roleId);

--- a/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/DatasetDAO.java
@@ -14,15 +14,18 @@ import org.broadinstitute.consent.http.db.mapper.DatasetReducer;
 import org.broadinstitute.consent.http.db.mapper.DatasetStudySummaryMapper;
 import org.broadinstitute.consent.http.db.mapper.DictionaryMapper;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
+import org.broadinstitute.consent.http.enumeration.FileCategory;
 import org.broadinstitute.consent.http.models.ApprovedDataset;
 import org.broadinstitute.consent.http.models.Dataset;
 import org.broadinstitute.consent.http.models.DatasetAudit;
 import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.DatasetStudySummary;
 import org.broadinstitute.consent.http.models.Dictionary;
+import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.resources.Resource;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -52,43 +55,13 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
    * @param datasetId The dataset id
    * @return Dataset
    */
-  @UseRowReducer(DatasetReducer.class)
-  @SqlQuery(
-      """
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              d.study_id, d.indexed_date,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.pi_email AS s_pi_email,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type
-      FROM dataset d
-      LEFT JOIN users u on d.create_user_id = u.user_id
-      LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-      LEFT JOIN dictionary k ON k.key_id = dp.property_key
-      LEFT JOIN study s ON s.study_id = d.study_id
-      LEFT JOIN study_property sp ON sp.study_id = s.study_id
-      LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-      WHERE d.dataset_id = :datasetId
-      """)
-  Dataset findDatasetWithoutFSOInformation(@Bind("datasetId") Integer datasetId);
+  default Dataset findDatasetWithoutFSOInformation(Integer datasetId) {
+    if (isInTransaction()) {
+      return assembleDataset(this, datasetId, false);
+    }
+    return inTransaction(
+        TransactionIsolationLevel.REPEATABLE_READ, dao -> assembleDataset(dao, datasetId, false));
+  }
 
   /**
    * Find a minimal version of a Dataset by alias. This query excludes file and study information
@@ -161,57 +134,21 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
       @Bind("updateUserId") Integer updateUserId,
       @Bind("dacId") Integer updatedDacId);
 
-  @UseRowReducer(DatasetReducer.class)
-  @SqlQuery(
-      """
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              fso.file_storage_object_id AS fso_file_storage_object_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.pi_email AS s_pi_email,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-              fso.entity_id AS fso_entity_id,
-              fso.file_name AS fso_file_name,
-              fso.category AS fso_category,
-              fso.gcs_file_uri AS fso_gcs_file_uri,
-              fso.media_type AS fso_media_type,
-              fso.create_date AS fso_create_date,
-              fso.create_user_id AS fso_create_user_id,
-              fso.update_date AS fso_update_date,
-              fso.update_user_id AS fso_update_user_id,
-              fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
-          FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
-          LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-          LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          WHERE d.dataset_id = :datasetId
-      """)
-  Dataset findDatasetById(@Bind("datasetId") Integer datasetId);
+  /**
+   * Finds a fully populated dataset without joining all child collections into one Cartesian
+   * product. The focused reads run in a single REPEATABLE READ transaction so that they all observe
+   * the same snapshot; under the default READ COMMITTED level each statement would take its own
+   * snapshot and the assembled dataset could mix pre- and post-commit state.
+   */
+  default Dataset findDatasetById(Integer datasetId) {
+    // A handle that is already in a transaction cannot open a nested one at a different
+    // isolation level, so reuse the transaction the caller established rather than failing.
+    if (isInTransaction()) {
+      return assembleDataset(this, datasetId, true);
+    }
+    return inTransaction(
+        TransactionIsolationLevel.REPEATABLE_READ, dao -> assembleDataset(dao, datasetId, true));
+  }
 
   /**
    * Return a list of Dataset objects from a list of dataset ids. This explicitly does NOT populate
@@ -241,19 +178,35 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.update_date AS fso_update_date,
               fso.update_user_id AS fso_update_user_id,
               fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
+              fso.delete_user_id AS fso_delete_user_id,
+              fso.delete_date AS fso_delete_date
           FROM dataset d
           LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+          LEFT JOIN LATERAL (
+              SELECT *
+              FROM file_storage_object
+              WHERE entity_id = d.dataset_id::text
+                  AND deleted = false
+                  AND category = :fileCategory
+              ORDER BY GREATEST(create_date, update_date, delete_date) DESC,
+                  file_storage_object_id DESC
+              LIMIT 1
+          ) fso ON true
           WHERE d.dataset_id in (<datasetIds>)
           ORDER BY d.dataset_id
       """)
-  List<Dataset> findDatasetsByIdList(
+  List<Dataset> findDatasetsByIdListAndFileCategory(
       @BindList(value = "datasetIds", onEmpty = EmptyHandling.NULL_STRING)
-          Collection<Integer> datasetIds);
+          Collection<Integer> datasetIds,
+      @Bind("fileCategory") String fileCategory);
+
+  default List<Dataset> findDatasetsByIdList(Collection<Integer> datasetIds) {
+    return findDatasetsByIdListAndFileCategory(
+        datasetIds, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue());
+  }
 
   @SqlQuery(
       """
@@ -339,54 +292,142 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
   @UseRowReducer(DatasetReducer.class)
   @SqlQuery(
       """
-          SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
-              d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use, d.dac_approval,
-              dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
-              u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
-              u.create_date AS u_create_date, u.email_preference AS u_email_preference,
-              u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
-              k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property, dp.property_id,
-              s.study_id AS s_study_id,
-              s.name AS s_name,
-              s.description AS s_description,
-              s.data_types AS s_data_types,
-              s.pi_name AS s_pi_name,
-              s.pi_email AS s_pi_email,
-              s.create_user_id AS s_create_user_id,
-              s.create_date AS s_create_date,
-              s.update_user_id AS s_user_id,
-              s.update_date AS s_update_date,
-              s.public_visibility AS s_public_visibility,
-              s_dataset.dataset_id AS s_dataset_id,
-              sp.study_property_id AS sp_study_property_id,
-              sp.study_id AS sp_study_id,
-              sp.key AS sp_key,
-              sp.value AS sp_value,
-              sp.type AS sp_type,
-              fso.file_storage_object_id AS fso_file_storage_object_id,
-              fso.entity_id AS fso_entity_id,
-              fso.file_name AS fso_file_name,
-              fso.category AS fso_category,
-              fso.gcs_file_uri AS fso_gcs_file_uri,
-              fso.media_type AS fso_media_type,
-              fso.create_date AS fso_create_date,
-              fso.create_user_id AS fso_create_user_id,
-              fso.update_date AS fso_update_date,
-              fso.update_user_id AS fso_update_user_id,
-              fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
-          FROM dataset d
-          LEFT JOIN users u on d.create_user_id = u.user_id
-          LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
-          LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
-          LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN study s ON s.study_id = d.study_id
-          LEFT JOIN study_property sp ON sp.study_id = s.study_id
-          LEFT JOIN dataset s_dataset ON s_dataset.study_id = s.study_id
-          LEFT JOIN file_storage_object fso ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text) AND fso.deleted = false
-          WHERE d.alias = :alias
+      SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+          d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
+          d.dac_approval, dar_ds_ids.id AS in_use, d.study_id, d.indexed_date,
+          u.user_id AS u_user_id, u.email AS u_email, u.display_name AS u_display_name,
+          u.create_date AS u_create_date, u.email_preference AS u_email_preference,
+          u.institution_id AS u_institution_id, u.era_commons_id AS u_era_commons_id,
+          k.key, dp.property_value, dp.property_key, dp.property_type, dp.schema_property,
+          dp.property_id
+      FROM dataset d
+      LEFT JOIN users u ON d.create_user_id = u.user_id
+      LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids
+          ON dar_ds_ids.id = d.dataset_id
+      LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
+      LEFT JOIN dictionary k ON k.key_id = dp.property_key
+      WHERE d.dataset_id = :datasetId
       """)
-  Dataset findDatasetByAlias(@Bind("alias") Integer alias);
+  Dataset findDatasetDetailsById(@Bind("datasetId") Integer datasetId);
+
+  @UseRowReducer(DatasetReducer.class)
+  @SqlQuery(
+      """
+      SELECT d.dataset_id, d.name, d.create_date, d.create_user_id, d.update_date,
+          d.update_user_id, d.object_id, d.dac_id, d.alias, d.data_use, d.translated_data_use,
+          d.dac_approval, d.study_id, d.indexed_date,
+          s.study_id AS s_study_id,
+          s.name AS s_name,
+          s.description AS s_description,
+          s.data_types AS s_data_types,
+          s.pi_name AS s_pi_name,
+          s.pi_email AS s_pi_email,
+          s.create_user_id AS s_create_user_id,
+          s.create_date AS s_create_date,
+          s.update_user_id AS s_update_user_id,
+          s.update_date AS s_update_date,
+          s.public_visibility AS s_public_visibility,
+          s.uuid AS s_uuid,
+          sp.study_property_id AS sp_study_property_id,
+          sp.study_id AS sp_study_id,
+          sp.key AS sp_key,
+          sp.value AS sp_value,
+          sp.type AS sp_type
+      FROM dataset d
+      LEFT JOIN study s ON s.study_id = d.study_id
+      LEFT JOIN study_property sp ON sp.study_id = s.study_id
+      WHERE d.dataset_id = :datasetId
+      """)
+  Dataset findDatasetStudyById(@Bind("datasetId") Integer datasetId);
+
+  @SqlQuery("SELECT dataset_id FROM dataset WHERE study_id = :studyId")
+  List<Integer> findDatasetIdsByStudyId(@Bind("studyId") Integer studyId);
+
+  @SqlQuery(
+      """
+      SELECT
+          fso.file_storage_object_id AS fso_file_storage_object_id,
+          fso.entity_id AS fso_entity_id,
+          fso.file_name AS fso_file_name,
+          fso.category AS fso_category,
+          fso.gcs_file_uri AS fso_gcs_file_uri,
+          fso.media_type AS fso_media_type,
+          fso.create_date AS fso_create_date,
+          fso.create_user_id AS fso_create_user_id,
+          fso.update_date AS fso_update_date,
+          fso.update_user_id AS fso_update_user_id,
+          fso.deleted AS fso_deleted,
+          fso.delete_user_id AS fso_delete_user_id,
+          fso.delete_date AS fso_delete_date
+      FROM dataset d
+      LEFT JOIN study s ON s.study_id = d.study_id
+      INNER JOIN file_storage_object fso
+          ON (fso.entity_id = d.dataset_id::text OR fso.entity_id = s.uuid::text)
+          AND fso.deleted = false
+          AND fso.category = :category
+      WHERE d.dataset_id = :datasetId
+      ORDER BY GREATEST(fso.create_date, fso.update_date, fso.delete_date) DESC,
+          fso.file_storage_object_id DESC
+      LIMIT 1
+      """)
+  FileStorageObject findLatestFileByDatasetIdAndCategory(
+      @Bind("datasetId") Integer datasetId, @Bind("category") String category);
+
+  @SqlQuery("SELECT dataset_id FROM dataset WHERE dataset_id = :datasetId")
+  Integer findDatasetIdById(@Bind("datasetId") Integer datasetId);
+
+  @SqlQuery("SELECT dataset_id FROM dataset WHERE alias = :alias")
+  Integer findDatasetIdByAlias(@Bind("alias") Integer alias);
+
+  /**
+   * Finds a fully populated dataset without joining all child collections into one Cartesian
+   * product. The focused reads run in a single REPEATABLE READ transaction so that they all observe
+   * the same snapshot; under the default READ COMMITTED level each statement would take its own
+   * snapshot and the assembled dataset could mix pre- and post-commit state.
+   */
+  default Dataset findDatasetByAlias(Integer alias) {
+    // A handle that is already in a transaction cannot open a nested one at a different isolation
+    // level, so reuse the transaction the caller established rather than failing.
+    if (isInTransaction()) {
+      return assembleDatasetByAlias(this, alias);
+    }
+    return inTransaction(
+        TransactionIsolationLevel.REPEATABLE_READ, dao -> assembleDatasetByAlias(dao, alias));
+  }
+
+  private Dataset assembleDatasetByAlias(DatasetDAO dao, Integer alias) {
+    Integer datasetId = dao.findDatasetIdByAlias(alias);
+    return datasetId == null ? null : assembleDataset(dao, datasetId, true);
+  }
+
+  private Dataset assembleDataset(DatasetDAO dao, Integer datasetId, boolean includeFiles) {
+    Dataset dataset = dao.findDatasetDetailsById(datasetId);
+    if (dataset == null) {
+      return null;
+    }
+
+    // findDatasetDetailsById populates the study id, so a null one means there is no study to read.
+    if (dataset.getStudyId() != null) {
+      Dataset datasetWithStudy = dao.findDatasetStudyById(datasetId);
+      if (datasetWithStudy != null && datasetWithStudy.getStudy() != null) {
+        Study study = datasetWithStudy.getStudy();
+        dao.findDatasetIdsByStudyId(study.getStudyId()).forEach(study::addDatasetId);
+        if (includeFiles) {
+          study.setAlternativeDataSharingPlan(
+              dao.findLatestFileByDatasetIdAndCategory(
+                  datasetId, FileCategory.ALTERNATIVE_DATA_SHARING_PLAN.getValue()));
+        }
+        dataset.setStudy(study);
+      }
+    }
+
+    if (includeFiles) {
+      dataset.setNihInstitutionalCertificationFile(
+          dao.findLatestFileByDatasetIdAndCategory(
+              datasetId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue()));
+    }
+    return dataset;
+  }
 
   /**
    * Return a list of Dataset objects from a list of dataset aliases. This explicitly does NOT
@@ -416,17 +457,33 @@ public interface DatasetDAO extends Transactional<DatasetDAO> {
               fso.update_date AS fso_update_date,
               fso.update_user_id AS fso_update_user_id,
               fso.deleted AS fso_deleted,
-              fso.delete_user_id AS fso_delete_user_id
+              fso.delete_user_id AS fso_delete_user_id,
+              fso.delete_date AS fso_delete_date
           FROM dataset d
           LEFT JOIN users u on d.create_user_id = u.user_id
           LEFT JOIN (SELECT DISTINCT dataset_id AS id FROM dar_dataset) dar_ds_ids ON dar_ds_ids.id = d.dataset_id
           LEFT JOIN dataset_property dp ON dp.dataset_id = d.dataset_id
           LEFT JOIN dictionary k ON k.key_id = dp.property_key
-          LEFT JOIN file_storage_object fso ON fso.entity_id = d.dataset_id::text AND fso.deleted = false
+          LEFT JOIN LATERAL (
+              SELECT *
+              FROM file_storage_object
+              WHERE entity_id = d.dataset_id::text
+                  AND deleted = false
+                  AND category = :fileCategory
+              ORDER BY GREATEST(create_date, update_date, delete_date) DESC,
+                  file_storage_object_id DESC
+              LIMIT 1
+          ) fso ON true
           WHERE d.alias IN (<aliases>)
       """)
-  List<Dataset> findDatasetsByAlias(
-      @BindList(value = "aliases", onEmpty = EmptyHandling.NULL_STRING) List<Integer> aliases);
+  List<Dataset> findDatasetsByAliasAndFileCategory(
+      @BindList(value = "aliases", onEmpty = EmptyHandling.NULL_STRING) List<Integer> aliases,
+      @Bind("fileCategory") String fileCategory);
+
+  default List<Dataset> findDatasetsByAlias(List<Integer> aliases) {
+    return findDatasetsByAliasAndFileCategory(
+        aliases, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue());
+  }
 
   @SqlUpdate("UPDATE dataset SET dac_id = :dacId WHERE dataset_id = :datasetId")
   void updateDatasetDacId(@Bind("datasetId") Integer datasetId, @Bind("dacId") Integer dacId);

--- a/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/StudyDAO.java
@@ -6,8 +6,11 @@ import java.util.Set;
 import java.util.UUID;
 import org.broadinstitute.consent.http.db.mapper.FileStorageObjectMapperWithFSOPrefix;
 import org.broadinstitute.consent.http.db.mapper.StudyReducer;
+import org.broadinstitute.consent.http.enumeration.FileCategory;
+import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyDatasetCountRecord;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
@@ -24,6 +27,35 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 @RegisterRowMapper(FileStorageObjectMapperWithFSOPrefix.class)
 public interface StudyDAO extends Transactional<StudyDAO> {
 
+  /**
+   * Finds a fully populated study without joining all child collections into one Cartesian product.
+   * The focused reads run in a single REPEATABLE READ transaction so that they all observe the same
+   * snapshot; under the default READ COMMITTED level each statement would take its own snapshot and
+   * the assembled study could mix pre- and post-commit state.
+   */
+  default Study findStudyById(Integer studyId) {
+    // A handle that is already in a transaction cannot open a nested one at a different isolation
+    // level, so reuse the transaction the caller established rather than failing.
+    if (isInTransaction()) {
+      return assembleStudy(this, studyId);
+    }
+    return inTransaction(
+        TransactionIsolationLevel.REPEATABLE_READ, dao -> assembleStudy(dao, studyId));
+  }
+
+  private Study assembleStudy(StudyDAO dao, Integer studyId) {
+    Study study = dao.findStudyDetailsById(studyId);
+    if (study == null) {
+      return null;
+    }
+
+    dao.findDatasetIdsByStudyId(studyId).forEach(study::addDatasetId);
+    study.setAlternativeDataSharingPlan(
+        dao.findLatestFileByStudyIdAndCategory(
+            studyId, FileCategory.ALTERNATIVE_DATA_SHARING_PLAN.getValue()));
+    return study;
+  }
+
   @UseRowReducer(StudyReducer.class)
   @SqlQuery(
       """
@@ -33,8 +65,20 @@ public interface StudyDAO extends Transactional<StudyDAO> {
           sp.study_id AS sp_study_id,
           sp.key AS sp_key,
           sp.value AS sp_value,
-          sp.type AS sp_type,
-          d.dataset_id AS s_dataset_id,
+          sp.type AS sp_type
+      FROM
+          study s
+      LEFT JOIN study_property sp ON sp.study_id = s.study_id
+      WHERE s.study_id = :studyId
+      """)
+  Study findStudyDetailsById(@Bind("studyId") Integer studyId);
+
+  @SqlQuery("SELECT dataset_id FROM dataset WHERE study_id = :studyId")
+  List<Integer> findDatasetIdsByStudyId(@Bind("studyId") Integer studyId);
+
+  @SqlQuery(
+      """
+      SELECT
           fso.file_storage_object_id AS fso_file_storage_object_id,
           fso.entity_id AS fso_entity_id,
           fso.file_name AS fso_file_name,
@@ -46,15 +90,20 @@ public interface StudyDAO extends Transactional<StudyDAO> {
           fso.update_date AS fso_update_date,
           fso.update_user_id AS fso_update_user_id,
           fso.deleted AS fso_deleted,
-          fso.delete_user_id AS fso_delete_user_id
-      FROM
-          study s
-      LEFT JOIN study_property sp ON sp.study_id = s.study_id
-      LEFT JOIN file_storage_object fso ON fso.entity_id = s.uuid::text AND fso.deleted = false
-      LEFT JOIN dataset d ON d.study_id = s.study_id
+          fso.delete_user_id AS fso_delete_user_id,
+          fso.delete_date AS fso_delete_date
+      FROM study s
+      INNER JOIN file_storage_object fso
+          ON fso.entity_id = s.uuid::text
+          AND fso.deleted = false
+          AND fso.category = :category
       WHERE s.study_id = :studyId
+      ORDER BY GREATEST(fso.create_date, fso.update_date, fso.delete_date) DESC,
+          fso.file_storage_object_id DESC
+      LIMIT 1
       """)
-  Study findStudyById(@Bind("studyId") Integer studyId);
+  FileStorageObject findLatestFileByStudyIdAndCategory(
+      @Bind("studyId") Integer studyId, @Bind("category") String category);
 
   @SqlUpdate(
       """

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/StudyReducer.java
@@ -3,7 +3,6 @@ package org.broadinstitute.consent.http.db.mapper;
 import java.util.Map;
 import java.util.Objects;
 import org.broadinstitute.consent.http.enumeration.PropertyType;
-import org.broadinstitute.consent.http.models.FileStorageObject;
 import org.broadinstitute.consent.http.models.Study;
 import org.broadinstitute.consent.http.models.StudyProperty;
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
@@ -21,10 +20,6 @@ public class StudyReducer implements LinkedHashMapRowReducer<Integer, Study>, Ro
   }
 
   public void reduceStudy(Study study, RowView rowView) {
-
-    if (hasNonZeroColumn(rowView, "s_dataset_id")) {
-      study.addDatasetId(rowView.getColumn("s_dataset_id", Integer.class));
-    }
 
     if (hasNonZeroColumn(rowView, "sp_study_property_id")) {
       Integer studyPropertyId = rowView.getColumn("sp_study_property_id", Integer.class);
@@ -51,24 +46,5 @@ public class StudyReducer implements LinkedHashMapRowReducer<Integer, Study>, Ro
         }
       }
     }
-
-    if (hasNonZeroColumn(rowView, "fso_file_storage_object_id")
-        && Objects.nonNull(rowView.getColumn("fso_file_storage_object_id", Integer.class))) {
-      FileStorageObject fileStorageObject = rowView.getRow(FileStorageObject.class);
-
-      switch (fileStorageObject.getCategory()) {
-        case ALTERNATIVE_DATA_SHARING_PLAN -> {
-          if (isFileNewer(fileStorageObject, study.getAlternativeDataSharingPlan())) {
-            study.setAlternativeDataSharingPlan(fileStorageObject);
-          }
-        }
-        default -> {}
-      }
-    }
-  }
-
-  private boolean isFileNewer(FileStorageObject incomingFile, FileStorageObject existingFile) {
-    return Objects.isNull(existingFile)
-        || incomingFile.getLatestUpdateDate().isAfter(existingFile.getLatestUpdateDate());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetRegistrationService.java
@@ -619,6 +619,8 @@ public class DatasetRegistrationService implements ConsentLogger {
     }
   }
 
+  private static final int CLEANUP_BATCH_SIZE = 500;
+
   public void asyncCleanupDatasetsAndStudiesWithEmptyFiles(User user) {
     executorService.submit(() -> cleanupDatasetsAndStudiesWithEmptyFiles(user));
   }
@@ -635,15 +637,28 @@ public class DatasetRegistrationService implements ConsentLogger {
     AtomicInteger studyProgress = new AtomicInteger();
     AtomicInteger studyDeleted = new AtomicInteger();
     AtomicInteger studyError = new AtomicInteger();
-    allDatasetIDs.forEach(
-        id -> {
-          processDataset(
-              id, user, datasetDeleted, datasetErrors, studyProgress, studyDeleted, studyError);
-          datasetProgress.getAndIncrement();
-          if (datasetProgress.get() % 100 == 0) {
-            logWarn(String.format("Cleaned %d entries.", datasetProgress.get()));
-          }
-        });
+    // Read the datasets in batches rather than one round trip per id.
+    for (int start = 0; start < allDatasetIDs.size(); start += CLEANUP_BATCH_SIZE) {
+      List<Integer> batch =
+          allDatasetIDs.subList(start, Math.min(start + CLEANUP_BATCH_SIZE, allDatasetIDs.size()));
+      datasetDAO
+          .findDatasetsByIdList(batch)
+          .forEach(
+              dataset -> {
+                processDataset(
+                    dataset,
+                    user,
+                    datasetDeleted,
+                    datasetErrors,
+                    studyProgress,
+                    studyDeleted,
+                    studyError);
+                datasetProgress.getAndIncrement();
+                if (datasetProgress.get() % 100 == 0) {
+                  logWarn(String.format("Cleaned %d entries.", datasetProgress.get()));
+                }
+              });
+    }
     logWarn(
         String.format(
             "Cleaning empty NIH Institutional and Alternative Sharing Plan files complete.  %d datasets, %d dataset files deleted, %d  dataset unexpected errors.  Study files deleted: %d, Study file errors: %d",
@@ -680,15 +695,15 @@ public class DatasetRegistrationService implements ConsentLogger {
   }
 
   private void processDataset(
-      Integer id,
+      Dataset dataset,
       User user,
       AtomicInteger deleted,
       AtomicInteger errors,
       AtomicInteger studyProgress,
       AtomicInteger studyDeleted,
       AtomicInteger studyError) {
-    Dataset dataset = datasetDAO.findDatasetById(id);
     if (dataset != null) {
+      Integer id = dataset.getDatasetId();
       FileStorageObject nihFile = dataset.getNihInstitutionalCertificationFile();
       try {
         if (nihFile != null && !gcsService.hasBytes(nihFile.getBlobId())) {
@@ -703,9 +718,9 @@ public class DatasetRegistrationService implements ConsentLogger {
             String.format("Error checking file for dataset id %d.  Error: %s", id, e.getMessage()));
         errors.getAndIncrement();
       } finally {
-        Study study = dataset.getStudy();
-        if (study != null) {
-          Study fullStudyObject = studyDAO.findStudyById(study.getStudyId());
+        Integer studyId = dataset.getStudyId();
+        if (studyId != null) {
+          Study fullStudyObject = studyDAO.findStudyById(studyId);
           processStudy(fullStudyObject, user, studyProgress, studyDeleted, studyError);
         }
       }

--- a/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/DatasetService.java
@@ -17,8 +17,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -150,6 +152,9 @@ public class DatasetService implements ConsentLogger {
       return summaries;
     }
     List<DatasetStudySummary> authorizedSummaries = new ArrayList<>();
+    // Summaries frequently repeat study ids, and the custodian check only reads the study's
+    // creator and properties, so look each study up once with the details-only query.
+    Map<Integer, Study> studyCache = new HashMap<>();
     for (DatasetStudySummary summary : summaries) {
       if (Boolean.TRUE.equals(summary.public_visibility())) {
         authorizedSummaries.add(summary);
@@ -159,7 +164,11 @@ public class DatasetService implements ConsentLogger {
         authorizedSummaries.add(summary);
       } else if (summary.study_id() != null) {
         // fetch study and see if the user is a custodian
-        Study study = studyDAO.findStudyById(summary.study_id());
+        Integer studyId = summary.study_id();
+        if (!studyCache.containsKey(studyId)) {
+          studyCache.put(studyId, studyDAO.findStudyDetailsById(studyId));
+        }
+        Study study = studyCache.get(studyId);
         if (study != null && isCreatorOrCustodian(user, study)) {
           authorizedSummaries.add(summary);
         }
@@ -179,12 +188,14 @@ public class DatasetService implements ConsentLogger {
     if (dataset.getStudyId() == null) {
       return dataset;
     }
-    // Study isn't always populated, so fetch it if necessary
-    if (dataset.getStudy() == null) {
-      dataset.setStudy(studyDAO.findStudyById(dataset.getStudyId()));
-    }
-    if (canReadStudy(user, dataset.getStudy())
-        || Objects.equals(dataset.getCreateUserId(), user.getUserId())) {
+    // Reuse the study when the caller already populated it for the response. Otherwise read only
+    // the details canReadStudy needs, and do not attach it - callers decide what the response
+    // carries.
+    Study study =
+        dataset.getStudy() != null
+            ? dataset.getStudy()
+            : studyDAO.findStudyDetailsById(dataset.getStudyId());
+    if (canReadStudy(user, study) || Objects.equals(dataset.getCreateUserId(), user.getUserId())) {
       return dataset;
     }
     return null;

--- a/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/ElasticSearchService.java
@@ -593,8 +593,8 @@ public class ElasticSearchService implements ConsentLogger {
 
   protected void updateDatasetIndexDate(Integer datasetId, Integer userId, Instant indexDate) {
     // It is possible that a dataset has been deleted. If so, we don't want to try and update it.
-    Dataset dataset = datasetDAO.findDatasetById(datasetId);
-    if (dataset != null) {
+    // Only the dataset's existence matters here, so avoid assembling the full dataset.
+    if (datasetDAO.findDatasetIdById(datasetId) != null) {
       try {
         datasetServiceDAO.updateDatasetIndex(datasetId, userId, indexDate);
       } catch (SQLException e) {

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -7,7 +7,10 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.db.MatchDAO;
@@ -92,26 +95,33 @@ public class MatchService implements ConsentLogger {
 
   protected List<Match> createMatchesForDataAccessRequest(DataAccessRequest dar) {
     List<Match> matches = new ArrayList<>();
-    dar.getDatasetIds()
-        .forEach(
-            id -> {
-              Dataset dataset = datasetDAO.findDatasetById(id);
-              if (Objects.nonNull(dataset)) {
-                try {
-                  matches.add(singleEntitiesMatch(dataset, dar));
-                } catch (Exception _) {
-                  String message =
-                      "Error finding single match for purpose: " + dar.getReferenceId();
-                  logWarn(message);
-                  matches.add(
-                      matchFailure(
-                          dataset.getDatasetIdentifier(),
-                          dar.getReferenceId(),
-                          MatchAlgorithm.V5,
-                          List.of(message)));
-                }
-              }
-            });
+    List<Integer> datasetIds = dar.getDatasetIds();
+    if (Objects.isNull(datasetIds) || datasetIds.isEmpty()) {
+      return matches;
+    }
+    // Fetch every dataset in a single query. Matching only needs the data use and the dataset
+    // identifier, both of which this query populates.
+    Map<Integer, Dataset> datasetsById =
+        datasetDAO.findDatasetsByIdList(datasetIds).stream()
+            .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
+    datasetIds.forEach(
+        id -> {
+          Dataset dataset = datasetsById.get(id);
+          if (Objects.nonNull(dataset)) {
+            try {
+              matches.add(singleEntitiesMatch(dataset, dar));
+            } catch (Exception _) {
+              String message = "Error finding single match for purpose: " + dar.getReferenceId();
+              logWarn(message);
+              matches.add(
+                  matchFailure(
+                      dataset.getDatasetIdentifier(),
+                      dar.getReferenceId(),
+                      MatchAlgorithm.V5,
+                      List.of(message)));
+            }
+          }
+        });
     return matches;
   }
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -95,8 +95,9 @@ public class MatchService implements ConsentLogger {
 
   protected List<Match> createMatchesForDataAccessRequest(DataAccessRequest dar) {
     List<Match> matches = new ArrayList<>();
+    // getDatasetIds normalizes a null list to an empty one
     List<Integer> datasetIds = dar.getDatasetIds();
-    if (Objects.isNull(datasetIds) || datasetIds.isEmpty()) {
+    if (datasetIds.isEmpty()) {
       return matches;
     }
     // Fetch every dataset in a single query. Matching only needs the data use and the dataset

--- a/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MetricsService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.broadinstitute.consent.http.db.DataAccessRequestDAO;
 import org.broadinstitute.consent.http.db.DatasetDAO;
 import org.broadinstitute.consent.http.models.DarMetricsSummary;
-import org.broadinstitute.consent.http.models.Dataset;
 import org.jdbi.v3.core.Jdbi;
 
 public class MetricsService {
@@ -21,8 +20,9 @@ public class MetricsService {
   }
 
   public List<DarMetricsSummary> generateDarSummaries(Integer datasetId) {
-    Dataset dataset = dataSetDAO.findDatasetById(datasetId);
-    if (dataset == null) {
+    // Only the dataset's existence matters here, so avoid assembling the full dataset.
+    Integer existingDatasetId = dataSetDAO.findDatasetIdById(datasetId);
+    if (existingDatasetId == null) {
       throw new NotFoundException("Dataset with specified ID does not exist.");
     }
     return darDAO.findSummaryMetricApprovedDARsByDatasetIdIncludesExpired(datasetId);

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -54,6 +54,7 @@ import org.broadinstitute.consent.http.models.User;
 import org.broadinstitute.consent.http.rules.DACAutomationRule;
 import org.broadinstitute.consent.http.rules.DACAutomationRuleType;
 import org.jdbi.v3.core.statement.Update;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -315,6 +316,95 @@ class DatasetDAOTest extends DAOTestHelper {
 
     assertNotNull(foundDataset.getStudy());
     assertEquals(updateUser.getUserId(), foundDataset.getStudy().getUpdateUserId());
+  }
+
+  @Test
+  void testFindDatasetLookupsReturnNullForUnknownDataset() {
+    assertNull(datasetDAO.findDatasetById(999999999));
+    assertNull(datasetDAO.findDatasetByAlias(999999999));
+    assertNull(datasetDAO.findDatasetWithoutFSOInformation(999999999));
+    assertNull(datasetDAO.findDatasetIdById(999999999));
+    assertNull(datasetDAO.findDatasetIdByAlias(999999999));
+  }
+
+  @Test
+  void testFindDatasetIdByIdAndAlias() {
+    Dataset dataset = insertDataset();
+    assertEquals(dataset.getDatasetId(), datasetDAO.findDatasetIdById(dataset.getDatasetId()));
+    assertEquals(dataset.getDatasetId(), datasetDAO.findDatasetIdByAlias(dataset.getAlias()));
+  }
+
+  @Test
+  void testFindDatasetJoinsCallerTransaction() {
+    // The assembling queries open their own REPEATABLE READ transaction, unless the caller already
+    // established one, in which case they must join it rather than fail on a nested transaction
+    // with a different isolation level.
+    Dataset dataset = insertDataset();
+    datasetDAO.useTransaction(
+        TransactionIsolationLevel.READ_COMMITTED,
+        dao -> {
+          assertNotNull(dao.findDatasetById(dataset.getDatasetId()));
+          assertNotNull(dao.findDatasetByAlias(dataset.getAlias()));
+          assertNotNull(dao.findDatasetWithoutFSOInformation(dataset.getDatasetId()));
+        });
+  }
+
+  @Test
+  void testFindLatestFileByDatasetIdAndCategory() {
+    Dataset dataset = insertDataset();
+    String entityId = dataset.getDatasetId().toString();
+    Instant now = Instant.now();
+    // The newer file is inserted first so that a correct result cannot come from the
+    // file_storage_object_id tiebreaker alone.
+    FileStorageObject newerNihFile =
+        createFileStorageObject(entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now);
+    createFileStorageObject(
+        entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now.minus(1, ChronoUnit.DAYS));
+    createFileStorageObject(
+        entityId, FileCategory.ALTERNATIVE_DATA_SHARING_PLAN, now.plus(1, ChronoUnit.DAYS));
+
+    FileStorageObject foundFile =
+        datasetDAO.findLatestFileByDatasetIdAndCategory(
+            dataset.getDatasetId(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION.getValue());
+
+    assertEquals(newerNihFile, foundFile);
+    assertNull(
+        datasetDAO.findLatestFileByDatasetIdAndCategory(
+            dataset.getDatasetId(), FileCategory.DATA_USE_LETTER.getValue()));
+  }
+
+  @Test
+  void testFindDatasetByIdWithoutStudyReturnsLatestNihFile() {
+    Dataset dataset = insertDataset();
+    String entityId = dataset.getDatasetId().toString();
+    Instant now = Instant.now();
+    FileStorageObject newerNihFile =
+        createFileStorageObject(entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now);
+    createFileStorageObject(
+        entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now.minus(1, ChronoUnit.DAYS));
+
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    assertNull(foundDataset.getStudy());
+    assertEquals(newerNihFile, foundDataset.getNihInstitutionalCertificationFile());
+  }
+
+  @Test
+  void testFindDatasetsByIdListReturnsLatestNihFile() {
+    Dataset dataset = insertDataset();
+    String entityId = dataset.getDatasetId().toString();
+    Instant now = Instant.now();
+    FileStorageObject newerNihFile =
+        createFileStorageObject(entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now);
+    createFileStorageObject(
+        entityId, FileCategory.NIH_INSTITUTIONAL_CERTIFICATION, now.minus(1, ChronoUnit.DAYS));
+    createFileStorageObject(
+        entityId, FileCategory.ALTERNATIVE_DATA_SHARING_PLAN, now.plus(1, ChronoUnit.DAYS));
+
+    List<Dataset> foundDatasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()));
+
+    assertEquals(1, foundDatasets.size());
+    assertEquals(newerNihFile, foundDatasets.getFirst().getNihInstitutionalCertificationFile());
   }
 
   @Test
@@ -1614,11 +1704,15 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   private FileStorageObject createFileStorageObject(String entityId, FileCategory category) {
+    return createFileStorageObject(entityId, category, Instant.now());
+  }
+
+  private FileStorageObject createFileStorageObject(
+      String entityId, FileCategory category, Instant createDate) {
     String fileName = randomAlphabetic(10);
     String bucketName = randomAlphabetic(10);
     String gcsFileUri = randomAlphabetic(10);
     User createUser = createUser();
-    Instant createDate = Instant.now();
 
     Integer newFileStorageObjectId =
         fileStorageObjectDAO.insertNewFile(

--- a/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DatasetDAOTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.broadinstitute.consent.http.enumeration.ElectionStatus;
 import org.broadinstitute.consent.http.enumeration.ElectionType;
@@ -115,8 +116,10 @@ class DatasetDAOTest extends DAOTestHelper {
     // The query under test specifically excludes FSO information
     // and INCLUDES User, Study, and Properties information
     Dataset dataset = insertDataset();
+    Dataset siblingDataset = insertDataset();
     Study study = insertStudyWithProperties();
     datasetDAO.updateStudyId(dataset.getDatasetId(), study.getStudyId());
+    datasetDAO.updateStudyId(siblingDataset.getDatasetId(), study.getStudyId());
     createFileStorageObject(study.getUuid().toString(), FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
     createFileStorageObject(
         dataset.getDatasetId().toString(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
@@ -125,10 +128,29 @@ class DatasetDAOTest extends DAOTestHelper {
     assertNotNull(foundDataset.getProperties());
     assertNotNull(foundDataset.getStudy().getProperties());
     assertEquals(study.getStudyId(), foundDataset.getStudy().getStudyId());
+    assertEquals(
+        Set.of(dataset.getDatasetId(), siblingDataset.getDatasetId()),
+        foundDataset.getStudy().getDatasetIds());
     assertEquals(dataset.getCreateUserId(), foundDataset.getCreateUser().getUserId());
     // Explicitly check un-queried entities
     assertNull(foundDataset.getNihInstitutionalCertificationFile());
     assertNull(foundDataset.getStudy().getAlternativeDataSharingPlan());
+  }
+
+  @Test
+  void testFindDatasetWithoutFSOInformationReportsRealDeletableValue() {
+    User user = createUser();
+    Dataset deletableDataset = insertDataset();
+    Dataset inUseDataset = insertDataset();
+    Dac dac = insertDac();
+    createDarCollectionWithDatasets(dac.getDacId(), user, List.of(inUseDataset));
+
+    assertTrue(
+        datasetDAO
+            .findDatasetWithoutFSOInformation(deletableDataset.getDatasetId())
+            .getDeletable());
+    assertFalse(
+        datasetDAO.findDatasetWithoutFSOInformation(inUseDataset.getDatasetId()).getDeletable());
   }
 
   @Test
@@ -234,16 +256,92 @@ class DatasetDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testFindDatasetByAliasAndIdPopulateAllChildCollections() {
+    Dataset dataset = insertDataset();
+    Dataset siblingDataset = insertDataset();
+    Study study = insertStudyWithProperties();
+    datasetDAO.updateStudyId(dataset.getDatasetId(), study.getStudyId());
+    datasetDAO.updateStudyId(siblingDataset.getDatasetId(), study.getStudyId());
+    FileStorageObject alternativeDataSharingPlan =
+        createFileStorageObject(
+            study.getUuid().toString(), FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
+    FileStorageObject nihInstitutionalCertification =
+        createFileStorageObject(
+            dataset.getDatasetId().toString(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
+
+    List<Dataset> foundDatasets =
+        List.of(
+            datasetDAO.findDatasetByAlias(dataset.getAlias()),
+            datasetDAO.findDatasetById(dataset.getDatasetId()));
+
+    for (Dataset foundDataset : foundDatasets) {
+      assertNotNull(foundDataset);
+      assertEquals(dataset.getDatasetId(), foundDataset.getDatasetId());
+      assertFalse(foundDataset.getProperties().isEmpty());
+      assertEquals(dataset.getCreateUserId(), foundDataset.getCreateUser().getUserId());
+      assertTrue(foundDataset.getDeletable());
+      assertNotNull(foundDataset.getStudy());
+      assertEquals(study.getStudyId(), foundDataset.getStudy().getStudyId());
+      assertEquals(study.getUuid(), foundDataset.getStudy().getUuid());
+      assertEquals(study.getProperties(), foundDataset.getStudy().getProperties());
+      assertEquals(
+          Set.of(dataset.getDatasetId(), siblingDataset.getDatasetId()),
+          foundDataset.getStudy().getDatasetIds());
+      assertEquals(
+          alternativeDataSharingPlan, foundDataset.getStudy().getAlternativeDataSharingPlan());
+      assertEquals(
+          nihInstitutionalCertification, foundDataset.getNihInstitutionalCertificationFile());
+    }
+  }
+
+  @Test
+  void testFindDatasetByIdPopulatesStudyUpdateUser() {
+    Dataset dataset = insertDataset();
+    Study study = insertStudyWithProperties();
+    User updateUser = createUser();
+    datasetDAO.updateStudyId(dataset.getDatasetId(), study.getStudyId());
+    studyDAO.updateStudy(
+        study.getStudyId(),
+        study.getName(),
+        study.getDescription(),
+        study.getPiName(),
+        study.getPiEmail(),
+        study.getDataTypes(),
+        study.getPublicVisibility(),
+        updateUser.getUserId(),
+        Instant.now());
+
+    Dataset foundDataset = datasetDAO.findDatasetById(dataset.getDatasetId());
+
+    assertNotNull(foundDataset.getStudy());
+    assertEquals(updateUser.getUserId(), foundDataset.getStudy().getUpdateUserId());
+  }
+
+  @Test
   void testFindDatasetsByAlias() {
     Dataset dataset1 = insertDataset();
     Dataset dataset2 = insertDataset();
+    FileStorageObject dataset1NihFile =
+        createFileStorageObject(
+            dataset1.getDatasetId().toString(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
+    FileStorageObject dataset2NihFile =
+        createFileStorageObject(
+            dataset2.getDatasetId().toString(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
 
     List<Dataset> foundDatasets =
         datasetDAO.findDatasetsByAlias(List.of(dataset1.getAlias(), dataset2.getAlias()));
-    List<Integer> foundDatasetIds = foundDatasets.stream().map(Dataset::getDatasetId).toList();
-    assertNotNull(foundDatasets);
-    assertTrue(
-        foundDatasetIds.containsAll(List.of(dataset1.getDatasetId(), dataset2.getDatasetId())));
+    Map<Integer, Dataset> foundById =
+        foundDatasets.stream().collect(Collectors.toMap(Dataset::getDatasetId, d -> d));
+
+    assertEquals(Set.of(dataset1.getDatasetId(), dataset2.getDatasetId()), foundById.keySet());
+    assertEquals(
+        dataset1NihFile,
+        foundById.get(dataset1.getDatasetId()).getNihInstitutionalCertificationFile());
+    assertEquals(
+        dataset2NihFile,
+        foundById.get(dataset2.getDatasetId()).getNihInstitutionalCertificationFile());
+    assertNull(foundById.get(dataset1.getDatasetId()).getStudy());
+    assertNull(foundById.get(dataset2.getDatasetId()).getStudy());
   }
 
   @Test
@@ -401,6 +499,9 @@ class DatasetDAOTest extends DAOTestHelper {
     Dataset dataset = insertDataset();
     Dac dac = insertDac();
     datasetDAO.updateDatasetDacId(dataset.getDatasetId(), dac.getDacId());
+    FileStorageObject nihFile =
+        createFileStorageObject(
+            dataset.getDatasetId().toString(), FileCategory.NIH_INSTITUTIONAL_CERTIFICATION);
 
     List<Dataset> datasets = datasetDAO.findDatasetsByIdList(List.of(dataset.getDatasetId()));
     assertFalse(datasets.isEmpty());
@@ -408,6 +509,8 @@ class DatasetDAOTest extends DAOTestHelper {
     assertEquals(dac.getDacId(), datasets.getFirst().getDacId());
     assertFalse(datasets.getFirst().getProperties().isEmpty());
     assertNotNull(datasets.getFirst().getCreateUser());
+    assertEquals(nihFile, datasets.getFirst().getNihInstitutionalCertificationFile());
+    assertNull(datasets.getFirst().getStudy());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/StudyDAOTest.java
@@ -272,8 +272,10 @@ class StudyDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testIncludesDatasetIds() {
+  void testFindStudyByIdPopulatesAllChildCollections() {
     Study s = insertStudyWithProperties();
+    FileStorageObject altFile =
+        createFileStorageObject(s.getUuid().toString(), FileCategory.ALTERNATIVE_DATA_SHARING_PLAN);
 
     insertDataset();
     Dataset ds1 = insertDatasetForStudy(s.getStudyId());
@@ -283,9 +285,14 @@ class StudyDAOTest extends DAOTestHelper {
 
     s = studyDAO.findStudyById(s.getStudyId());
 
+    assertEquals(2, s.getProperties().size());
+    assertEquals(
+        Set.of("prop1", "prop2"),
+        s.getProperties().stream().map(StudyProperty::getKey).collect(Collectors.toSet()));
     assertEquals(2, s.getDatasetIds().size());
     assertTrue(s.getDatasetIds().contains(ds1.getDatasetId()));
     assertTrue(s.getDatasetIds().contains(ds2.getDatasetId()));
+    assertEquals(altFile, s.getAlternativeDataSharingPlan());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -847,13 +847,13 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
     BlobId fso1BlobId = mock(BlobId.class);
     fso1.setBlobId(fso1BlobId);
     dataset1.setNihInstitutionalCertificationFile(fso1);
-    dataset1.setStudy(study1);
+    dataset1.setStudyId(study1.getStudyId());
 
     Dataset dataset2 = new Dataset();
     dataset2.setDatasetId(2);
     Study study7 = new Study();
     study7.setStudyId(8);
-    dataset2.setStudy(study7);
+    dataset2.setStudyId(study7.getStudyId());
 
     Study study3 = new Study();
     study3.setStudyId(9);
@@ -873,7 +873,7 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
     fso3.setBlobId(fso3BlobId);
     String fso3Name = "FSO3";
     dataset3.setNihInstitutionalCertificationFile(fso3);
-    dataset3.setStudy(study3);
+    dataset3.setStudyId(study3.getStudyId());
 
     Dataset dataset4 = new Dataset();
     FileStorageObject fso4 = new FileStorageObject();
@@ -890,15 +890,12 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
     alternateSharingPlan.setBlobId(asp1BlobId);
     alternateSharingPlan.setFileStorageObjectId(90);
     study2.setAlternativeDataSharingPlan(alternateSharingPlan);
-    dataset4.setStudy(study2);
+    dataset4.setStudyId(study2.getStudyId());
 
     List<Dataset> datasetList = List.of(dataset1, dataset2, dataset3, dataset4);
     List<Integer> datasetIds = datasetList.stream().map(Dataset::getDatasetId).toList();
     when(datasetDAO.findAllDatasetIds()).thenReturn(datasetIds);
-    when(datasetDAO.findDatasetById(dataset1.getDatasetId())).thenReturn(dataset1);
-    when(datasetDAO.findDatasetById(dataset2.getDatasetId())).thenReturn(dataset2);
-    when(datasetDAO.findDatasetById(dataset3.getDatasetId())).thenReturn(dataset3);
-    when(datasetDAO.findDatasetById(dataset4.getDatasetId())).thenReturn(dataset4);
+    when(datasetDAO.findDatasetsByIdList(datasetIds)).thenReturn(datasetList);
     when(studyDAO.findStudyById(study2.getStudyId())).thenReturn(study2);
     when(studyDAO.findStudyById(study1.getStudyId())).thenReturn(study1);
     when(studyDAO.findStudyById(study3.getStudyId())).thenReturn(study3);

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetRegistrationServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.broadinstitute.consent.http.AbstractTestHelper;
 import org.broadinstitute.consent.http.cloudstore.GCSService;
@@ -917,6 +919,47 @@ class DatasetRegistrationServiceTest extends AbstractTestHelper {
 
     verify(gcsService, times(4)).deleteDocument(any());
     verify(fileStorageObjectDAO, times(4)).deleteFileById(anyInt(), anyInt());
+  }
+
+  @Test
+  void testCleanupReadsDatasetsInBatches() {
+    User user = new User();
+    user.setUserId(1);
+    List<Integer> datasetIds = IntStream.rangeClosed(1, 1200).boxed().toList();
+    when(datasetDAO.findAllDatasetIds()).thenReturn(datasetIds);
+    when(datasetDAO.findDatasetsByIdList(anyList())).thenReturn(List.of());
+
+    assertDoesNotThrow(
+        () -> datasetRegistrationService.cleanupDatasetsAndStudiesWithEmptyFiles(user));
+
+    verify(datasetDAO).findDatasetsByIdList(datasetIds.subList(0, 500));
+    verify(datasetDAO).findDatasetsByIdList(datasetIds.subList(500, 1000));
+    verify(datasetDAO).findDatasetsByIdList(datasetIds.subList(1000, 1200));
+  }
+
+  @Test
+  void testCleanupDatasetsWithoutStudyOrFilesSkipsStudyProcessing() {
+    User user = new User();
+    user.setUserId(1);
+    // Enough datasets without files or a study to also cross the progress-logging threshold
+    List<Dataset> datasets =
+        IntStream.rangeClosed(1, 100)
+            .mapToObj(
+                id -> {
+                  Dataset dataset = new Dataset();
+                  dataset.setDatasetId(id);
+                  return dataset;
+                })
+            .toList();
+    List<Integer> datasetIds = datasets.stream().map(Dataset::getDatasetId).toList();
+    when(datasetDAO.findAllDatasetIds()).thenReturn(datasetIds);
+    when(datasetDAO.findDatasetsByIdList(datasetIds)).thenReturn(datasets);
+
+    assertDoesNotThrow(
+        () -> datasetRegistrationService.cleanupDatasetsAndStudiesWithEmptyFiles(user));
+
+    verify(studyDAO, never()).findStudyById(anyInt());
+    verify(gcsService, never()).hasBytes(any());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -942,6 +942,59 @@ class DatasetServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testVerifyPublicVisibilitySummaries_StudyFetchedOncePerStudyId() {
+    User user = new User();
+    user.setUserId(1);
+    Study study = new Study();
+    study.setStudyId(10);
+    study.setCreateUserId(user.getUserId() + 1);
+    study.setPublicVisibility(false);
+    DatasetStudySummary summary1 =
+        new DatasetStudySummary(
+            1,
+            user.getUserId() + 1,
+            "Dataset 1",
+            "DUOS-123",
+            study.getStudyId(),
+            "Study Name",
+            study.getCreateUserId(),
+            false);
+    DatasetStudySummary summary2 =
+        new DatasetStudySummary(
+            2,
+            user.getUserId() + 1,
+            "Dataset 2",
+            "DUOS-124",
+            study.getStudyId(),
+            "Study Name",
+            study.getCreateUserId(),
+            false);
+    when(studyDAO.findStudyDetailsById(study.getStudyId())).thenReturn(study);
+
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary1, summary2), user);
+
+    assertEquals(0, authorizedSummaries.size());
+    // Both summaries reference the same study, so it is only looked up once
+    verify(studyDAO, times(1)).findStudyDetailsById(study.getStudyId());
+  }
+
+  @Test
+  void testVerifyPublicVisibilitySummaries_StudyLookupReturnsNull() {
+    User user = new User();
+    user.setUserId(1);
+    DatasetStudySummary summary =
+        new DatasetStudySummary(
+            1, user.getUserId() + 1, "Dataset Name", "DUOS-123", 10, "Study Name", 1000, false);
+    when(studyDAO.findStudyDetailsById(summary.study_id())).thenReturn(null);
+
+    List<DatasetStudySummary> authorizedSummaries =
+        datasetService.verifyPublicVisibilityAccess(List.of(summary), user);
+
+    assertEquals(0, authorizedSummaries.size());
+  }
+
+  @Test
   void testVerifyPublicVisibilitySummaries_Study_DoesntExist() {
     User user = new User();
     user.setUserId(1);
@@ -1072,6 +1125,66 @@ class DatasetServiceTest extends AbstractTestHelper {
 
     Dataset verfiedDataset = datasetService.verifyPublicVisibilityAccess(dataset, user);
     assertNull(verfiedDataset);
+  }
+
+  @Test
+  void testVerifyPublicVisibilityAccess_FetchesStudyDetailsWithoutAttaching() {
+    User user = new User();
+    user.setUserId(1);
+    user.setEmail("user@email.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(5);
+    dataset.setCreateUserId(2);
+    dataset.setStudyId(10);
+    Study study = new Study();
+    study.setStudyId(dataset.getStudyId());
+    study.setCreateUserId(3);
+    study.setPublicVisibility(Boolean.TRUE);
+    when(studyDAO.findStudyDetailsById(dataset.getStudyId())).thenReturn(study);
+
+    Dataset verifiedDataset = datasetService.verifyPublicVisibilityAccess(dataset, user);
+
+    assertEquals(dataset.getDatasetId(), verifiedDataset.getDatasetId());
+    // The study is fetched only for the visibility check, not attached to the response
+    assertNull(verifiedDataset.getStudy());
+  }
+
+  @Test
+  void testVerifyPublicVisibilityAccess_FetchedStudyNotVisible() {
+    User user = new User();
+    user.setUserId(1);
+    user.setEmail("user@email.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(5);
+    dataset.setCreateUserId(2);
+    dataset.setStudyId(10);
+    Study study = new Study();
+    study.setStudyId(dataset.getStudyId());
+    study.setCreateUserId(3);
+    study.setPublicVisibility(Boolean.FALSE);
+    when(studyDAO.findStudyDetailsById(dataset.getStudyId())).thenReturn(study);
+
+    assertNull(datasetService.verifyPublicVisibilityAccess(dataset, user));
+  }
+
+  @Test
+  void testVerifyPublicVisibilityAccess_DatasetCreatorWithHiddenStudy() {
+    User datasetCreator = new User();
+    datasetCreator.setUserId(1);
+    datasetCreator.setEmail("dsCreator@email.com");
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(5);
+    dataset.setCreateUserId(datasetCreator.getUserId());
+    dataset.setStudyId(10);
+    Study study = new Study();
+    study.setStudyId(dataset.getStudyId());
+    study.setCreateUserId(datasetCreator.getUserId() + 1);
+    study.setPublicVisibility(Boolean.FALSE);
+    when(studyDAO.findStudyDetailsById(dataset.getStudyId())).thenReturn(study);
+
+    Dataset verifiedDataset = datasetService.verifyPublicVisibilityAccess(dataset, datasetCreator);
+
+    assertEquals(dataset.getDatasetId(), verifiedDataset.getDatasetId());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/DatasetServiceTest.java
@@ -901,7 +901,7 @@ class DatasetServiceTest extends AbstractTestHelper {
             "Study Name",
             study.getCreateUserId(),
             false);
-    when(studyDAO.findStudyById(summary.study_id())).thenReturn(study);
+    when(studyDAO.findStudyDetailsById(summary.study_id())).thenReturn(study);
 
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), custodian);
@@ -934,7 +934,7 @@ class DatasetServiceTest extends AbstractTestHelper {
             "Study Name",
             study.getCreateUserId(),
             false);
-    when(studyDAO.findStudyById(summary.study_id())).thenReturn(study);
+    when(studyDAO.findStudyDetailsById(summary.study_id())).thenReturn(study);
 
     List<DatasetStudySummary> authorizedSummaries =
         datasetService.verifyPublicVisibilityAccess(List.of(summary), custodian);

--- a/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/ElasticSearchServiceTest.java
@@ -1247,15 +1247,14 @@ class ElasticSearchServiceTest extends AbstractTestHelper {
 
   @Test
   void testDeleteDatasetIndexWhenDatasetExists() throws Exception {
-    Dataset dataset = new Dataset();
-    when(datasetDAO.findDatasetById(any())).thenReturn(dataset);
+    when(datasetDAO.findDatasetIdById(any())).thenReturn(1);
     assertDoesNotThrow(() -> service.updateDatasetIndexDate(1, 1, null));
     verify(datasetServiceDAO).updateDatasetIndex(any(), any(), any());
   }
 
   @Test
   void testDeleteDatasetIndexWhenDatasetIsNull() throws Exception {
-    when(datasetDAO.findDatasetById(any())).thenReturn(null);
+    when(datasetDAO.findDatasetIdById(any())).thenReturn(null);
     assertDoesNotThrow(() -> service.updateDatasetIndexDate(1, 1, null));
     verify(datasetServiceDAO, never()).updateDatasetIndex(any(), any(), any());
   }

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +78,7 @@ class MatchServiceTest extends AbstractTestHelper {
     dar.setDatasetIds(List.of(1, 2, 3));
 
     service.createMatchesForDataAccessRequest(dar);
-    verify(datasetDAO, times(dar.getDatasetIds().size())).findDatasetById(any());
+    verify(datasetDAO).findDatasetsByIdList(dar.getDatasetIds());
   }
 
   @Test
@@ -94,7 +93,7 @@ class MatchServiceTest extends AbstractTestHelper {
     dar.setData(new DataAccessRequestData());
     dar.getData().setHmb(true);
     dar.getData().setDiseases(false);
-    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
+    when(datasetDAO.findDatasetsByIdList(dar.getDatasetIds())).thenReturn(List.of(dataset));
     when(useRestrictionConverter.parseDataUsePurpose(dar))
         .thenThrow(new IllegalArgumentException());
 
@@ -184,7 +183,7 @@ class MatchServiceTest extends AbstractTestHelper {
     dar.setData(new DataAccessRequestData());
     dar.getData().setHmb(true);
     dar.getData().setDiseases(false);
-    when(datasetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
+    when(datasetDAO.findDatasetsByIdList(dar.getDatasetIds())).thenReturn(List.of(dataset));
     when(dataAccessRequestDAO.findByReferenceId(dar.getReferenceId())).thenReturn(dar);
     when(useRestrictionConverter.parseDataUsePurpose(dar))
         .thenReturn(new DataUseBuilder().setHmbResearch(true).build());

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -110,6 +110,50 @@ class MatchServiceTest extends AbstractTestHelper {
   }
 
   @Test
+  void testCreateMatchesForDataAccessRequestNullDatasetIds() {
+    DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+    dar.setDatasetIds(null);
+
+    List<Match> matches = service.createMatchesForDataAccessRequest(dar);
+
+    assertTrue(matches.isEmpty());
+    verify(datasetDAO, never()).findDatasetsByIdList(anyList());
+  }
+
+  @Test
+  void testCreateMatchesForDataAccessRequestEmptyDatasetIds() {
+    DataAccessRequest dar = getSampleDataAccessRequest("DAR-2");
+    dar.setDatasetIds(List.of());
+
+    List<Match> matches = service.createMatchesForDataAccessRequest(dar);
+
+    assertTrue(matches.isEmpty());
+    verify(datasetDAO, never()).findDatasetsByIdList(anyList());
+  }
+
+  @Test
+  void testCreateMatchesForDataAccessRequestSkipsDatasetIdsNotFound() {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(1);
+    dataset.setName("Test Dataset 1");
+    dataset.setDataUse(new DataUseBuilder().setHmbResearch(true).build());
+    dataset.setProperties(Collections.emptySet());
+    DataAccessRequest dar = getSampleDataAccessRequest(UUID.randomUUID().toString());
+    dar.setDatasetIds(List.of(dataset.getDatasetId(), 2));
+    dar.setData(new DataAccessRequestData());
+    dar.getData().setHmb(true);
+    dar.getData().setDiseases(false);
+    // Only one of the two requested datasets exists
+    when(datasetDAO.findDatasetsByIdList(dar.getDatasetIds())).thenReturn(List.of(dataset));
+    when(useRestrictionConverter.parseDataUsePurpose(dar))
+        .thenThrow(new IllegalArgumentException());
+
+    List<Match> matches = service.createMatchesForDataAccessRequest(dar);
+
+    assertEquals(1, matches.size());
+  }
+
+  @Test
   void testSingleEntitiesMatchEmptyDataset() {
     DataAccessRequest dar = new DataAccessRequest();
 

--- a/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MetricsServiceTest.java
@@ -44,7 +44,7 @@ class MetricsServiceTest extends AbstractTestHelper {
     DarMetricsSummary summary = generateDarMetricsSummary();
     Dataset dataset = generateDataset();
 
-    when(dataSetDAO.findDatasetById(dataset.getDatasetId())).thenReturn(dataset);
+    when(dataSetDAO.findDatasetIdById(dataset.getDatasetId())).thenReturn(dataset.getDatasetId());
     when(darDAO.findSummaryMetricApprovedDARsByDatasetIdIncludesExpired(any()))
         .thenReturn(List.of(summary));
 
@@ -52,13 +52,13 @@ class MetricsServiceTest extends AbstractTestHelper {
 
     assertEquals(summary.projectTitle(), metrics.getFirst().projectTitle());
     assertEquals(summary.darCode(), metrics.getFirst().darCode());
-    verify(dataSetDAO).findDatasetById(dataset.getDatasetId());
+    verify(dataSetDAO).findDatasetIdById(dataset.getDatasetId());
     verify(darDAO).findSummaryMetricApprovedDARsByDatasetIdIncludesExpired(dataset.getDatasetId());
   }
 
   @Test
   void testGenerateDarSummariesNotFound() {
-    when(dataSetDAO.findDatasetById(any())).thenReturn(null);
+    when(dataSetDAO.findDatasetIdById(any())).thenReturn(null);
 
     assertThrows(NotFoundException.class, () -> service.generateDarSummaries(1));
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-4041](https://broadworkbench.atlassian.net/browse/DT-4041)

### Summary

Targets refactoring of DatasetDAO and StudyDAO queries that produce large cartesian products by moving to multiple queries that produce the same result.
The original queries could lead to system Out Of Memory (OOM) events by single API use calls for datasets and studies.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
