### PR TITLE
[DT-3942] Add match_entity.dataset_id and write matches through it

### DIFF
--- a/docs/plans/data-use-primary-consistency-plan.md
+++ b/docs/plans/data-use-primary-consistency-plan.md
@@ -10,7 +10,7 @@ In progress. Ticket-by-ticket state:
 | 2. Canonical primary classification on Data Use writes | Done. `DataUsePrimaryClassifier`/`DataUsePrimaryValidator` back registration, admin Data Use replacement, and dataset-to-study conversion. |
 | 3. Explicit legacy and unsupported matcher behavior | Done. `DataUseMatcherV5` classifies before matching and abstains on Other-only, NONE/null, and MULTIPLE. |
 | 4. Normalize legacy records and reprocess affected matches | Done. |
-| 5. Replace alias-derived internal dataset references | Not started. `match_entity.consent` still holds the formatted alias. |
+| 5. Replace alias-derived internal dataset references | In progress. Alias allocation moved to a database sequence (DT-3865). For matches (DT-3942), Phase 1 has landed: nullable `match_entity.dataset_id`, dual write, and a dataset-correlated election join. The reprocess and the non-null and uniqueness constraints follow once Phase 1 is deployed everywhere. |
 | 6. Align duos-ui with the canonical classification | Done in duos-ui (DT-3866). The Data Use translation collapse is an owned follow-up (DT-4008). |
 
 ## Objective
@@ -460,8 +460,12 @@ in external contracts and does not make the internal numeric `dataset_id` public
 
 - Audit null, duplicate, noncanonical, and conflicting aliases before adding constraints.
 - Add a nullable `match_entity.dataset_id`, its foreign key, and an index first.
