### PR TITLE
[DT-4058] Update NA exception signature

### DIFF
--- a/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
+++ b/src/main/java/org/broadinstitute/consent/http/util/HttpClientUtil.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -193,7 +194,8 @@ public class HttpClientUtil implements ConsentLogger {
           }
           case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED -> {
             logErrorResponse(request, response);
-            throw new NotAuthorizedException(response.getStatusMessage());
+            throw new NotAuthorizedException(
+                Objects.requireNonNullElse(response.getStatusMessage(), "Unauthorized"), "Bearer");
           }
           case HttpStatusCodes.STATUS_CODE_FORBIDDEN -> {
             logErrorResponse(request, response);

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -5,10 +5,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
@@ -18,7 +18,6 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import jakarta.ws.rs.NotAuthorizedException;
 import java.io.IOException;
-import java.util.stream.IntStream;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.RequestFailedException;
 import org.broadinstitute.consent.http.WireMockTestHelper;
@@ -47,15 +46,9 @@ class HttpClientUtilTest extends WireMockTestHelper {
   @Test
   void testGetCachedResponse_case1() {
     wireMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
-    IntStream.range(3, 10)
-        .forEach(
-            i -> {
-              try {
-                clientUtil.getCachedResponse(new HttpGet(statusUrl));
-              } catch (Exception e) {
-                fail(e.getMessage());
-              }
-            });
+    for (int i = 3; i < 10; i++) {
+      assertDoesNotThrow(() -> clientUtil.getCachedResponse(new HttpGet(statusUrl)));
+    }
     wireMockServer.verify(exactly(1), anyRequestedFor(anyUrl()));
   }
 
@@ -70,15 +63,9 @@ class HttpClientUtilTest extends WireMockTestHelper {
     wireMockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
 
     int count = randomInt(5, 10);
-    IntStream.range(0, count)
-        .forEach(
-            i -> {
-              try {
-                clientUtil.getCachedResponse(new HttpGet(statusUrl));
-              } catch (Exception e) {
-                fail(e.getMessage());
-              }
-            });
+    for (int i = 0; i < count; i++) {
+      assertDoesNotThrow(() -> clientUtil.getCachedResponse(new HttpGet(statusUrl)));
+    }
     wireMockServer.verify(exactly(count), anyRequestedFor(anyUrl()));
   }
 
@@ -113,10 +100,7 @@ class HttpClientUtilTest extends WireMockTestHelper {
     wireMockServer.stubFor(
         any(anyUrl()).willReturn(aResponse().withStatus(200).withFixedDelay(3000)));
     assertThrows(
-        RequestFailedException.class,
-        () -> {
-          clientUtil.getHttpResponse(new HttpGet(statusUrl));
-        });
+        RequestFailedException.class, () -> clientUtil.getHttpResponse(new HttpGet(statusUrl)));
   }
 
   /**
@@ -128,7 +112,7 @@ class HttpClientUtilTest extends WireMockTestHelper {
    */
   @Test
   void testHandleHttpRequestUnauthorizedWithoutReasonPhrase() throws Exception {
-    HttpRequest request = requestReturning(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, null);
+    HttpRequest request = requestReturning(null);
 
     assertThrows(NotAuthorizedException.class, () -> clientUtil.handleHttpRequest(request));
   }
@@ -136,17 +120,18 @@ class HttpClientUtilTest extends WireMockTestHelper {
   /** A 401 that does carry a reason phrase keeps that phrase in the exception message. */
   @Test
   void testHandleHttpRequestUnauthorizedKeepsReasonPhrase() throws Exception {
-    HttpRequest request =
-        requestReturning(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, "Token expired");
+    HttpRequest request = requestReturning("Token expired");
 
     NotAuthorizedException e =
         assertThrows(NotAuthorizedException.class, () -> clientUtil.handleHttpRequest(request));
     assertTrue(e.getMessage().contains("Token expired"), e.getMessage());
   }
 
-  private HttpRequest requestReturning(int statusCode, String reasonPhrase) throws IOException {
+  private HttpRequest requestReturning(String reasonPhrase) throws IOException {
     MockLowLevelHttpResponse response =
-        new MockLowLevelHttpResponse().setStatusCode(statusCode).setReasonPhrase(reasonPhrase);
+        new MockLowLevelHttpResponse()
+            .setStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED)
+            .setReasonPhrase(reasonPhrase);
     HttpTransport transport =
         new MockHttpTransport.Builder().setLowLevelHttpResponse(response).build();
     return transport.createRequestFactory().buildGetRequest(new GenericUrl(statusUrl));

--- a/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/util/HttpClientUtilTest.java
@@ -10,7 +10,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import jakarta.ws.rs.NotAuthorizedException;
+import java.io.IOException;
 import java.util.stream.IntStream;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.RequestFailedException;
@@ -110,5 +117,38 @@ class HttpClientUtilTest extends WireMockTestHelper {
         () -> {
           clientUtil.getHttpResponse(new HttpGet(statusUrl));
         });
+  }
+
+  /**
+   * A downstream server can answer 401 without an HTTP reason phrase. Tomcat omits the phrase by
+   * default, and an ingress that forwards the status line unchanged delivers it that way. The
+   * status message is then null. A null must not reach the NotAuthorizedException challenge
+   * parameter, because that constructor answers with a NullPointerException, which callers that
+   * catch NotAuthorizedException cannot handle.
+   */
+  @Test
+  void testHandleHttpRequestUnauthorizedWithoutReasonPhrase() throws Exception {
+    HttpRequest request = requestReturning(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, null);
+
+    assertThrows(NotAuthorizedException.class, () -> clientUtil.handleHttpRequest(request));
+  }
+
+  /** A 401 that does carry a reason phrase keeps that phrase in the exception message. */
+  @Test
+  void testHandleHttpRequestUnauthorizedKeepsReasonPhrase() throws Exception {
+    HttpRequest request =
+        requestReturning(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, "Token expired");
+
+    NotAuthorizedException e =
+        assertThrows(NotAuthorizedException.class, () -> clientUtil.handleHttpRequest(request));
+    assertTrue(e.getMessage().contains("Token expired"), e.getMessage());
+  }
+
+  private HttpRequest requestReturning(int statusCode, String reasonPhrase) throws IOException {
+    MockLowLevelHttpResponse response =
+        new MockLowLevelHttpResponse().setStatusCode(statusCode).setReasonPhrase(reasonPhrase);
+    HttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(response).build();
+    return transport.createRequestFactory().buildGetRequest(new GenericUrl(statusUrl));
   }
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-4058

## Summary

Authenticated `GET /api/user/me` calls return a 500 in BEEs:

```json
{"message":"Primary challenge parameter must not be null.","code":500}
```

The endpoint works in dev, staging, and prod.

### Why only BEEs failed

ECM answers 401 when the user has not accepted the Terms of Service.
`NihService.syncAccount` expects this and catches `NotAuthorizedException`. It
cannot catch an NPE, so the NPE reaches `Resource.createExceptionResponse`,
which has no handler for it and returns a 500.

Tomcat omits the reason phrase by default, so ECM sends `HTTP/1.1 401` with an
empty phrase. The two environments then differ:

- Live environments use the GKE ingress. The Google load balancer rewrites the status line and adds `Unauthorized`. Consent never sees a null.
- BEEs use the HAProxy ingress. HAProxy passes the reason phrase through unchanged and adds nothing, so Consent sees a null.

### Testing
I have manually tested in a BEE. Steps to reproduce:
1. Deploy a new DUOS BEE
2. Update consent's version to point to this branch
3. Visit the consent swagger page
4. Authenticate
5. Hit `GET /api/user/me` and correctly see a 404
6. Hit `POST /api/user` to create an entry for your authenticated account
7. Revisit `GET /api/user/me` and see your user information.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