-- Backfill only exact, unambiguous legacy mappings. Quarantine or explicitly resolve unmatched and
-  ambiguous `match_entity.consent` values; never guess from numeric parsing alone.
+- Reprocess rather than backfill (DT-3942, endorsed on review). The legacy `consent` values are
+  UUIDs whose dataset mapping was deleted in 2024, so no mapping can be derived without guessing.
+  Re-running matching for the affected purposes rebuilds the rows carrying a real `dataset_id`, and
+  purposes whose DAR has no dataset associations rebuild to nothing, which deletes them. The cost is
+  that historical `v1` rationales are replaced by current-algorithm results; this is what the
+  application already does whenever a DAR is edited. Snapshot the affected rows first.
 - Change match creation to pass the selected dataset's `dataset_id`. Join to `dataset` when the
   public identifier is needed in a response.
 - During rollout, use an explicitly bounded compatibility phase (for example, dual-write plus
@@ -483,8 +487,9 @@ in external contracts and does not make the internal numeric `dataset_id` public
 - Concurrent dataset creation cannot allocate duplicate aliases, and the database enforces alias
   uniqueness.
 - Match uniqueness is enforced by `(purpose, dataset_id)`.
-- Backfill totals reconcile: migrated plus explicitly unresolved rows equals the pre-migration row
-  count.
+- The execution-time snapshot reconciles: rebuilt plus explicitly deleted rows equals the snapshotted
+  row count. Counts drift as DARs are re-matched, so the snapshot is taken when the migration runs
+  rather than fixed in advance.
 - Rollout and rollback tests cover legacy reads, dual-write comparison (if used), constraint
   validation, and public identifier compatibility.
 

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -48,9 +48,12 @@ public interface MatchDAO extends Transactional<MatchDAO> {
           FROM election
           WHERE LOWER(election.election_type) = 'dataaccess'
           ) AS e ON e.reference_id = match_entity.purpose
-            -- Legacy rows carry no dataset_id and would otherwise drop out; the tolerance goes
-            -- away with the non-null constraint.
-            AND (match_entity.dataset_id IS NULL OR e.dataset_id = match_entity.dataset_id)
+            -- Correlate on dataset only when both sides carry one: legacy match rows predate
+            -- dataset_id and legacy elections can be missing it too, and either would otherwise
+            -- drop out. The tolerance goes away with the non-null constraints.
+            AND (match_entity.dataset_id IS NULL
+                 OR e.dataset_id IS NULL
+                 OR e.dataset_id = match_entity.dataset_id)
         WHERE match_entity.purpose IN (<purposeIds>) AND e.election_id = latest
       """)
   List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -48,6 +48,9 @@ public interface MatchDAO extends Transactional<MatchDAO> {
           FROM election
           WHERE LOWER(election.election_type) = 'dataaccess'
           ) AS e ON e.reference_id = match_entity.purpose
+            -- Legacy rows carry no dataset_id and would otherwise drop out; the tolerance goes
+            -- away with the non-null constraint.
+            AND (match_entity.dataset_id IS NULL OR e.dataset_id = match_entity.dataset_id)
         WHERE match_entity.purpose IN (<purposeIds>) AND e.election_id = latest
       """)
   List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(
@@ -56,13 +59,16 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   @SqlUpdate(
       """
         INSERT INTO match_entity
-          (consent, purpose, match_entity, failed, create_date, algorithm_version, abstain)
+          (consent, dataset_id, purpose, match_entity, failed, create_date,
+           algorithm_version, abstain)
         VALUES
-          (:consentId, :purposeId, :match, :failed, :createDate, :algorithmVersion, :abstain)
+          (:consentId, :datasetId, :purposeId, :match, :failed, :createDate,
+           :algorithmVersion, :abstain)
       """)
   @GetGeneratedKeys
   Integer insertMatch(
       @Bind("consentId") String consentId,
+      @Bind("datasetId") Integer datasetId,
       @Bind("purposeId") String purposeId,
       @Bind("match") Boolean match,
       @Bind("failed") Boolean failed,

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchDAO.java
@@ -1,12 +1,12 @@
 package org.broadinstitute.consent.http.db;
 
-import java.util.Date;
 import java.util.List;
 import org.broadinstitute.consent.http.db.mapper.MatchMapper;
 import org.broadinstitute.consent.http.db.mapper.MatchReducer;
 import org.broadinstitute.consent.http.models.Match;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
@@ -56,25 +56,21 @@ public interface MatchDAO extends Transactional<MatchDAO> {
   List<Match> findMatchesForLatestDataAccessElectionsByPurposeIds(
       @BindList(value = "purposeIds", onEmpty = EmptyHandling.NULL_STRING) List<String> purposeIds);
 
+  /**
+   * Bound from the {@link Match} itself. The column list is long enough that positional parameters
+   * were both unreadable and a Sonar finding, and the model already holds exactly these fields.
+   */
   @SqlUpdate(
       """
         INSERT INTO match_entity
           (consent, dataset_id, purpose, match_entity, failed, create_date,
            algorithm_version, abstain)
         VALUES
-          (:consentId, :datasetId, :purposeId, :match, :failed, :createDate,
+          (:consent, :datasetId, :purpose, :match, :failed, :createDate,
            :algorithmVersion, :abstain)
       """)
   @GetGeneratedKeys
-  Integer insertMatch(
-      @Bind("consentId") String consentId,
-      @Bind("datasetId") Integer datasetId,
-      @Bind("purposeId") String purposeId,
-      @Bind("match") Boolean match,
-      @Bind("failed") Boolean failed,
-      @Bind("createDate") Date date,
-      @Bind("algorithmVersion") String algorithmVersion,
-      @Bind("abstain") Boolean abstain);
+  Integer insertMatch(@BindBean Match match);
 
   @SqlUpdate(
       "INSERT INTO match_rationale (match_entity_id, rationale) VALUES (:matchId, :rationale) ")

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchMapper.java
@@ -13,6 +13,7 @@ public class MatchMapper implements RowMapper<Match> {
     return new Match(
         r.getInt("match_id"),
         r.getString("consent"),
+        (r.getObject("dataset_id") == null) ? null : r.getInt("dataset_id"),
         r.getString("purpose"),
         r.getBoolean("match_entity"),
         r.getBoolean("abstain"),

--- a/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/mapper/MatchReducer.java
@@ -14,6 +14,7 @@ public class MatchReducer implements LinkedHashMapRowReducer<Integer, Match>, Ro
         map.computeIfAbsent(
             rowView.getColumn("match_id", Integer.class), id -> rowView.getRow(Match.class));
     hasOptionalColumn(rowView, "consent", String.class).ifPresent(match::setConsent);
+    hasOptionalColumn(rowView, "dataset_id", Integer.class).ifPresent(match::setDatasetId);
     hasOptionalColumn(rowView, "purpose", String.class).ifPresent(match::setPurpose);
     hasOptionalColumn(rowView, "algorithm_version", String.class)
         .ifPresent(match::setAlgorithmVersion);

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -16,6 +16,8 @@ public class Match {
 
   private String consent;
 
+  private Integer datasetId;
+
   private String purpose;
 
   private Boolean match;
@@ -33,6 +35,7 @@ public class Match {
   public Match(
       Integer id,
       String consent,
+      Integer datasetId,
       String purpose,
       Boolean match,
       Boolean abstain,
@@ -41,6 +44,7 @@ public class Match {
       String algorithmVersion) {
     this.id = id;
     this.consent = consent;
+    this.datasetId = datasetId;
     this.purpose = purpose;
     this.match = match;
     this.abstain = abstain;
@@ -50,14 +54,15 @@ public class Match {
   }
 
   public Match(
-      String consentId,
+      Dataset dataset,
       String purposeId,
       boolean match,
       boolean abstain,
       boolean failed,
       MatchAlgorithm algorithm,
       List<String> rationales) {
-    this.setConsent(consentId);
+    this.setConsent(dataset.getDatasetIdentifier());
+    this.setDatasetId(dataset.getDatasetId());
     this.setPurpose(purposeId);
     this.setMatch(match);
     this.setAbstain(abstain);
@@ -83,6 +88,14 @@ public class Match {
 
   public void setConsent(String consent) {
     this.consent = consent;
+  }
+
+  public Integer getDatasetId() {
+    return datasetId;
+  }
+
+  public void setDatasetId(Integer datasetId) {
+    this.datasetId = datasetId;
   }
 
   public String getPurpose() {
@@ -154,17 +167,17 @@ public class Match {
   }
 
   public static Match matchFailure(
-      String consentId, String purposeId, MatchAlgorithm algorithm, List<String> rationales) {
-    return new Match(consentId, purposeId, false, false, true, algorithm, rationales);
+      Dataset dataset, String purposeId, MatchAlgorithm algorithm, List<String> rationales) {
+    return new Match(dataset, purposeId, false, false, true, algorithm, rationales);
   }
 
   public static Match matchSuccess(
-      String consentId,
+      Dataset dataset,
       String purposeId,
       DataUseMatchResultType match,
       MatchAlgorithm algorithm,
       List<String> rationales) {
     return new Match(
-        consentId, purposeId, Approve(match), Abstain(match), false, algorithm, rationales);
+        dataset, purposeId, Approve(match), Abstain(match), false, algorithm, rationales);
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/Match.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/Match.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.models;
 import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Abstain;
 import static org.broadinstitute.consent.http.models.matching.DataUseMatchResultType.Approve;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -16,7 +17,8 @@ public class Match {
 
   private String consent;
 
-  private Integer datasetId;
+  // Internal identity only: responses keep exposing the dataset through the public `consent` id.
+  @JsonIgnore private Integer datasetId;
 
   private String purpose;
 

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -50,6 +50,7 @@ public class MatchService implements ConsentLogger {
           Integer id =
               dao.insertMatch(
                   m.getConsent(),
+                  m.getDatasetId(),
                   m.getPurpose(),
                   m.getMatch(),
                   m.getFailed(),
@@ -92,8 +93,8 @@ public class MatchService implements ConsentLogger {
     if (datasetIds.isEmpty()) {
       return matches;
     }
-    // Fetch every dataset in a single query. Matching only needs the data use and the dataset
-    // identifier, both of which this query populates.
+    // Fetch every dataset in a single query. Matching only needs the data use and the dataset's
+    // identity, both of which this query populates.
     Map<Integer, Dataset> datasetsById =
         datasetDAO.findDatasetsByIdList(datasetIds).stream()
             .collect(Collectors.toMap(Dataset::getDatasetId, Function.identity()));
@@ -107,11 +108,7 @@ public class MatchService implements ConsentLogger {
               String message = "Error finding single match for purpose: " + dar.getReferenceId();
               logWarn(message);
               matches.add(
-                  matchFailure(
-                      dataset.getDatasetIdentifier(),
-                      dar.getReferenceId(),
-                      MatchAlgorithm.V5,
-                      List.of(message)));
+                  matchFailure(dataset, dar.getReferenceId(), MatchAlgorithm.V5, List.of(message)));
             }
           }
         });
@@ -136,7 +133,7 @@ public class MatchService implements ConsentLogger {
     MatchResult matchResult =
         dataUseMatcherV5.matchPurposeAndDatasetV5(darDataUse, dataset.getDataUse());
     return matchSuccess(
-        dataset.getDatasetIdentifier(),
+        dataset,
         dar.getReferenceId(),
         matchResult.getMatchResultType(),
         MatchAlgorithm.V5,

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchService.java
@@ -5,7 +5,6 @@ import static org.broadinstitute.consent.http.models.Match.matchSuccess;
 
 import com.google.inject.Inject;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -47,16 +46,7 @@ public class MatchService implements ConsentLogger {
   private static void insertMatches(MatchDAO dao, List<Match> match) {
     match.forEach(
         m -> {
-          Integer id =
-              dao.insertMatch(
-                  m.getConsent(),
-                  m.getDatasetId(),
-                  m.getPurpose(),
-                  m.getMatch(),
-                  m.getFailed(),
-                  new Date(),
-                  m.getAlgorithmVersion(),
-                  m.getAbstain());
+          Integer id = dao.insertMatch(m);
           if (!m.getRationales().isEmpty()) {
             m.getRationales().forEach(f -> dao.insertRationale(id, f));
           }

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -6,11 +6,6 @@ properties:
   consent:
     type: string
     description: The Consent ID or Dataset Identifier
-  datasetId:
-    type:
-      - integer
-      - 'null'
-    description: The id of the matched dataset. Null on legacy matches recorded before the column existed.
   purpose:
     type: string
     description: The Data Access Request ID

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -7,7 +7,9 @@ properties:
     type: string
     description: The Consent ID or Dataset Identifier
   datasetId:
-    type: integer
+    type:
+      - integer
+      - 'null'
     description: The id of the matched dataset. Null on legacy matches recorded before the column existed.
   purpose:
     type: string

--- a/src/main/resources/assets/schemas/MatchResult.yaml
+++ b/src/main/resources/assets/schemas/MatchResult.yaml
@@ -6,6 +6,9 @@ properties:
   consent:
     type: string
     description: The Consent ID or Dataset Identifier
+  datasetId:
+    type: integer
+    description: The id of the matched dataset. Null on legacy matches recorded before the column existed.
   purpose:
     type: string
     description: The Data Access Request ID

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -257,4 +257,5 @@
   <include file="changesets/changelog-consent-2026-08-07-so-dashboard-indices.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-09-09-match-dataset-id.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-09-09-match-dataset-id.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-09-09-match-dataset-id.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <!--
+    match_entity identifies its dataset by text in `consent`: the public `DUOS-######` identifier on
+    current rows, but a consent UUID on legacy ones, and those UUIDs resolve to no dataset since the
+    consent mapping was dropped in 2024. Add the real foreign key alongside it.
+
+    Nullable, and `consent` keeps being written, so an instance on the previous release can still
+    write a complete row and read one written by this release. The column becomes non-null once the
+    legacy rows have been reprocessed.
+  -->
+  <changeSet id="changelog-consent-2026-09-09-match-dataset-id" author="kmarete">
+    <addColumn tableName="match_entity">
+      <column name="dataset_id" type="bigint">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <addForeignKeyConstraint baseTableName="match_entity" baseColumnNames="dataset_id"
+      constraintName="fk_match_entity_dataset_id" referencedTableName="dataset"
+      referencedColumnNames="dataset_id" onDelete="CASCADE"/>
+    <!-- Deleting a dataset now cascades into match_entity, so the rationales of the rows it
+         removes have to go with them; the original constraint took no action. -->
+    <dropForeignKeyConstraint baseTableName="match_rationale"
+      constraintName="fk_match_failure_entity_id"/>
+    <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
+      constraintName="fk_match_rationale_match_entity_id" referencedTableName="match_entity"
+      referencedColumnNames="match_id" onDelete="CASCADE"/>
+    <rollback>
+      <dropForeignKeyConstraint baseTableName="match_rationale"
+        constraintName="fk_match_rationale_match_entity_id"/>
+      <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
+        constraintName="fk_match_failure_entity_id" referencedTableName="match_entity"
+        referencedColumnNames="match_id"/>
+      <dropColumn tableName="match_entity" columnName="dataset_id"/>
+    </rollback>
+  </changeSet>
+
+  <!--
+    Postgres does not index the referencing side of a foreign key, and the delete cascade above
+    reads match_entity by dataset_id. Built CONCURRENTLY (runInTransaction="false") to avoid the
+    write-blocking SHARE lock; see changelog-consent-2026-08-07-so-dashboard-indices.xml for
+    recovery notes.
+  -->
+  <changeSet id="changelog-consent-2026-09-09-match-dataset-id-index" author="kmarete"
+    runInTransaction="false">
+    <sql>CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_match_entity_dataset_id ON match_entity (dataset_id)</sql>
+    <rollback>
+      <sql>DROP INDEX CONCURRENTLY IF EXISTS idx_match_entity_dataset_id</sql>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-09-09-match-dataset-id.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-09-09-match-dataset-id.xml
@@ -10,6 +10,10 @@
     Nullable, and `consent` keeps being written, so an instance on the previous release can still
     write a complete row and read one written by this release. The column becomes non-null once the
     legacy rows have been reprocessed.
+
+    NO ACTION, like the sibling `dar_dataset` and `election` references. A dataset carrying matches
+    always carries the `dar_dataset` rows that produced them, so it is already undeletable, and
+    match deletion is driven by the DAR rather than by the dataset.
   -->
   <changeSet id="changelog-consent-2026-09-09-match-dataset-id" author="kmarete">
     <addColumn tableName="match_entity">
@@ -19,29 +23,17 @@
     </addColumn>
     <addForeignKeyConstraint baseTableName="match_entity" baseColumnNames="dataset_id"
       constraintName="fk_match_entity_dataset_id" referencedTableName="dataset"
-      referencedColumnNames="dataset_id" onDelete="CASCADE"/>
-    <!-- Deleting a dataset now cascades into match_entity, so the rationales of the rows it
-         removes have to go with them; the original constraint took no action. -->
-    <dropForeignKeyConstraint baseTableName="match_rationale"
-      constraintName="fk_match_failure_entity_id"/>
-    <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
-      constraintName="fk_match_rationale_match_entity_id" referencedTableName="match_entity"
-      referencedColumnNames="match_id" onDelete="CASCADE"/>
+      referencedColumnNames="dataset_id" onDelete="NO ACTION" onUpdate="NO ACTION"/>
     <rollback>
-      <dropForeignKeyConstraint baseTableName="match_rationale"
-        constraintName="fk_match_rationale_match_entity_id"/>
-      <addForeignKeyConstraint baseTableName="match_rationale" baseColumnNames="match_entity_id"
-        constraintName="fk_match_failure_entity_id" referencedTableName="match_entity"
-        referencedColumnNames="match_id"/>
       <dropColumn tableName="match_entity" columnName="dataset_id"/>
     </rollback>
   </changeSet>
 
   <!--
-    Postgres does not index the referencing side of a foreign key, and the delete cascade above
-    reads match_entity by dataset_id. Built CONCURRENTLY (runInTransaction="false") to avoid the
-    write-blocking SHARE lock; see changelog-consent-2026-08-07-so-dashboard-indices.xml for
-    recovery notes.
+    Postgres does not index the referencing side of a foreign key, so every dataset delete would
+    otherwise scan match_entity to enforce the constraint above. Built CONCURRENTLY
+    (runInTransaction="false") to avoid the write-blocking SHARE lock; see
+    changelog-consent-2026-08-07-so-dashboard-indices.xml for recovery notes.
   -->
   <changeSet id="changelog-consent-2026-09-09-match-dataset-id-index" author="kmarete"
     runInTransaction="false">

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import org.broadinstitute.consent.http.models.DatasetProperty;
 import org.broadinstitute.consent.http.models.Election;
 import org.broadinstitute.consent.http.models.Match;
 import org.broadinstitute.consent.http.models.User;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -267,6 +269,23 @@ class MatchDAOTest extends DAOTestHelper {
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
     assertEquals(1, matchResults.size());
     assertEquals(matchId, matchResults.getFirst().getId());
+  }
+
+  @Test
+  void testDeletingDatasetIsRefusedWhileMatchesReferenceIt() {
+    // The dataset reference is NO ACTION, not CASCADE: matches are deleted with the DAR that
+    // produced them, and taking them out silently with the dataset would drop the evidence behind
+    // a past access decision. The identifier is asserted so the refusal cannot come from some
+    // other reference to dataset.
+    Dataset dataset = createDataset();
+    matchDAO.insertMatch(makeMockMatch(dataset));
+    datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
+
+    UnableToExecuteStatementException thrown =
+        assertThrows(
+            UnableToExecuteStatementException.class,
+            () -> datasetDAO.deleteDatasetById(dataset.getDatasetId()));
+    assertTrue(thrown.getMessage().contains("fk_match_entity_dataset_id"));
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -246,38 +246,38 @@ class MatchDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testDeletingDatasetCascadesToMatchesAndRationales() {
+  void testFindMatchesForLatestDataAccessElectionsReturnsElectionsWithNoDatasetId() {
+    // election.dataset_id is nullable too, and a reprocessed match must not drop out of an older
+    // election that never recorded one.
     Dataset dataset = createDataset();
-    Match match = makeMockMatch(dataset);
-    match.addRationale(randomAlphabetic(100));
-    Integer matchId = matchDAO.insertMatch(match);
-    match.getRationales().forEach(r -> matchDAO.insertRationale(matchId, r));
-    assertEquals(1, getRationaleCount(matchId));
+    String darReferenceId = UUID.randomUUID().toString();
+    createDataAccessElection(darReferenceId, null);
 
-    datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
-    datasetDAO.deleteDatasetById(dataset.getDatasetId());
+    Integer matchId =
+        matchDAO.insertMatch(
+            mockMatch(
+                dataset.getDatasetIdentifier(),
+                dataset.getDatasetId(),
+                darReferenceId,
+                true,
+                false,
+                MatchAlgorithm.V5.getVersion()));
 
-    assertNull(matchDAO.findMatchById(matchId));
-    assertEquals(0, getRationaleCount(matchId));
-  }
-
-  private static Integer getRationaleCount(Integer matchId) {
-    return jdbi.withHandle(
-        handle ->
-            handle
-                .createQuery(
-                    "SELECT count(*) FROM match_rationale WHERE match_entity_id = :matchId")
-                .bind("matchId", matchId)
-                .mapTo(Integer.class)
-                .one());
+    List<Match> matchResults =
+        matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
+    assertEquals(1, matchResults.size());
+    assertEquals(matchId, matchResults.getFirst().getId());
   }
 
   @Test
   void testFindMatchById() {
     Match match = makeMockMatch(createDataset());
+    match.setAbstain(true);
     Integer matchId = matchDAO.insertMatch(match);
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
+    assertEquals(match.getDatasetId(), foundMatch.getDatasetId());
+    assertTrue(foundMatch.getAbstain());
   }
 
   @Test

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -278,13 +278,13 @@ class MatchDAOTest extends DAOTestHelper {
     // a past access decision. The identifier is asserted so the refusal cannot come from some
     // other reference to dataset.
     Dataset dataset = createDataset();
+    Integer datasetId = dataset.getDatasetId();
     matchDAO.insertMatch(makeMockMatch(dataset));
-    datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
+    datasetDAO.deleteDatasetPropertiesByDatasetId(datasetId);
 
     UnableToExecuteStatementException thrown =
         assertThrows(
-            UnableToExecuteStatementException.class,
-            () -> datasetDAO.deleteDatasetById(dataset.getDatasetId()));
+            UnableToExecuteStatementException.class, () -> datasetDAO.deleteDatasetById(datasetId));
     assertTrue(thrown.getMessage().contains("fk_match_entity_dataset_id"));
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.consent.http.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -36,13 +37,15 @@ class MatchDAOTest extends DAOTestHelper {
     assertEquals(found.getId(), m.getId());
     assertEquals(found.getPurpose(), m.getPurpose());
     assertEquals(found.getConsent(), m.getConsent());
+    assertEquals(found.getDatasetId(), m.getDatasetId());
     assertEquals(found.getFailed(), m.getFailed());
     assertEquals(found.getMatch(), m.getMatch());
   }
 
-  private Match makeMockMatch(String consentId) {
+  private Match makeMockMatch(Dataset dataset) {
     Match match = new Match();
-    match.setConsent(consentId);
+    match.setConsent(dataset.getDatasetIdentifier());
+    match.setDatasetId(dataset.getDatasetId());
     match.setPurpose(UUID.randomUUID().toString());
     match.setFailed(false);
     match.setCreateDate(FIXED_DATE);
@@ -90,6 +93,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This match represents the match record generated for the target election
     matchDAO.insertMatch(
         datasetIdentifier,
+        dataset.getDatasetId(),
         darReferenceId,
         true,
         false,
@@ -100,6 +104,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This match represents the match record generated for the ignored access election
     matchDAO.insertMatch(
         datasetIdentifier,
+        dataset.getDatasetId(),
         ignoredAccessElection.getReferenceId(),
         false,
         false,
@@ -111,6 +116,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
         datasetIdentifier,
+        dataset.getDatasetId(),
         unknownElection.getReferenceId(),
         false,
         false,
@@ -141,6 +147,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This match represents the match record generated for the access election
     matchDAO.insertMatch(
         datasetIdentifier,
+        dataset.getDatasetId(),
         accessElection.getReferenceId(),
         true,
         false,
@@ -152,6 +159,7 @@ class MatchDAOTest extends DAOTestHelper {
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
         datasetIdentifier,
+        dataset.getDatasetId(),
         unknownElection.getReferenceId(),
         false,
         false,
@@ -169,11 +177,109 @@ class MatchDAOTest extends DAOTestHelper {
   }
 
   @Test
-  void testFindMatchById() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+  void testFindMatchesForLatestDataAccessElectionsCorrelatesOnDatasetId() {
+    // A multi-dataset purpose where only one of its datasets went to a data access election. The
+    // other dataset's match has no election of its own and must not borrow the first one's.
+    Dataset elected = createDataset();
+    Dataset notElected = createDataset();
+    String darReferenceId = UUID.randomUUID().toString();
+    createDataAccessElection(darReferenceId, elected.getDatasetId());
+
+    Integer electedMatchId =
+        matchDAO.insertMatch(
+            elected.getDatasetIdentifier(),
+            elected.getDatasetId(),
+            darReferenceId,
+            true,
+            false,
+            FIXED_DATE,
+            MatchAlgorithm.V5.getVersion(),
+            false);
+    matchDAO.insertMatch(
+        notElected.getDatasetIdentifier(),
+        notElected.getDatasetId(),
+        darReferenceId,
+        true,
+        false,
+        FIXED_DATE,
+        MatchAlgorithm.V5.getVersion(),
+        false);
+
+    List<Match> matchResults =
+        matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
+    assertEquals(1, matchResults.size());
+    assertEquals(electedMatchId, matchResults.getFirst().getId());
+  }
+
+  @Test
+  void testFindMatchesForLatestDataAccessElectionsReturnsMatchesWithNoDatasetId() {
+    // Legacy rows predate dataset_id and are still readable until they have been reprocessed.
+    Dataset dataset = createDataset();
+    String darReferenceId = UUID.randomUUID().toString();
+    createDataAccessElection(darReferenceId, dataset.getDatasetId());
+
+    Integer matchId =
+        matchDAO.insertMatch(
+            UUID.randomUUID().toString(),
+            null,
+            darReferenceId,
+            true,
+            false,
+            FIXED_DATE,
+            MatchAlgorithm.V1.getVersion(),
+            false);
+
+    List<Match> matchResults =
+        matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
+    assertEquals(1, matchResults.size());
+    Match result = matchResults.getFirst();
+    assertEquals(matchId, result.getId());
+    assertNull(result.getDatasetId());
+  }
+
+  @Test
+  void testDeletingDatasetCascadesToMatchesAndRationales() {
+    Dataset dataset = createDataset();
+    Match match = makeMockMatch(dataset);
+    match.addRationale(randomAlphabetic(100));
     Integer matchId =
         matchDAO.insertMatch(
             match.getConsent(),
+            match.getDatasetId(),
+            match.getPurpose(),
+            match.getMatch(),
+            match.getFailed(),
+            match.getCreateDate(),
+            match.getAlgorithmVersion(),
+            match.getAbstain());
+    match.getRationales().forEach(r -> matchDAO.insertRationale(matchId, r));
+    assertEquals(1, getRationaleCount(matchId));
+
+    datasetDAO.deleteDatasetPropertiesByDatasetId(dataset.getDatasetId());
+    datasetDAO.deleteDatasetById(dataset.getDatasetId());
+
+    assertNull(matchDAO.findMatchById(matchId));
+    assertEquals(0, getRationaleCount(matchId));
+  }
+
+  private static Integer getRationaleCount(Integer matchId) {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    "SELECT count(*) FROM match_rationale WHERE match_entity_id = :matchId")
+                .bind("matchId", matchId)
+                .mapTo(Integer.class)
+                .one());
+  }
+
+  @Test
+  void testFindMatchById() {
+    Match match = makeMockMatch(createDataset());
+    Integer matchId =
+        matchDAO.insertMatch(
+            match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -186,7 +292,7 @@ class MatchDAOTest extends DAOTestHelper {
 
   @Test
   void testInsertFailureReason() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Match match = makeMockMatch(createDataset());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
@@ -194,6 +300,7 @@ class MatchDAOTest extends DAOTestHelper {
     Integer matchId =
         matchDAO.insertMatch(
             match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -208,7 +315,7 @@ class MatchDAOTest extends DAOTestHelper {
 
   @Test
   void testDeleteFailureReasonsByPurposeIds() {
-    Match match = makeMockMatch(UUID.randomUUID().toString());
+    Match match = makeMockMatch(createDataset());
     match.setMatch(false);
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
@@ -216,6 +323,7 @@ class MatchDAOTest extends DAOTestHelper {
     Integer matchId =
         matchDAO.insertMatch(
             match.getConsent(),
+            match.getDatasetId(),
             match.getPurpose(),
             match.getMatch(),
             match.getFailed(),
@@ -236,6 +344,7 @@ class MatchDAOTest extends DAOTestHelper {
     Integer matchId =
         matchDAO.insertMatch(
             dataset.getDatasetIdentifier(),
+            dataset.getDatasetId(),
             dar.getReferenceId(),
             randomBoolean(),
             false,

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchDAOTest.java
@@ -43,16 +43,32 @@ class MatchDAOTest extends DAOTestHelper {
   }
 
   private Match makeMockMatch(Dataset dataset) {
-    Match match = new Match();
-    match.setConsent(dataset.getDatasetIdentifier());
-    match.setDatasetId(dataset.getDatasetId());
-    match.setPurpose(UUID.randomUUID().toString());
-    match.setFailed(false);
-    match.setCreateDate(FIXED_DATE);
-    match.setMatch(randomBoolean());
-    match.setAlgorithmVersion(MatchAlgorithm.V1.getVersion());
-    match.setAbstain(false);
-    return match;
+    return mockMatch(
+        dataset.getDatasetIdentifier(),
+        dataset.getDatasetId(),
+        UUID.randomUUID().toString(),
+        randomBoolean(),
+        false,
+        MatchAlgorithm.V1.getVersion());
+  }
+
+  private Match mockMatch(
+      String consent,
+      Integer datasetId,
+      String purposeId,
+      boolean match,
+      boolean failed,
+      String algorithmVersion) {
+    Match m = new Match();
+    m.setConsent(consent);
+    m.setDatasetId(datasetId);
+    m.setPurpose(purposeId);
+    m.setMatch(match);
+    m.setFailed(failed);
+    m.setAbstain(false);
+    m.setCreateDate(FIXED_DATE);
+    m.setAlgorithmVersion(algorithmVersion);
+    return m;
   }
 
   @Test
@@ -92,37 +108,34 @@ class MatchDAOTest extends DAOTestHelper {
 
     // This match represents the match record generated for the target election
     matchDAO.insertMatch(
-        datasetIdentifier,
-        dataset.getDatasetId(),
-        darReferenceId,
-        true,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V4.getVersion(),
-        false);
+        mockMatch(
+            datasetIdentifier,
+            dataset.getDatasetId(),
+            darReferenceId,
+            true,
+            false,
+            MatchAlgorithm.V4.getVersion()));
 
     // This match represents the match record generated for the ignored access election
     matchDAO.insertMatch(
-        datasetIdentifier,
-        dataset.getDatasetId(),
-        ignoredAccessElection.getReferenceId(),
-        false,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V4.getVersion(),
-        false);
+        mockMatch(
+            datasetIdentifier,
+            dataset.getDatasetId(),
+            ignoredAccessElection.getReferenceId(),
+            false,
+            false,
+            MatchAlgorithm.V4.getVersion()));
 
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
-        datasetIdentifier,
-        dataset.getDatasetId(),
-        unknownElection.getReferenceId(),
-        false,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V4.getVersion(),
-        true);
+        mockMatch(
+            datasetIdentifier,
+            dataset.getDatasetId(),
+            unknownElection.getReferenceId(),
+            false,
+            false,
+            MatchAlgorithm.V4.getVersion()));
 
     List<Match> matchResults =
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
@@ -146,26 +159,24 @@ class MatchDAOTest extends DAOTestHelper {
 
     // This match represents the match record generated for the access election
     matchDAO.insertMatch(
-        datasetIdentifier,
-        dataset.getDatasetId(),
-        accessElection.getReferenceId(),
-        true,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V4.getVersion(),
-        false);
+        mockMatch(
+            datasetIdentifier,
+            dataset.getDatasetId(),
+            accessElection.getReferenceId(),
+            true,
+            false,
+            MatchAlgorithm.V4.getVersion()));
 
     // This match is never created under consent's workflow (unless the cause is a bug)
     // This is included simply to test the DataAccess conditional on the INNER JOIN statement
     matchDAO.insertMatch(
-        datasetIdentifier,
-        dataset.getDatasetId(),
-        unknownElection.getReferenceId(),
-        false,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V4.getVersion(),
-        false);
+        mockMatch(
+            datasetIdentifier,
+            dataset.getDatasetId(),
+            unknownElection.getReferenceId(),
+            false,
+            false,
+            MatchAlgorithm.V4.getVersion()));
 
     // Negative testing means we'll feed the query a reference id that isn't tied to a DataAccess
     // election
@@ -187,23 +198,21 @@ class MatchDAOTest extends DAOTestHelper {
 
     Integer electedMatchId =
         matchDAO.insertMatch(
-            elected.getDatasetIdentifier(),
-            elected.getDatasetId(),
+            mockMatch(
+                elected.getDatasetIdentifier(),
+                elected.getDatasetId(),
+                darReferenceId,
+                true,
+                false,
+                MatchAlgorithm.V5.getVersion()));
+    matchDAO.insertMatch(
+        mockMatch(
+            notElected.getDatasetIdentifier(),
+            notElected.getDatasetId(),
             darReferenceId,
             true,
             false,
-            FIXED_DATE,
-            MatchAlgorithm.V5.getVersion(),
-            false);
-    matchDAO.insertMatch(
-        notElected.getDatasetIdentifier(),
-        notElected.getDatasetId(),
-        darReferenceId,
-        true,
-        false,
-        FIXED_DATE,
-        MatchAlgorithm.V5.getVersion(),
-        false);
+            MatchAlgorithm.V5.getVersion()));
 
     List<Match> matchResults =
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
@@ -220,14 +229,13 @@ class MatchDAOTest extends DAOTestHelper {
 
     Integer matchId =
         matchDAO.insertMatch(
-            UUID.randomUUID().toString(),
-            null,
-            darReferenceId,
-            true,
-            false,
-            FIXED_DATE,
-            MatchAlgorithm.V1.getVersion(),
-            false);
+            mockMatch(
+                UUID.randomUUID().toString(),
+                null,
+                darReferenceId,
+                true,
+                false,
+                MatchAlgorithm.V1.getVersion()));
 
     List<Match> matchResults =
         matchDAO.findMatchesForLatestDataAccessElectionsByPurposeIds(List.of(darReferenceId));
@@ -242,16 +250,7 @@ class MatchDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Match match = makeMockMatch(dataset);
     match.addRationale(randomAlphabetic(100));
-    Integer matchId =
-        matchDAO.insertMatch(
-            match.getConsent(),
-            match.getDatasetId(),
-            match.getPurpose(),
-            match.getMatch(),
-            match.getFailed(),
-            match.getCreateDate(),
-            match.getAlgorithmVersion(),
-            match.getAbstain());
+    Integer matchId = matchDAO.insertMatch(match);
     match.getRationales().forEach(r -> matchDAO.insertRationale(matchId, r));
     assertEquals(1, getRationaleCount(matchId));
 
@@ -276,16 +275,7 @@ class MatchDAOTest extends DAOTestHelper {
   @Test
   void testFindMatchById() {
     Match match = makeMockMatch(createDataset());
-    Integer matchId =
-        matchDAO.insertMatch(
-            match.getConsent(),
-            match.getDatasetId(),
-            match.getPurpose(),
-            match.getMatch(),
-            match.getFailed(),
-            match.getCreateDate(),
-            match.getAlgorithmVersion(),
-            match.getAbstain());
+    Integer matchId = matchDAO.insertMatch(match);
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
   }
@@ -297,16 +287,7 @@ class MatchDAOTest extends DAOTestHelper {
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
     match.addRationale(randomAlphabetic(100));
-    Integer matchId =
-        matchDAO.insertMatch(
-            match.getConsent(),
-            match.getDatasetId(),
-            match.getPurpose(),
-            match.getMatch(),
-            match.getFailed(),
-            match.getCreateDate(),
-            match.getAlgorithmVersion(),
-            match.getAbstain());
+    Integer matchId = matchDAO.insertMatch(match);
     match.getRationales().forEach(f -> matchDAO.insertRationale(matchId, f));
     Match foundMatch = matchDAO.findMatchById(matchId);
     assertNotNull(foundMatch);
@@ -320,16 +301,7 @@ class MatchDAOTest extends DAOTestHelper {
     match.setAlgorithmVersion(MatchAlgorithm.V4.getVersion());
     match.addRationale(randomAlphabetic(100));
     match.addRationale(randomAlphabetic(100));
-    Integer matchId =
-        matchDAO.insertMatch(
-            match.getConsent(),
-            match.getDatasetId(),
-            match.getPurpose(),
-            match.getMatch(),
-            match.getFailed(),
-            match.getCreateDate(),
-            match.getAlgorithmVersion(),
-            match.getAbstain());
+    Integer matchId = matchDAO.insertMatch(match);
     match.getRationales().forEach(f -> matchDAO.insertRationale(matchId, f));
     matchDAO.deleteRationalesByPurposeIds(List.of(match.getPurpose()));
     Match foundMatch = matchDAO.findMatchById(matchId);
@@ -343,14 +315,13 @@ class MatchDAOTest extends DAOTestHelper {
     Dataset dataset = createDataset();
     Integer matchId =
         matchDAO.insertMatch(
-            dataset.getDatasetIdentifier(),
-            dataset.getDatasetId(),
-            dar.getReferenceId(),
-            randomBoolean(),
-            false,
-            FIXED_DATE,
-            MatchAlgorithm.V4.getVersion(),
-            false);
+            mockMatch(
+                dataset.getDatasetIdentifier(),
+                dataset.getDatasetId(),
+                dar.getReferenceId(),
+                randomBoolean(),
+                false,
+                MatchAlgorithm.V4.getVersion()));
     return matchDAO.findMatchById(matchId);
   }
 

--- a/src/test/java/org/broadinstitute/consent/http/models/MatchTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/models/MatchTest.java
@@ -1,0 +1,35 @@
+package org.broadinstitute.consent.http.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.models.matching.DataUseMatchResultType;
+import org.junit.jupiter.api.Test;
+
+class MatchTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void datasetIdIsNotSerialized() throws Exception {
+    Dataset dataset = new Dataset();
+    dataset.setDatasetId(42);
+    dataset.setAlias(7);
+    Match match =
+        Match.matchSuccess(
+            dataset, "purpose", DataUseMatchResultType.APPROVE, MatchAlgorithm.V5, List.of());
+
+    ObjectNode json = (ObjectNode) mapper.readTree(mapper.writeValueAsString(match));
+
+    // dataset_id is internal identity: responses carry the dataset as its public identifier only.
+    assertFalse(json.has("datasetId"));
+    assertTrue(json.has("consent"));
+    assertEquals(dataset.getDatasetIdentifier(), json.get("consent").asText());
+    assertEquals(42, match.getDatasetId());
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
@@ -38,6 +37,7 @@ import org.jdbi.v3.sqlobject.transaction.TransactionalConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -237,16 +237,13 @@ class MatchServiceTest extends AbstractTestHelper {
     service.reprocessMatchesForPurpose(dar.getReferenceId());
     verify(matchDAO).deleteRationalesByPurposeIds(List.of(dar.getReferenceId()));
     verify(matchDAO).deleteMatchesByPurposeId(dar.getReferenceId());
-    verify(matchDAO)
-        .insertMatch(
-            eq(dataset.getDatasetIdentifier()),
-            eq(dataset.getDatasetId()),
-            eq(dar.getReferenceId()),
-            any(),
-            any(),
-            any(),
-            eq(MatchAlgorithm.V5.getVersion()),
-            any());
+    ArgumentCaptor<Match> inserted = ArgumentCaptor.forClass(Match.class);
+    verify(matchDAO).insertMatch(inserted.capture());
+    Match persisted = inserted.getValue();
+    assertEquals(dataset.getDatasetIdentifier(), persisted.getConsent());
+    assertEquals(dataset.getDatasetId(), persisted.getDatasetId());
+    assertEquals(dar.getReferenceId(), persisted.getPurpose());
+    assertEquals(MatchAlgorithm.V5.getVersion(), persisted.getAlgorithmVersion());
   }
 
   /** The rebuild is computed first, so a purpose is never left with its matches deleted. */
@@ -291,7 +288,7 @@ class MatchServiceTest extends AbstractTestHelper {
 
     verify(matchDAO).deleteRationalesByPurposeIds(List.of("DAR-gone"));
     verify(matchDAO).deleteMatchesByPurposeId("DAR-gone");
-    verify(matchDAO, never()).insertMatch(any(), any(), any(), any(), any(), any(), any(), any());
+    verify(matchDAO, never()).insertMatch(any());
   }
 
   /** Runs the transaction body against the mock, which otherwise never invokes the callback. */

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchServiceTest.java
@@ -93,7 +93,11 @@ class MatchServiceTest extends AbstractTestHelper {
       List<Match> matches = service.createMatchesForDataAccessRequest(dar);
       assertFalse(matches.isEmpty());
       // Each match should be false since the exception is thrown during the matching process
-      matches.forEach(m -> assertFalse(m.getMatch()));
+      matches.forEach(
+          m -> {
+            assertFalse(m.getMatch());
+            assertEquals(dataset.getDatasetId(), m.getDatasetId());
+          });
     } catch (Exception e) {
       fail(
           "createMatchesForDataAccessRequest should not throw an exception even if singleEntitiesMatch fails: "
@@ -180,6 +184,7 @@ class MatchServiceTest extends AbstractTestHelper {
   void testSingleEntitiesMatch() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
+    dataset.setAlias(1);
     dataset.setName("Test Dataset 1");
     dataset.setDataUse(new DataUseBuilder().setHmbResearch(true).build());
     dataset.setProperties(Collections.emptySet());
@@ -195,6 +200,8 @@ class MatchServiceTest extends AbstractTestHelper {
     assertNotNull(match);
     assertTrue(match.getMatch());
     assertEquals(MatchAlgorithm.V5.getVersion(), match.getAlgorithmVersion());
+    assertEquals(dataset.getDatasetId(), match.getDatasetId());
+    assertEquals(dataset.getDatasetIdentifier(), match.getConsent());
   }
 
   @Test
@@ -211,6 +218,7 @@ class MatchServiceTest extends AbstractTestHelper {
   void testReprocessMatchesForPurpose() {
     Dataset dataset = new Dataset();
     dataset.setDatasetId(1);
+    dataset.setAlias(1);
     dataset.setName("Test Dataset 1");
     dataset.setDataUse(new DataUseBuilder().setHmbResearch(true).build());
     dataset.setProperties(Collections.emptySet());
@@ -230,7 +238,15 @@ class MatchServiceTest extends AbstractTestHelper {
     verify(matchDAO).deleteRationalesByPurposeIds(List.of(dar.getReferenceId()));
     verify(matchDAO).deleteMatchesByPurposeId(dar.getReferenceId());
     verify(matchDAO)
-        .insertMatch(any(), any(), any(), any(), any(), eq(MatchAlgorithm.V5.getVersion()), any());
+        .insertMatch(
+            eq(dataset.getDatasetIdentifier()),
+            eq(dataset.getDatasetId()),
+            eq(dar.getReferenceId()),
+            any(),
+            any(),
+            any(),
+            eq(MatchAlgorithm.V5.getVersion()),
+            any());
   }
 
   /** The rebuild is computed first, so a purpose is never left with its matches deleted. */
@@ -275,7 +291,7 @@ class MatchServiceTest extends AbstractTestHelper {
 
     verify(matchDAO).deleteRationalesByPurposeIds(List.of("DAR-gone"));
     verify(matchDAO).deleteMatchesByPurposeId("DAR-gone");
-    verify(matchDAO, never()).insertMatch(any(), any(), any(), any(), any(), any(), any());
+    verify(matchDAO, never()).insertMatch(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   /** Runs the transaction body against the mock, which otherwise never invokes the callback. */
@@ -323,6 +339,7 @@ class MatchServiceTest extends AbstractTestHelper {
     return new Match(
         1,
         UUID.randomUUID().toString(),
+        1,
         UUID.randomUUID().toString(),
         true,
         true,


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-3942 — security risk: low

Phase 1 only. Phase 2 (snapshot, reprocess, reconcile, constraints) is gated on this being deployed everywhere and will be a separate PR.

## Summary

Persisted matches identify their dataset by text in `match_entity.consent`. Current rows hold the public `DUOS-######` identifier, but the 409 legacy rows hold a consent UUID, and those resolve to no dataset since the consent mapping was dropped in 2024. This adds the real foreign key so the mapping question goes away instead of being answered by guesswork.

**Schema** (`changelog-consent-2026-09-09-match-dataset-id.xml`) — nullable `match_entity.dataset_id` with a `NO ACTION` foreign key to `dataset`, matching the sibling `dar_dataset` and `election` references, plus `idx_match_entity_dataset_id` built `CONCURRENTLY` in its own non-transactional changeset because Postgres does not index the referencing side of a foreign key and every dataset delete would otherwise scan `match_entity` to enforce the constraint.

**Writes** — `insertMatch` persists `dataset_id`, and `matchSuccess`/`matchFailure` take the `Dataset` rather than its identifier string so the id and the public text come from one object and cannot drift. `consent` keeps being written.

**Reads** — `findMatchesForLatestDataAccessElectionsByPurposeIds` joined elections on `reference_id` alone while partitioning by `(reference_id, dataset_id)`, so a multi-dataset DAR cross-joined every latest election against every match row for the purpose. It now correlates on `dataset_id`. The observable fix: a dataset with no data access election of its own no longer borrows another dataset's.

**Compatibility** — the column is nullable and `consent` is still written, so an instance on the previous release writes complete rows and reads ours. `dataset_id` is nullable on `election` too, so the join correlates only when both sides carry one; that tolerance keeps legacy rows and legacy elections visible until Phase 2, and the comment says so.

`dataset_id` stays internal — it is `@JsonIgnore` on `Match` and absent from `MatchResult.yaml`, since `consent` already carries the public identifier and this ticket is not meant to make the numeric id public. `docs/plans/data-use-primary-consistency-plan.md` tracked this as Ticket 5 and still prescribed the backfill approach that Greg's review replaced with reprocess-and-delete, so its status row and implementation notes are updated to match the ticket.

### Operational impact

Raised because Copilot flagged this for human validation of the schema and data-migration impacts. In short: **this release migrates no data and changes no delete behavior.** The column is added nullable and nothing is backfilled, so every existing match row is untouched.

**Dataset deletion is unchanged.** An earlier revision made the new key cascade — dataset → matches → rationales — and replaced `match_rationale`'s foreign key to carry it. Review established the cascade could not fire: `DatasetServiceDAO.deleteDataset` never removes `dar_dataset` or `election` rows, which hold `NO ACTION` references of their own, and `DatasetReducer` derives `deletable` from the absence of `dar_dataset` rows, so a dataset carrying matches is already undeletable through the API. Both cascades are gone. `NO ACTION` also adds no new failure path, since `deleteDataAccessRequest` deletes matches and rationales before `dar_dataset` — no match outlives the `dar_dataset` row that produced it. Orphaned legacy match rows stay orphaned, as they are today; Phase 2's reprocess is what clears them.

**Lock profile of the changeset.** `addForeignKeyConstraint` takes ACCESS EXCLUSIVE on `match_entity` and validates existing rows — all of which are NULL at this point, so validation passes trivially. `match_rationale` is no longer touched, so nothing revalidates it.

**An interrupted index build needs manual cleanup.** `CREATE INDEX CONCURRENTLY` cannot run in a transaction, hence the separate `runInTransaction="false"` changeset. If a deploy is interrupted partway, it leaves an INVALID index that `IF NOT EXISTS` will then skip on re-run — check `pg_index.indisvalid = false` and drop before re-deploying. Same recovery as `changelog-consent-2026-08-07-so-dashboard-indices.xml`, which the changeset cites.

**Rollback** is the changeset's own rollback block: drop the column, which drops its constraint and index with it. Nothing to restore, since nothing was rewritten.

### Testing

`MatchDAOTest` 12/12, `MatchServiceTest` 15/15, `MatchResourceTest` 5/5, and `DatasetDAOTest`/`DatasetServiceDAOTest` 121/121 since the new foreign key touches the dataset delete path. New cases cover the per-dataset election correlation, reads of legacy rows with a null `dataset_id`, reads against a legacy election with a null `dataset_id`, the round trip of `dataset_id` and `abstain` through the rewritten INSERT, and the refusal of a dataset delete while a match references it — asserting the constraint identifier, so it cannot pass on an unrelated reference to `dataset`.

### Reviewer notes

- The null tolerance in the election join is deliberate and temporary, and it applies to both sides: without it, legacy match rows and matches under an older election that never recorded a `dataset_id` would drop out of `/api/match/purpose/batch` between this deploy and the Phase 2 reprocess.
- The new foreign key is `NO ACTION` rather than cascading. See the deletion note above — the cascade was unreachable, and dropping it also removes a write-blocking revalidation of `match_rationale` at deploy time.
- Left `findMatchesForLatestDataAccessElectionsByPurposeIds` as an inline subquery rather than converting it to a CTE. The query scans once, so a CTE would not reduce work, and keeping the diff to the join predicate makes the semantic change easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
