### PR TITLE
[DT-3942] Add the match dataset_id migration surface and snapshot

### DIFF
--- a/docs/plans/data-use-primary-consistency-plan.md
+++ b/docs/plans/data-use-primary-consistency-plan.md
@@ -10,7 +10,7 @@ In progress. Ticket-by-ticket state:
 | 2. Canonical primary classification on Data Use writes | Done. `DataUsePrimaryClassifier`/`DataUsePrimaryValidator` back registration, admin Data Use replacement, and dataset-to-study conversion. |
 | 3. Explicit legacy and unsupported matcher behavior | Done. `DataUseMatcherV5` classifies before matching and abstains on Other-only, NONE/null, and MULTIPLE. |
 | 4. Normalize legacy records and reprocess affected matches | Done. |
-| 5. Replace alias-derived internal dataset references | In progress. Alias allocation moved to a database sequence (DT-3865). For matches (DT-3942), Phase 1 has landed: nullable `match_entity.dataset_id`, dual write, and a dataset-correlated election join. The reprocess and the non-null and uniqueness constraints follow once Phase 1 is deployed everywhere. |
+| 5. Replace alias-derived internal dataset references | In progress. Alias allocation moved to a database sequence (DT-3865). For matches (DT-3942), Phase 1 has landed: nullable `match_entity.dataset_id`, dual write, and a dataset-correlated election join. Phase 2a adds the snapshot tables and the admin migration surface that runs the reprocess. The constraints are release C, gated on that run reporting clean. |
 | 6. Align duos-ui with the canonical classification | Done in duos-ui (DT-3866). The Data Use translation collapse is an owned follow-up (DT-4008). |
 
 ## Objective
@@ -498,6 +498,60 @@ in external contracts and does not make the internal numeric `dataset_id` public
 - Replacing the `DUOS-######` public identifier contract.
 - Reusing deleted aliases or requiring gapless alias numbering.
 - Changing Data Use classification or matcher decisions.
+
+
+**Phase 2 execution and validation (DT-3942)**
+
+Three releases, because the constraints must not deploy until the run that clears them has happened.
+Their changeset halts on the same conditions the run reports, so releasing it early fails the deploy
+rather than corrupting anything - but a halted deploy is still a broken deploy, so the ordering is
+not optional.
+
+| Release | Contents | Gate to the next |
+| --- | --- | --- |
+| A | Nullable `dataset_id`, dual write, dataset-correlated election join | Deployed everywhere |
+| B | Snapshot tables and the admin migration surface | `run` reports `readyForConstraints` |
+| C | Non-null and `(purpose, dataset_id)` uniqueness constraints; retire the surface | Confirmed good |
+
+Pre-deployment, per environment, before running anything:
+
+- `GET /api/match/migration/dataset-id/population`. Record `affectedMatches`, `affectedPurposes`,
+  `versionV1`, `versionV2`, `versionNull`, `archivedOrMissingPurposes`, and
+  `duplicatePurposeDatasetPairs`. These are recounted on every call and drain on their own as DARs
+  are re-matched, so the figures in this plan and in the ticket are illustrative only.
+- A non-zero `archivedOrMissingPurposes` is expected to be zero in production but is not an error:
+  those purposes are skipped, reported by id, and left for a decision.
+- A non-zero `duplicatePurposeDatasetPairs` blocks release C on its own and is not something the run
+  fixes. Reconcile those pairs first.
+
+Post-deployment, after `POST /api/match/migration/dataset-id/run`:
+
+- `readyForConstraints` is the single check. It requires both that the reconciliation balances and
+  that nothing affected remains beyond what was skipped.
+- `run.failedPurposeIds` scopes a rerun. The run is restartable: each purpose is rebuilt in its own
+  transaction and the snapshot keeps its first capture, so re-running is safe and captures nothing
+  new.
+- `snapshottedRowsGone` plus `snapshottedRowsRemaining` equals `snapshotted`, and
+  `snapshottedRowsRemaining` equals `unresolvableRows`. A snapshotted row that is still present was
+  not handled, because a reprocess deletes and re-inserts under new ids.
+- `purposesHoldingNoMatches` counts the intended deletions - purposes whose DAR carries no dataset
+  associations. Expect this to be non-zero and reconcile it against the population's
+  `affectedPurposes`.
+- Re-check `GET /api/match/migration/dataset-id/reconciliation` after any DAR activity, before
+  releasing C.
+
+Rollback:
+
+- Before release C, restoring is an insert from `match_migration_snapshot` and
+  `match_migration_rationale_snapshot`; the snapshot carries no foreign key to `match_entity`, so it
+  survives the deletion of the rows it describes. Restored rows return under new `match_id`s, which
+  is why reconciliation keys on presence rather than on identity.
+- After release C, the constraints reject the legacy shape, so rolling back means rolling back that
+  changeset first.
+- Release A's changeset rolls back on its own; the election join's `IS NULL` tolerance means a
+  half-migrated table still reads correctly either side of it.
+- Retain both snapshot tables until the migration is confirmed good in production, then drop them
+  with the surface.
 
 ---
 

--- a/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentApplication.java
@@ -69,6 +69,7 @@ import org.broadinstitute.consent.http.resources.InstitutionResource;
 import org.broadinstitute.consent.http.resources.LibraryCardResource;
 import org.broadinstitute.consent.http.resources.LivenessResource;
 import org.broadinstitute.consent.http.resources.MailResource;
+import org.broadinstitute.consent.http.resources.MatchMigrationResource;
 import org.broadinstitute.consent.http.resources.MatchResource;
 import org.broadinstitute.consent.http.resources.MetricsResource;
 import org.broadinstitute.consent.http.resources.NihAccountResource;
@@ -188,6 +189,7 @@ public class ConsentApplication extends Application<ConsentConfiguration> {
     env.jersey().register(injector.getInstance(LivenessResource.class));
     env.jersey().register(injector.getInstance(MailResource.class));
     env.jersey().register(injector.getInstance(MatchResource.class));
+    env.jersey().register(injector.getInstance(MatchMigrationResource.class));
     env.jersey().register(injector.getInstance(MetricsResource.class));
     env.jersey().register(injector.getInstance(NihAccountResource.class));
     env.jersey().register(injector.getInstance(OAuth2Resource.class));

--- a/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
+++ b/src/main/java/org/broadinstitute/consent/http/ConsentModule.java
@@ -69,6 +69,7 @@ import org.broadinstitute.consent.http.service.FeatureFlagService;
 import org.broadinstitute.consent.http.service.FileStorageObjectService;
 import org.broadinstitute.consent.http.service.InstitutionService;
 import org.broadinstitute.consent.http.service.LibraryCardService;
+import org.broadinstitute.consent.http.service.MatchMigrationService;
 import org.broadinstitute.consent.http.service.MatchService;
 import org.broadinstitute.consent.http.service.MetricsService;
 import org.broadinstitute.consent.http.service.NihService;
@@ -811,6 +812,13 @@ public class ConsentModule extends AbstractModule implements ConsentLogger {
       UseRestrictionConverter useRestrictionConverter,
       DataUseMatcherV5 dataUseMatcherV5) {
     return new MatchService(jdbi, useRestrictionConverter, dataUseMatcherV5);
+  }
+
+  @Provides
+  @Singleton
+  private MatchMigrationService providesMatchMigrationService(
+      Jdbi jdbi, MatchService matchService) {
+    return new MatchMigrationService(jdbi, matchService);
   }
 
   @Provides

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
@@ -16,7 +16,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
  * {@code v1} or {@code v2} stamp, or has no stamp at all. Versions are reported separately because
  * the acceptance criteria count those populations, but they are not what selects the work.
  *
- * <p>{@code ARCHIVED_TEST} repeats the archived-status condition from {@code
+ * <p>{@code NOT_ARCHIVED} repeats the not-archived condition from {@code
  * DataAccessRequestDAO.findByReferenceId} rather than sharing it. That lookup is what a reprocess
  * resolves its DAR through, so the run has to predict it exactly; if it changes, these queries have
  * to be revisited deliberately, not silently follow it.
@@ -30,8 +30,7 @@ public interface MatchMigrationDAO {
         OR LOWER(m.algorithm_version) IN ('v1', 'v2'))
       """;
 
-  String ARCHIVED_TEST =
-      "(LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)";
+  String NOT_ARCHIVED = "(LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)";
 
   /**
    * Counted in one statement so the totals cannot disagree with each other, and recounted on every
@@ -52,7 +51,7 @@ public interface MatchMigrationDAO {
         FROM affected a
         JOIN data_access_request dar ON dar.reference_id = a.purpose
         WHERE """
-          + ARCHIVED_TEST
+          + NOT_ARCHIVED
           + """
       ),
       counts AS (
@@ -95,7 +94,7 @@ public interface MatchMigrationDAO {
       WHERE """
           + AFFECTED_PREDICATE
           + " AND "
-          + ARCHIVED_TEST
+          + NOT_ARCHIVED
           + """
       ORDER BY m.purpose
       """)
@@ -113,7 +112,7 @@ public interface MatchMigrationDAO {
           SELECT 1 FROM data_access_request dar
           WHERE dar.reference_id = m.purpose
             AND """
-          + ARCHIVED_TEST
+          + NOT_ARCHIVED
           + """
         )
       ORDER BY m.purpose
@@ -143,20 +142,21 @@ public interface MatchMigrationDAO {
   int snapshotAffectedMatches();
 
   /**
-   * Keyed on the snapshot rather than on {@code match_entity}, so it can never capture rationales
-   * for a match the other half did not capture. Re-runnable for the same reason as that half.
+   * Joined against the snapshot rather than {@code match_entity}, so it can never capture
+   * rationales for a match the other half did not capture.
+   *
+   * <p>Carries each row's own {@code match_rationale.id}, which makes the capture exact where
+   * comparing text would not: two rationales identical in text are still two rows, and restoring
+   * has to produce two. That id is also what makes the insert re-runnable, by the same {@code ON
+   * CONFLICT} idiom as the matches half.
    */
   @SqlUpdate(
       """
-      INSERT INTO match_migration_rationale_snapshot (match_id, rationale)
-      SELECT r.match_entity_id, r.rationale
+      INSERT INTO match_migration_rationale_snapshot (rationale_id, match_id, rationale)
+      SELECT r.id, r.match_entity_id, r.rationale
       FROM match_rationale r
       JOIN match_migration_snapshot s ON s.match_id = r.match_entity_id
-      WHERE NOT EXISTS (
-        SELECT 1 FROM match_migration_rationale_snapshot existing
-        WHERE existing.match_id = r.match_entity_id
-          AND existing.rationale = r.rationale
-      )
+      ON CONFLICT (rationale_id) DO NOTHING
       """)
   int snapshotAffectedRationales();
 
@@ -177,7 +177,7 @@ public interface MatchMigrationDAO {
             SELECT 1 FROM data_access_request dar
             WHERE dar.reference_id = m.purpose
               AND """
-          + ARCHIVED_TEST
+          + NOT_ARCHIVED
           + """
           )
       ),

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
@@ -1,0 +1,202 @@
+package org.broadinstitute.consent.http.db;
+
+import java.util.List;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationPopulation;
+import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+/**
+ * Backs the one-off migration that replaces {@code match_entity.consent} with a real {@code
+ * dataset_id}. Retired with the rest of the migration surface once the constraints are on.
+ *
+ * <p>The affected set is defined by what the constraints will reject rather than by algorithm
+ * version alone: a row needs reprocessing if it has no {@code dataset_id}, or still carries a
+ * {@code v1} or {@code v2} stamp, or has no stamp at all. Versions are reported separately because
+ * the acceptance criteria count those populations, but they are not what selects the work.
+ *
+ * <p>{@code ARCHIVED_TEST} repeats the archived-status condition from {@code
+ * DataAccessRequestDAO.findByReferenceId} rather than sharing it. That lookup is what a reprocess
+ * resolves its DAR through, so the run has to predict it exactly; if it changes, these queries have
+ * to be revisited deliberately, not silently follow it.
+ */
+public interface MatchMigrationDAO {
+
+  String AFFECTED_PREDICATE =
+      """
+      (m.dataset_id IS NULL
+        OR m.algorithm_version IS NULL
+        OR LOWER(m.algorithm_version) IN ('v1', 'v2'))
+      """;
+
+  String ARCHIVED_TEST =
+      "(LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)";
+
+  /**
+   * Counted in one statement so the totals cannot disagree with each other, and recounted on every
+   * call because the affected set drains as DARs are re-matched.
+   */
+  @RegisterConstructorMapper(MatchMigrationPopulation.class)
+  @SqlQuery(
+      """
+      WITH affected AS (
+        SELECT m.match_id, m.purpose, m.dataset_id, m.algorithm_version
+        FROM match_entity m
+        WHERE """
+          + AFFECTED_PREDICATE
+          + """
+      ),
+      resolvable AS (
+        SELECT DISTINCT a.purpose
+        FROM affected a
+        JOIN data_access_request dar ON dar.reference_id = a.purpose
+        WHERE """
+          + ARCHIVED_TEST
+          + """
+      )
+      SELECT
+        (SELECT COUNT(*) FROM affected) AS affected_matches,
+        (SELECT COUNT(DISTINCT purpose) FROM affected) AS affected_purposes,
+        (SELECT COUNT(*) FROM affected WHERE LOWER(algorithm_version) = 'v1') AS version_v1,
+        (SELECT COUNT(*) FROM affected WHERE LOWER(algorithm_version) = 'v2') AS version_v2,
+        (SELECT COUNT(*) FROM affected WHERE algorithm_version IS NULL) AS version_null,
+        (SELECT COUNT(*) FROM affected WHERE dataset_id IS NULL) AS missing_dataset_id,
+        (SELECT COUNT(*) FROM resolvable) AS resolvable_purposes,
+        (SELECT COUNT(DISTINCT purpose) FROM affected) - (SELECT COUNT(*) FROM resolvable)
+          AS archived_or_missing_purposes,
+        (SELECT COUNT(*) FROM (
+          SELECT purpose FROM affected GROUP BY purpose HAVING COUNT(*) > 1
+        ) multi) AS purposes_with_multiple_affected_matches,
+        (SELECT COUNT(*) FROM (
+          SELECT purpose, dataset_id FROM match_entity
+          WHERE dataset_id IS NOT NULL
+          GROUP BY purpose, dataset_id HAVING COUNT(*) > 1
+        ) dupes) AS duplicate_purpose_dataset_pairs
+      """)
+  MatchMigrationPopulation findPopulation();
+
+  /**
+   * The purposes to reprocess, restricted to those whose DAR still resolves. The rest are reported
+   * by {@link #findUnresolvablePurposes()} rather than silently dropped: reprocessing one would
+   * delete its matches and insert nothing, because the rebuild has no DAR to read.
+   */
+  @SqlQuery(
+      """
+      SELECT DISTINCT m.purpose
+      FROM match_entity m
+      JOIN data_access_request dar ON dar.reference_id = m.purpose
+      WHERE """
+          + AFFECTED_PREDICATE
+          + " AND "
+          + ARCHIVED_TEST
+          + """
+      ORDER BY m.purpose
+      """)
+  List<String> findResolvablePurposes();
+
+  /** Affected purposes whose DAR is archived or gone; left untouched and reported for follow-up. */
+  @SqlQuery(
+      """
+      SELECT DISTINCT m.purpose
+      FROM match_entity m
+      WHERE """
+          + AFFECTED_PREDICATE
+          + """
+        AND NOT EXISTS (
+          SELECT 1 FROM data_access_request dar
+          WHERE dar.reference_id = m.purpose
+            AND """
+          + ARCHIVED_TEST
+          + """
+        )
+      ORDER BY m.purpose
+      """)
+  List<String> findUnresolvablePurposes();
+
+  /**
+   * Captures every affected row before anything is reprocessed.
+   *
+   * <p>{@code ON CONFLICT DO NOTHING} keeps the first capture authoritative: a re-run after a
+   * partial failure must not overwrite pre-migration state with post-migration state, and must not
+   * fail on the rows it already holds.
+   */
+  @SqlUpdate(
+      """
+      INSERT INTO match_migration_snapshot
+        (match_id, consent, dataset_id, purpose, match_entity, abstain, failed, create_date,
+         algorithm_version)
+      SELECT m.match_id, m.consent, m.dataset_id, m.purpose, m.match_entity, m.abstain, m.failed,
+             m.create_date, m.algorithm_version
+      FROM match_entity m
+      WHERE """
+          + AFFECTED_PREDICATE
+          + """
+      ON CONFLICT (match_id) DO NOTHING
+      """)
+  int snapshotAffectedMatches();
+
+  /**
+   * Keyed on the snapshot rather than on {@code match_entity}, so it can never capture rationales
+   * for a match the other half did not capture. Re-runnable for the same reason as that half.
+   */
+  @SqlUpdate(
+      """
+      INSERT INTO match_migration_rationale_snapshot (match_id, rationale)
+      SELECT r.match_entity_id, r.rationale
+      FROM match_rationale r
+      JOIN match_migration_snapshot s ON s.match_id = r.match_entity_id
+      WHERE NOT EXISTS (
+        SELECT 1 FROM match_migration_rationale_snapshot existing
+        WHERE existing.match_id = r.match_entity_id
+          AND existing.rationale = r.rationale
+      )
+      """)
+  int snapshotAffectedRationales();
+
+  /**
+   * Measures the snapshot against what the run left behind. A reprocess deletes and re-inserts, so
+   * replacements carry new ids and a snapshotted row that is gone was handled.
+   */
+  @RegisterConstructorMapper(SnapshotReconciliation.class)
+  @SqlQuery(
+      """
+      WITH unresolvable AS (
+        SELECT m.match_id
+        FROM match_entity m
+        WHERE """
+          + AFFECTED_PREDICATE
+          + """
+          AND NOT EXISTS (
+            SELECT 1 FROM data_access_request dar
+            WHERE dar.reference_id = m.purpose
+              AND """
+          + ARCHIVED_TEST
+          + """
+          )
+      )
+      SELECT
+        (SELECT COUNT(*) FROM match_migration_snapshot) AS snapshotted,
+        (SELECT COUNT(*) FROM match_migration_snapshot s
+         WHERE NOT EXISTS (SELECT 1 FROM match_entity m WHERE m.match_id = s.match_id))
+          AS snapshotted_rows_gone,
+        (SELECT COUNT(*) FROM match_migration_snapshot s
+         WHERE EXISTS (SELECT 1 FROM match_entity m WHERE m.match_id = s.match_id))
+          AS snapshotted_rows_remaining,
+        (SELECT COUNT(*) FROM unresolvable) AS unresolvable_rows,
+        (SELECT COUNT(DISTINCT purpose) FROM match_migration_snapshot) AS snapshotted_purposes,
+        (SELECT COUNT(*) FROM (
+          SELECT DISTINCT s.purpose FROM match_migration_snapshot s
+          WHERE EXISTS (SELECT 1 FROM match_entity m WHERE m.purpose = s.purpose)
+        ) holding) AS purposes_holding_matches,
+        (SELECT COUNT(*) FROM (
+          SELECT DISTINCT s.purpose FROM match_migration_snapshot s
+          WHERE NOT EXISTS (SELECT 1 FROM match_entity m WHERE m.purpose = s.purpose)
+        ) empty) AS purposes_holding_no_matches,
+        (SELECT COUNT(*) FROM match_entity m WHERE """
+          + AFFECTED_PREDICATE
+          + """
+        ) AS still_affected
+      """)
+  SnapshotReconciliation reconcile();
+}

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
@@ -33,6 +33,20 @@ public interface MatchMigrationDAO {
   String NOT_ARCHIVED = "(LOWER(dar.data->>'status') != 'archived' OR dar.data->>'status' IS NULL)";
 
   /**
+   * The purposes a run will reprocess. Reused by the snapshot, because a reprocess deletes every
+   * row for a purpose rather than only its affected ones.
+   */
+  String RESOLVABLE_PURPOSES =
+      """
+      SELECT DISTINCT m.purpose
+      FROM match_entity m
+      JOIN data_access_request dar ON dar.reference_id = m.purpose
+      WHERE """
+          + AFFECTED_PREDICATE
+          + " AND "
+          + NOT_ARCHIVED;
+
+  /**
    * Counted in one statement so the totals cannot disagree with each other, and recounted on every
    * call because the affected set drains as DARs are re-matched.
    */
@@ -86,18 +100,7 @@ public interface MatchMigrationDAO {
    * by {@link #findUnresolvablePurposes()} rather than silently dropped: reprocessing one would
    * delete its matches and insert nothing, because the rebuild has no DAR to read.
    */
-  @SqlQuery(
-      """
-      SELECT DISTINCT m.purpose
-      FROM match_entity m
-      JOIN data_access_request dar ON dar.reference_id = m.purpose
-      WHERE """
-          + AFFECTED_PREDICATE
-          + " AND "
-          + NOT_ARCHIVED
-          + """
-      ORDER BY m.purpose
-      """)
+  @SqlQuery(RESOLVABLE_PURPOSES + " ORDER BY m.purpose")
   List<String> findResolvablePurposes();
 
   /** Affected purposes whose DAR is archived or gone; left untouched and reported for follow-up. */
@@ -120,7 +123,13 @@ public interface MatchMigrationDAO {
   List<String> findUnresolvablePurposes();
 
   /**
-   * Captures every affected row before anything is reprocessed.
+   * Captures everything the run can destroy, before anything is reprocessed.
+   *
+   * <p>Wider than the affected set on purpose. {@code reprocessMatchesForPurpose} deletes every
+   * match row for a purpose and rebuilds from the DAR, so on a purpose holding both a legacy row
+   * and an already-current one, capturing only the legacy row would let the run delete the other
+   * with no way back. So: every row of a purpose that will be reprocessed, plus any affected row
+   * elsewhere - the latter covering unresolvable purposes, which are skipped and never deleted.
    *
    * <p>{@code ON CONFLICT DO NOTHING} keeps the first capture authoritative: a re-run after a
    * partial failure must not overwrite pre-migration state with post-migration state, and must not
@@ -134,7 +143,11 @@ public interface MatchMigrationDAO {
       SELECT m.match_id, m.consent, m.dataset_id, m.purpose, m.match_entity, m.abstain, m.failed,
              m.create_date, m.algorithm_version
       FROM match_entity m
-      WHERE """
+      WHERE m.purpose IN ("""
+          + RESOLVABLE_PURPOSES
+          + """
+      )
+         OR """
           + AFFECTED_PREDICATE
           + """
       ON CONFLICT (match_id) DO NOTHING

--- a/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
+++ b/src/main/java/org/broadinstitute/consent/http/db/MatchMigrationDAO.java
@@ -54,8 +54,9 @@ public interface MatchMigrationDAO {
         WHERE """
           + ARCHIVED_TEST
           + """
-      )
-      SELECT
+      ),
+      counts AS (
+        SELECT
         (SELECT COUNT(*) FROM affected) AS affected_matches,
         (SELECT COUNT(DISTINCT purpose) FROM affected) AS affected_purposes,
         (SELECT COUNT(*) FROM affected WHERE LOWER(algorithm_version) = 'v1') AS version_v1,
@@ -73,6 +74,11 @@ public interface MatchMigrationDAO {
           WHERE dataset_id IS NOT NULL
           GROUP BY purpose, dataset_id HAVING COUNT(*) > 1
         ) dupes) AS duplicate_purpose_dataset_pairs
+      )
+      SELECT counts.*,
+             (counts.affected_matches > 0 OR counts.duplicate_purpose_dataset_pairs > 0)
+               AS blocks_constraints
+      FROM counts
       """)
   MatchMigrationPopulation findPopulation();
 
@@ -174,8 +180,9 @@ public interface MatchMigrationDAO {
           + ARCHIVED_TEST
           + """
           )
-      )
-      SELECT
+      ),
+      counts AS (
+        SELECT
         (SELECT COUNT(*) FROM match_migration_snapshot) AS snapshotted,
         (SELECT COUNT(*) FROM match_migration_snapshot s
          WHERE NOT EXISTS (SELECT 1 FROM match_entity m WHERE m.match_id = s.match_id))
@@ -197,6 +204,11 @@ public interface MatchMigrationDAO {
           + AFFECTED_PREDICATE
           + """
         ) AS still_affected
+      )
+      SELECT counts.*,
+             (counts.snapshotted_rows_remaining = counts.unresolvable_rows
+               AND counts.still_affected = counts.unresolvable_rows) AS reconciles
+      FROM counts
       """)
   SnapshotReconciliation reconcile();
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationPopulation.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationPopulation.java
@@ -18,6 +18,11 @@ package org.broadinstitute.consent.http.models.matchmigration;
  *     rebuild could collapse two rows onto one (purpose, dataset_id) pair
  * @param duplicatePurposeDatasetPairs existing (purpose, dataset_id) collisions, which block the
  *     uniqueness constraint whether or not this migration created them
+ * @param blocksConstraints whether the non-null and uniqueness constraints would still be refused.
+ *     Derived in the query rather than from a method, so it reaches the JSON: responses serialize
+ *     with Gson, which reads fields and drops computed accessors. The changeset that applies the
+ *     constraints halts on the same conditions, so this is the report an operator reads before
+ *     releasing it rather than a second, softer opinion
  */
 public record MatchMigrationPopulation(
     int affectedMatches,
@@ -29,14 +34,5 @@ public record MatchMigrationPopulation(
     int resolvablePurposes,
     int archivedOrMissingPurposes,
     int purposesWithMultipleAffectedMatches,
-    int duplicatePurposeDatasetPairs) {
-
-  /**
-   * Whether the non-null and uniqueness constraints would still be refused. The changeset that
-   * applies them halts on the same conditions, so this is the report an operator reads before
-   * releasing it rather than a second, softer opinion.
-   */
-  public boolean blocksConstraints() {
-    return affectedMatches > 0 || duplicatePurposeDatasetPairs > 0;
-  }
-}
+    int duplicatePurposeDatasetPairs,
+    boolean blocksConstraints) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationPopulation.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationPopulation.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.consent.http.models.matchmigration;
+
+/**
+ * The match rows the dataset_id migration still has to deal with, counted in one pass.
+ *
+ * <p>Figures drift: the legacy set drains on its own as DARs are re-matched, which is why nothing
+ * here is ever hardcoded and why the run recounts rather than trusting an earlier report.
+ *
+ * @param affectedMatches rows the constraints would reject: no dataset_id, or a v1/v2/absent stamp
+ * @param affectedPurposes distinct purposes those rows belong to, the unit a reprocess works by
+ * @param versionV1 affected rows still stamped v1
+ * @param versionV2 affected rows still stamped v2
+ * @param versionNull affected rows with no stamp at all, which the acceptance criteria ask for
+ * @param missingDatasetId affected rows with no dataset_id, the non-null constraint's blockers
+ * @param resolvablePurposes affected purposes whose DAR still resolves, so a reprocess can rebuild
+ * @param archivedOrMissingPurposes affected purposes whose DAR does not; skipped, never reprocessed
+ * @param purposesWithMultipleAffectedMatches purposes holding more than one affected row, where a
+ *     rebuild could collapse two rows onto one (purpose, dataset_id) pair
+ * @param duplicatePurposeDatasetPairs existing (purpose, dataset_id) collisions, which block the
+ *     uniqueness constraint whether or not this migration created them
+ */
+public record MatchMigrationPopulation(
+    int affectedMatches,
+    int affectedPurposes,
+    int versionV1,
+    int versionV2,
+    int versionNull,
+    int missingDatasetId,
+    int resolvablePurposes,
+    int archivedOrMissingPurposes,
+    int purposesWithMultipleAffectedMatches,
+    int duplicatePurposeDatasetPairs) {
+
+  /**
+   * Whether the non-null and uniqueness constraints would still be refused. The changeset that
+   * applies them halts on the same conditions, so this is the report an operator reads before
+   * releasing it rather than a second, softer opinion.
+   */
+  public boolean blocksConstraints() {
+    return affectedMatches > 0 || duplicatePurposeDatasetPairs > 0;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunReport.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunReport.java
@@ -1,0 +1,34 @@
+package org.broadinstitute.consent.http.models.matchmigration;
+
+import java.util.List;
+
+/**
+ * Outcome of one migration run.
+ *
+ * <p>Redacted: failures carry a purpose id, never an exception message, which can quote a DAR's
+ * free text.
+ *
+ * @param snapshottedMatches rows captured by this run, zero if an earlier run already held them
+ * @param snapshottedRationales rationale rows captured by this run
+ * @param reprocessed purposes rebuilt without a failure
+ * @param skipped purposes left alone because their DAR is archived or gone
+ * @param failed purposes whose every attempt failed
+ * @param retried purposes that failed once and were attempted again, successfully or not
+ * @param failedPurposeIds purposes needing follow-up, so a rerun can be scoped to them
+ * @param skippedPurposeIds purposes the run refused to touch, for the same reason
+ */
+public record MatchMigrationRunReport(
+    int snapshottedMatches,
+    int snapshottedRationales,
+    int reprocessed,
+    int skipped,
+    int failed,
+    int retried,
+    List<String> failedPurposeIds,
+    List<String> skippedPurposeIds) {
+
+  public MatchMigrationRunReport {
+    failedPurposeIds = List.copyOf(failedPurposeIds);
+    skippedPurposeIds = List.copyOf(skippedPurposeIds);
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunReport.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunReport.java
@@ -10,7 +10,9 @@ import java.util.List;
  *
  * @param snapshottedMatches rows captured by this run, zero if an earlier run already held them
  * @param snapshottedRationales rationale rows captured by this run
- * @param reprocessed purposes rebuilt without a failure
+ * @param reprocessed purposes rebuilt successfully, counting any that succeeded on a retry. With
+ *     {@code failed} this accounts for every purpose attempted; {@code retried} overlaps both
+ *     rather than forming a bucket of its own
  * @param skipped purposes left alone because their DAR is archived or gone
  * @param failed purposes whose every attempt failed
  * @param retried purposes that failed once and were attempted again, successfully or not

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunResult.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.consent.http.models.matchmigration;
+
+/**
+ * A run and the evidence either side of it, so reconciliation is something the run produces rather
+ * than two calls an operator has to bookend it with.
+ */
+public record MatchMigrationRunResult(
+    MatchMigrationPopulation before,
+    MatchMigrationPopulation after,
+    MatchMigrationRunReport run,
+    SnapshotReconciliation reconciliation) {
+
+  /**
+   * Whether the constraints can now be released: the snapshot accounts for everything and no
+   * affected row is left except the ones deliberately skipped.
+   */
+  public boolean readyForConstraints() {
+    return reconciliation.reconciles() && !after.blocksConstraints();
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunResult.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/MatchMigrationRunResult.java
@@ -8,13 +8,27 @@ public record MatchMigrationRunResult(
     MatchMigrationPopulation before,
     MatchMigrationPopulation after,
     MatchMigrationRunReport run,
-    SnapshotReconciliation reconciliation) {
+    SnapshotReconciliation reconciliation,
+    boolean readyForConstraints) {
 
   /**
    * Whether the constraints can now be released: the snapshot accounts for everything and no
    * affected row is left except the ones deliberately skipped.
+   *
+   * <p>Computed here into a component rather than exposed as a method, because responses serialize
+   * with Gson, which reads fields and drops computed accessors. This is the run's headline signal,
+   * so it has to reach the operator reading the response.
    */
-  public boolean readyForConstraints() {
-    return reconciliation.reconciles() && !after.blocksConstraints();
+  public static MatchMigrationRunResult of(
+      MatchMigrationPopulation before,
+      MatchMigrationPopulation after,
+      MatchMigrationRunReport run,
+      SnapshotReconciliation reconciliation) {
+    return new MatchMigrationRunResult(
+        before,
+        after,
+        run,
+        reconciliation,
+        reconciliation.reconciles() && !after.blocksConstraints());
   }
 }

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/SnapshotReconciliation.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/SnapshotReconciliation.java
@@ -19,6 +19,11 @@ package org.broadinstitute.consent.http.models.matchmigration;
  * @param purposesHoldingNoMatches captured purposes now holding none - the intended deletions,
  *     where the DAR carries no dataset associations to rebuild from
  * @param stillAffected rows the constraints would still reject
+ * @param reconciles whether every captured row was either handled or deliberately skipped, and
+ *     nothing else is outstanding. Two equalities rather than one, so a run that skipped more than
+ *     it meant to fails here instead of looking complete. Derived in the query rather than from a
+ *     method, so it reaches the JSON: responses serialize with Gson, which reads fields and drops
+ *     computed accessors
  */
 public record SnapshotReconciliation(
     int snapshotted,
@@ -28,14 +33,5 @@ public record SnapshotReconciliation(
     int snapshottedPurposes,
     int purposesHoldingMatches,
     int purposesHoldingNoMatches,
-    int stillAffected) {
-
-  /**
-   * Every captured row was either handled or deliberately skipped, and nothing else is outstanding.
-   * Stated as two equalities rather than one so a run that skipped more than it meant to fails here
-   * instead of looking complete.
-   */
-  public boolean reconciles() {
-    return snapshottedRowsRemaining == unresolvableRows && stillAffected == unresolvableRows;
-  }
-}
+    int stillAffected,
+    boolean reconciles) {}

--- a/src/main/java/org/broadinstitute/consent/http/models/matchmigration/SnapshotReconciliation.java
+++ b/src/main/java/org/broadinstitute/consent/http/models/matchmigration/SnapshotReconciliation.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.consent.http.models.matchmigration;
+
+/**
+ * The snapshot measured against what the run left behind.
+ *
+ * <p>A reprocess deletes a purpose's rows and inserts replacements, which take new ids. So a
+ * snapshotted row that is gone was handled, whether it was rebuilt under a new id or deliberately
+ * removed because its DAR carries no dataset associations. A snapshotted row that is still there
+ * was not handled, and after a complete run the only such rows are the ones the run skipped.
+ *
+ * @param snapshotted rows captured before the run
+ * @param snapshottedRowsGone captured rows the run replaced or removed
+ * @param snapshottedRowsRemaining captured rows still present, expected to be the skipped ones
+ * @param unresolvableRows affected rows on purposes whose DAR does not resolve, skipped by design
+ * @param snapshottedPurposes distinct purposes captured
+ * @param purposesHoldingMatches captured purposes now holding at least one match. Named for the
+ *     state rather than the cause: a skipped purpose still holds its original rows, so it counts
+ *     here without having been rebuilt
+ * @param purposesHoldingNoMatches captured purposes now holding none - the intended deletions,
+ *     where the DAR carries no dataset associations to rebuild from
+ * @param stillAffected rows the constraints would still reject
+ */
+public record SnapshotReconciliation(
+    int snapshotted,
+    int snapshottedRowsGone,
+    int snapshottedRowsRemaining,
+    int unresolvableRows,
+    int snapshottedPurposes,
+    int purposesHoldingMatches,
+    int purposesHoldingNoMatches,
+    int stillAffected) {
+
+  /**
+   * Every captured row was either handled or deliberately skipped, and nothing else is outstanding.
+   * Stated as two equalities rather than one so a run that skipped more than it meant to fails here
+   * instead of looking complete.
+   */
+  public boolean reconciles() {
+    return snapshottedRowsRemaining == unresolvableRows && stillAffected == unresolvableRows;
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/resources/MatchMigrationResource.java
+++ b/src/main/java/org/broadinstitute/consent/http/resources/MatchMigrationResource.java
@@ -1,0 +1,67 @@
+package org.broadinstitute.consent.http.resources;
+
+import com.google.inject.Inject;
+import io.dropwizard.auth.Auth;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.service.MatchMigrationService;
+
+/**
+ * Temporary admin surface for the one-off migration that replaces {@code match_entity.consent} with
+ * a real {@code dataset_id}. Retired once the constraints are applied.
+ */
+@Path("api/match/migration/dataset-id")
+public class MatchMigrationResource extends Resource {
+
+  private final MatchMigrationService service;
+
+  @Inject
+  public MatchMigrationResource(MatchMigrationService service) {
+    this.service = service;
+  }
+
+  /** Read-only. Recounts the affected population, so a run is never scoped from stale figures. */
+  @GET
+  @Path("/population")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed({Resource.ADMIN})
+  public Response getPopulation(@Auth DuosUser duosUser) {
+    try {
+      return Response.ok().entity(service.findPopulation()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /** Read-only. Reconciles a run that has already happened, for a later confirmation pass. */
+  @GET
+  @Path("/reconciliation")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed({Resource.ADMIN})
+  public Response getReconciliation(@Auth DuosUser duosUser) {
+    try {
+      return Response.ok().entity(service.reconcile()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+
+  /** Snapshots and then rebuilds; rewrites only match rows and rationales. */
+  @POST
+  @Path("/run")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed({Resource.ADMIN})
+  public Response run(@Auth DuosUser duosUser) {
+    try {
+      return Response.ok().entity(service.run()).build();
+    } catch (Exception e) {
+      return createExceptionResponse(e);
+    }
+  }
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchMigrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchMigrationService.java
@@ -1,0 +1,129 @@
+package org.broadinstitute.consent.http.service;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import org.broadinstitute.consent.http.db.MatchMigrationDAO;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationPopulation;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunReport;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunResult;
+import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
+import org.broadinstitute.consent.http.util.ConsentLogger;
+import org.jdbi.v3.core.Jdbi;
+
+/**
+ * Rebuilds the match rows that still identify their dataset by legacy text, so they carry a real
+ * {@code dataset_id} at the current algorithm version.
+ *
+ * <p>Reprocesses rather than backfills. The legacy {@code consent} values are consent UUIDs whose
+ * dataset mapping was dropped in 2024, so no mapping can be derived without guessing; re-running
+ * matching rebuilds each purpose from its DAR instead. A purpose whose DAR carries no dataset
+ * associations rebuilds to nothing, which deletes its rows. That is the intended outcome for it,
+ * and it is what the application already does whenever a DAR is edited.
+ *
+ * <p>Snapshots before it touches anything, and is restartable: each purpose is rebuilt in its own
+ * transaction, so a failure leaves that purpose's existing matches in place, and the snapshot keeps
+ * the first capture rather than overwriting it.
+ */
+public class MatchMigrationService implements ConsentLogger {
+
+  private final MatchMigrationDAO matchMigrationDAO;
+  private final MatchService matchService;
+
+  @Inject
+  public MatchMigrationService(Jdbi jdbi, MatchService matchService) {
+    this(jdbi.onDemand(MatchMigrationDAO.class), matchService);
+  }
+
+  @VisibleForTesting
+  MatchMigrationService(MatchMigrationDAO matchMigrationDAO, MatchService matchService) {
+    this.matchMigrationDAO = matchMigrationDAO;
+    this.matchService = matchService;
+  }
+
+  /** Read-only. What a run would do, and whether the constraints would still be refused. */
+  public MatchMigrationPopulation findPopulation() {
+    return matchMigrationDAO.findPopulation();
+  }
+
+  /** Read-only. Reconciles a run that has already happened, for a later confirmation pass. */
+  public SnapshotReconciliation reconcile() {
+    return matchMigrationDAO.reconcile();
+  }
+
+  public MatchMigrationRunResult run() {
+    MatchMigrationPopulation before = matchMigrationDAO.findPopulation();
+    // Captured before any reprocess, which is what makes the run reversible
+    int snapshottedMatches = matchMigrationDAO.snapshotAffectedMatches();
+    int snapshottedRationales = matchMigrationDAO.snapshotAffectedRationales();
+
+    List<String> purposes = matchMigrationDAO.findResolvablePurposes();
+    List<String> skipped = matchMigrationDAO.findUnresolvablePurposes();
+    logInfo(
+        ("Reprocessing %d purposes for the match dataset_id migration; "
+                + "%d skipped for an archived or missing DAR")
+            .formatted(purposes.size(), skipped.size()));
+
+    int reprocessed = 0;
+    int retried = 0;
+    List<String> failedPurposeIds = new ArrayList<>();
+    for (String purposeId : purposes) {
+      Outcome outcome = reprocessWithOneRetry(purposeId);
+      if (outcome.retried()) {
+        retried++;
+      }
+      if (outcome.failed()) {
+        failedPurposeIds.add(purposeId);
+      } else {
+        reprocessed++;
+      }
+    }
+
+    MatchMigrationRunReport report =
+        new MatchMigrationRunReport(
+            snapshottedMatches,
+            snapshottedRationales,
+            reprocessed,
+            skipped.size(),
+            failedPurposeIds.size(),
+            retried,
+            failedPurposeIds,
+            skipped);
+    MatchMigrationRunResult result =
+        new MatchMigrationRunResult(
+            before, matchMigrationDAO.findPopulation(), report, matchMigrationDAO.reconcile());
+    if (!result.readyForConstraints()) {
+      // Said plainly, because the next step is a release whose changeset halts on these conditions
+      logWarn("Match dataset_id migration is not yet clear to have its constraints applied");
+    }
+    return result;
+  }
+
+  /**
+   * One retry, because a rebuild that failed on a transient database error is worth another attempt
+   * and one that failed on a programming error is not worth more than that.
+   */
+  private Outcome reprocessWithOneRetry(String purposeId) {
+    try {
+      matchService.reprocessMatchesForPurpose(purposeId);
+      return new Outcome(false, false);
+    } catch (Exception firstFailure) {
+      // The class, never the message: a failure raised while matching can quote a DAR's free text
+      logWarn(
+          "Match reprocess failed for purpose %s with %s, retrying once"
+              .formatted(purposeId, firstFailure.getClass().getName()));
+      try {
+        matchService.reprocessMatchesForPurpose(purposeId);
+        return new Outcome(false, true);
+      } catch (Exception retryFailure) {
+        logWarn(
+            "Match reprocess failed again for purpose %s with %s"
+                .formatted(purposeId, retryFailure.getClass().getName()));
+        return new Outcome(true, true);
+      }
+    }
+  }
+
+  private record Outcome(boolean failed, boolean retried) {}
+}

--- a/src/main/java/org/broadinstitute/consent/http/service/MatchMigrationService.java
+++ b/src/main/java/org/broadinstitute/consent/http/service/MatchMigrationService.java
@@ -91,7 +91,7 @@ public class MatchMigrationService implements ConsentLogger {
             failedPurposeIds,
             skipped);
     MatchMigrationRunResult result =
-        new MatchMigrationRunResult(
+        MatchMigrationRunResult.of(
             before, matchMigrationDAO.findPopulation(), report, matchMigrationDAO.reconcile());
     if (!result.readyForConstraints()) {
       // Said plainly, because the next step is a release whose changeset halts on these conditions

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -889,6 +889,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         500:
           description: Server error.
+  /api/match/migration/dataset-id/population:
+    $ref: './paths/matchMigrationPopulation.yaml'
+  /api/match/migration/dataset-id/reconciliation:
+    $ref: './paths/matchMigrationReconciliation.yaml'
+  /api/match/migration/dataset-id/run:
+    $ref: './paths/matchMigrationRun.yaml'
   /api/match/purpose/batch/:
     $ref: './paths/getMatchesForLatestDataAccessElectionsByPurposeIds.yaml'
   /api/metrics/dar-summaries/{datasetId}:
@@ -1309,6 +1315,12 @@ components:
       $ref: './schemas/Vote.yaml'
     MatchResult:
       $ref: './schemas/MatchResult.yaml'
+    MatchMigrationPopulation:
+      $ref: './schemas/MatchMigrationPopulation.yaml'
+    SnapshotReconciliation:
+      $ref: './schemas/SnapshotReconciliation.yaml'
+    MatchMigrationRunResult:
+      $ref: './schemas/MatchMigrationRunResult.yaml'
     SimplifiedUser:
       $ref: './schemas/SimplifiedUser.yaml'
     SigningOfficialUser:

--- a/src/main/resources/assets/paths/matchMigrationPopulation.yaml
+++ b/src/main/resources/assets/paths/matchMigrationPopulation.yaml
@@ -1,0 +1,30 @@
+get:
+  description: |
+    Recounts the match rows the dataset_id migration still has to deal with. Read-only.
+    The affected set is defined by what the constraints will reject - no dataset_id, or a v1/v2/absent
+    algorithm version - rather than by algorithm version alone. It drains on its own as DARs are
+    re-matched, so a run is always scoped from a fresh count rather than from an earlier report.
+  tags:
+    - Match
+    - Admin
+  responses:
+    200:
+      description: Returns the affected population and the conditions that would block the constraints.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/MatchMigrationPopulation.yaml'
+    401:
+      description: Unauthorized - The requester is not authenticated.
+    403:
+      description: Forbidden - Admin use only.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error - An error occurred while processing the request.
+
+  operationId: apiMatchMigrationPopulationGet

--- a/src/main/resources/assets/paths/matchMigrationReconciliation.yaml
+++ b/src/main/resources/assets/paths/matchMigrationReconciliation.yaml
@@ -1,0 +1,29 @@
+get:
+  description: |
+    Reconciles a migration run that has already happened, for a confirmation pass before the
+    constraints are released. Read-only.
+    Reports zeros for the snapshot until a run has populated it.
+  tags:
+    - Match
+    - Admin
+  responses:
+    200:
+      description: Returns the snapshot measured against what the run left behind.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/SnapshotReconciliation.yaml'
+    401:
+      description: Unauthorized - The requester is not authenticated.
+    403:
+      description: Forbidden - Admin use only.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error - An error occurred while processing the request.
+
+  operationId: apiMatchMigrationReconciliationGet

--- a/src/main/resources/assets/paths/matchMigrationRun.yaml
+++ b/src/main/resources/assets/paths/matchMigrationRun.yaml
@@ -1,0 +1,39 @@
+post:
+  description: |
+    Snapshots the affected match rows and their rationales, then rebuilds each affected purpose so
+    its matches carry a real dataset_id at the current algorithm version.
+    Rewrites only match rows and their rationales - never stored Data Use, elections, or votes.
+    Historical v1 and v2 rationales are replaced by current-algorithm results, including on closed
+    elections. This is deliberate and was endorsed on review; the snapshot makes it reversible.
+    A purpose whose DAR carries no dataset associations rebuilds to nothing, which deletes its rows.
+    That is the intended outcome for it.
+    A purpose whose DAR is archived or missing is skipped and reported, never reprocessed: the
+    rebuild would find no DAR and would delete the rows without inserting any.
+    Restartable. Each purpose is rebuilt in one transaction, so a failure leaves its existing matches
+    in place, and the snapshot keeps its first capture rather than overwriting it with post-run state.
+    Returns the population either side of the run plus the reconciliation, so a run can be seen to
+    account for everything it touched.
+  tags:
+    - Match
+    - Admin
+  responses:
+    200:
+      description: Returns the run totals, the population either side of it, and the reconciliation.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/MatchMigrationRunResult.yaml'
+    401:
+      description: Unauthorized - The requester is not authenticated.
+    403:
+      description: Forbidden - Admin use only.
+    429:
+      description: Too Many Requests - rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ErrorResponse.yaml'
+    500:
+      description: Internal Server Error - An error occurred while processing the request.
+
+  operationId: apiMatchMigrationRunPost

--- a/src/main/resources/assets/schemas/MatchMigrationPopulation.yaml
+++ b/src/main/resources/assets/schemas/MatchMigrationPopulation.yaml
@@ -1,0 +1,33 @@
+type: object
+description: The match rows the dataset_id migration still has to deal with, recounted on each call.
+properties:
+  affectedMatches:
+    type: integer
+    description: Rows the constraints would reject - no dataset_id, or a v1/v2/absent algorithm version.
+  affectedPurposes:
+    type: integer
+    description: Distinct purposes those rows belong to, the unit a reprocess works by.
+  versionV1:
+    type: integer
+    description: Affected rows still stamped v1.
+  versionV2:
+    type: integer
+    description: Affected rows still stamped v2.
+  versionNull:
+    type: integer
+    description: Affected rows carrying no algorithm version at all.
+  missingDatasetId:
+    type: integer
+    description: Affected rows with no dataset_id.
+  resolvablePurposes:
+    type: integer
+    description: Affected purposes whose DAR resolves, so a reprocess can rebuild them.
+  archivedOrMissingPurposes:
+    type: integer
+    description: Affected purposes whose DAR is archived or gone. Skipped, never reprocessed.
+  purposesWithMultipleAffectedMatches:
+    type: integer
+    description: Purposes holding more than one affected row, where a rebuild could collapse two onto one pair.
+  duplicatePurposeDatasetPairs:
+    type: integer
+    description: Existing (purpose, dataset_id) collisions, which block the uniqueness constraint.

--- a/src/main/resources/assets/schemas/MatchMigrationPopulation.yaml
+++ b/src/main/resources/assets/schemas/MatchMigrationPopulation.yaml
@@ -31,3 +31,8 @@ properties:
   duplicatePurposeDatasetPairs:
     type: integer
     description: Existing (purpose, dataset_id) collisions, which block the uniqueness constraint.
+  blocksConstraints:
+    type: boolean
+    description: >
+      Whether the non-null and uniqueness constraints would still be refused. The changeset that
+      applies them halts on the same conditions, so this is what to read before releasing it.

--- a/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
+++ b/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
@@ -23,7 +23,10 @@ properties:
         description: Rationale rows captured by this run.
       reprocessed:
         type: integer
-        description: Purposes rebuilt without a failure.
+        description: >
+          Purposes rebuilt successfully, counting any that succeeded on a retry. With failed this
+          accounts for every purpose attempted; retried overlaps both rather than forming a bucket
+          of its own.
       skipped:
         type: integer
         description: Purposes left alone because their DAR is archived or gone.

--- a/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
+++ b/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
@@ -1,0 +1,40 @@
+type: object
+description: One migration run, with the population either side of it and the reconciliation it produced.
+properties:
+  before:
+    $ref: './MatchMigrationPopulation.yaml'
+  after:
+    $ref: './MatchMigrationPopulation.yaml'
+  reconciliation:
+    $ref: './SnapshotReconciliation.yaml'
+  run:
+    type: object
+    properties:
+      snapshottedMatches:
+        type: integer
+        description: Rows captured by this run. Zero where an earlier run already held them.
+      snapshottedRationales:
+        type: integer
+        description: Rationale rows captured by this run.
+      reprocessed:
+        type: integer
+        description: Purposes rebuilt without a failure.
+      skipped:
+        type: integer
+        description: Purposes left alone because their DAR is archived or gone.
+      failed:
+        type: integer
+        description: Purposes whose every attempt failed.
+      retried:
+        type: integer
+        description: Purposes that failed once and were attempted again, successfully or not.
+      failedPurposeIds:
+        type: array
+        items:
+          type: string
+        description: Purposes needing follow-up, so a rerun can be scoped to them.
+      skippedPurposeIds:
+        type: array
+        items:
+          type: string
+        description: Purposes the run refused to touch.

--- a/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
+++ b/src/main/resources/assets/schemas/MatchMigrationRunResult.yaml
@@ -1,6 +1,11 @@
 type: object
 description: One migration run, with the population either side of it and the reconciliation it produced.
 properties:
+  readyForConstraints:
+    type: boolean
+    description: >
+      The run's headline signal: the snapshot accounts for everything and no affected row is left
+      except the ones deliberately skipped. The gate for releasing the constraints.
   before:
     $ref: './MatchMigrationPopulation.yaml'
   after:

--- a/src/main/resources/assets/schemas/SnapshotReconciliation.yaml
+++ b/src/main/resources/assets/schemas/SnapshotReconciliation.yaml
@@ -1,0 +1,31 @@
+type: object
+description: >
+  The snapshot measured against what the run left behind. A reprocess deletes and re-inserts, so
+  replacements carry new ids and a snapshotted row that is gone was handled.
+properties:
+  snapshotted:
+    type: integer
+    description: Rows captured before the run.
+  snapshottedRowsGone:
+    type: integer
+    description: Captured rows the run replaced or removed.
+  snapshottedRowsRemaining:
+    type: integer
+    description: Captured rows still present, expected to be exactly the skipped ones.
+  unresolvableRows:
+    type: integer
+    description: Affected rows on purposes whose DAR does not resolve. Skipped by design.
+  snapshottedPurposes:
+    type: integer
+    description: Distinct purposes captured.
+  purposesHoldingMatches:
+    type: integer
+    description: >
+      Captured purposes now holding at least one match. Named for the state, not the cause - a
+      skipped purpose still holds its original rows, so it counts here without having been rebuilt.
+  purposesHoldingNoMatches:
+    type: integer
+    description: Captured purposes now holding none - the intended deletions.
+  stillAffected:
+    type: integer
+    description: Rows the constraints would still reject.

--- a/src/main/resources/assets/schemas/SnapshotReconciliation.yaml
+++ b/src/main/resources/assets/schemas/SnapshotReconciliation.yaml
@@ -29,3 +29,8 @@ properties:
   stillAffected:
     type: integer
     description: Rows the constraints would still reject.
+  reconciles:
+    type: boolean
+    description: >
+      Whether every captured row was either handled or deliberately skipped, with nothing else
+      outstanding. False if the run skipped more than it meant to.

--- a/src/main/resources/changelog-master.xml
+++ b/src/main/resources/changelog-master.xml
@@ -258,4 +258,5 @@
   <include file="changesets/changelog-consent-2026-08-10-dataset-alias-sequence.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-08-11-researcher-dashboard-indices.xml" relativeToChangelogFile="true" />
   <include file="changesets/changelog-consent-2026-09-09-match-dataset-id.xml" relativeToChangelogFile="true" />
+  <include file="changesets/changelog-consent-2026-09-09-match-migration-snapshot.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-09-09-match-migration-snapshot.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-09-09-match-migration-snapshot.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <!--
+    Holds the pre-migration state of the match rows the dataset_id migration reprocesses, so the run
+    is reversible and can be reconciled against what it rebuilt or deleted.
+
+    Deliberately carries no foreign key to match_entity: the run deletes the very rows captured here,
+    so a reference would either block the delete or cascade the evidence away with it. Column types
+    are wider than the source for the same reason - the snapshot must never be the thing that fails.
+
+    Populated by POST /api/match/migration/dataset-id/run, not by this changeset. The affected set
+    drains as DARs are re-matched, so it is captured when the run executes rather than fixed now.
+    Retained until the migration is confirmed good, then dropped with the migration surface.
+  -->
+  <changeSet id="changelog-consent-2026-09-09-match-migration-snapshot" author="kmarete">
+    <createTable tableName="match_migration_snapshot">
+      <column name="match_id" type="bigint">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="consent" type="text"/>
+      <column name="dataset_id" type="bigint"/>
+      <column name="purpose" type="text">
+        <constraints nullable="false"/>
+      </column>
+      <column name="match_entity" type="boolean"/>
+      <column name="abstain" type="boolean"/>
+      <column name="failed" type="boolean"/>
+      <column name="create_date" type="timestamp"/>
+      <column name="algorithm_version" type="text"/>
+      <column name="captured_at" type="timestamp" defaultValue="now()">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <createIndex tableName="match_migration_snapshot" indexName="idx_match_migration_snapshot_purpose">
+      <column name="purpose"/>
+    </createIndex>
+
+    <createTable tableName="match_migration_rationale_snapshot">
+      <column name="id" type="bigint" autoIncrement="true">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="match_id" type="bigint">
+        <constraints nullable="false"/>
+      </column>
+      <column name="rationale" type="text">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+    <createIndex tableName="match_migration_rationale_snapshot"
+      indexName="idx_match_migration_rationale_snapshot_match_id">
+      <column name="match_id"/>
+    </createIndex>
+
+    <rollback>
+      <dropTable tableName="match_migration_rationale_snapshot"/>
+      <dropTable tableName="match_migration_snapshot"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/changesets/changelog-consent-2026-09-09-match-migration-snapshot.xml
+++ b/src/main/resources/changesets/changelog-consent-2026-09-09-match-migration-snapshot.xml
@@ -38,7 +38,9 @@
     </createIndex>
 
     <createTable tableName="match_migration_rationale_snapshot">
-      <column name="id" type="bigint" autoIncrement="true">
+      <!-- The source row's own match_rationale.id, so the capture is exact and re-runnable
+           without having to compare rationale text. -->
+      <column name="rationale_id" type="bigint">
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="match_id" type="bigint">

--- a/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/DAOTestHelper.java
@@ -56,6 +56,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
   protected static StudyDAO studyDAO;
   protected static DataAccessRequestDAO dataAccessRequestDAO;
   protected static MatchDAO matchDAO;
+  protected static MatchMigrationDAO matchMigrationDAO;
   protected static MailMessageDAO mailMessageDAO;
   protected static UserPropertyDAO userPropertyDAO;
   protected static InstitutionDAO institutionDAO;
@@ -152,6 +153,7 @@ public class DAOTestHelper extends AbstractTestHelper implements TestExecutionLi
     studyDAO = jdbi.onDemand(StudyDAO.class);
     dataAccessRequestDAO = jdbi.onDemand(DataAccessRequestDAO.class);
     matchDAO = jdbi.onDemand(MatchDAO.class);
+    matchMigrationDAO = jdbi.onDemand(MatchMigrationDAO.class);
     mailMessageDAO = jdbi.onDemand(MailMessageDAO.class);
     userPropertyDAO = jdbi.onDemand(UserPropertyDAO.class);
     institutionDAO = jdbi.onDemand(InstitutionDAO.class);

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
@@ -135,6 +135,23 @@ class MatchMigrationDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testSnapshotKeepsTwoRationalesThatShareTheirText() {
+    // Keyed on each row's own id, so identical text is still two rows and a restore rebuilds two
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    Integer matchId = insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchDAO.insertRationale(matchId, "same text");
+    matchDAO.insertRationale(matchId, "same text");
+
+    matchMigrationDAO.snapshotAffectedMatches();
+    assertEquals(2, matchMigrationDAO.snapshotAffectedRationales());
+    assertEquals(List.of("same text", "same text"), snapshottedRationales(matchId));
+
+    // And a second pass still captures nothing new
+    assertEquals(0, matchMigrationDAO.snapshotAffectedRationales());
+  }
+
+  @Test
   void testSnapshotIsRerunnableAndKeepsTheFirstCapture() {
     Dataset dataset = createDataset();
     String purposeId = createSubmittedDar(dataset, false);

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
@@ -135,6 +135,32 @@ class MatchMigrationDAOTest extends DAOTestHelper {
   }
 
   @Test
+  void testSnapshotCapturesCurrentRowsSharingAReprocessedPurpose() {
+    // A reprocess deletes every row for the purpose, not just the affected one, so a current row
+    // sitting alongside a legacy one has to be captured or it is destroyed with no way back
+    Dataset legacyDataset = createDataset();
+    Dataset currentDataset = createDataset();
+    String purposeId = createSubmittedDar(legacyDataset, false);
+    Integer legacy = insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    Integer current =
+        insertMatch(purposeId, currentDataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    assertEquals(2, matchMigrationDAO.snapshotAffectedMatches());
+    assertEquals(List.of(legacy, current), snapshottedMatchIds());
+  }
+
+  @Test
+  void testSnapshotLeavesCurrentRowsOnPurposesThatAreNotReprocessed() {
+    // The widening is scoped to purposes a run will touch; everything else stays out
+    Dataset dataset = createDataset();
+    insertMatch(
+        createSubmittedDar(dataset, false), dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    assertEquals(0, matchMigrationDAO.snapshotAffectedMatches());
+    assertEquals(List.of(), snapshottedMatchIds());
+  }
+
+  @Test
   void testSnapshotKeepsTwoRationalesThatShareTheirText() {
     // Keyed on each row's own id, so identical text is still two rows and a restore rebuilds two
     Dataset dataset = createDataset();

--- a/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/db/MatchMigrationDAOTest.java
@@ -1,0 +1,311 @@
+package org.broadinstitute.consent.http.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.broadinstitute.consent.http.enumeration.MatchAlgorithm;
+import org.broadinstitute.consent.http.models.DataAccessRequestData;
+import org.broadinstitute.consent.http.models.DataUse;
+import org.broadinstitute.consent.http.models.DataUseBuilder;
+import org.broadinstitute.consent.http.models.Dataset;
+import org.broadinstitute.consent.http.models.DatasetProperty;
+import org.broadinstitute.consent.http.models.Match;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationPopulation;
+import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchMigrationDAOTest extends DAOTestHelper {
+
+  @Test
+  void testFindPopulationCountsOnlyWhatTheConstraintsWouldReject() {
+    Dataset dataset = createDataset();
+    String legacy = createSubmittedDar(dataset, false);
+    String current = createSubmittedDar(dataset, false);
+    insertMatch(legacy, null, MatchAlgorithm.V1.getVersion());
+    insertMatch(current, dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    MatchMigrationPopulation population = matchMigrationDAO.findPopulation();
+    assertEquals(1, population.affectedMatches());
+    assertEquals(1, population.affectedPurposes());
+    assertEquals(1, population.versionV1());
+    assertEquals(1, population.missingDatasetId());
+    assertTrue(population.blocksConstraints());
+  }
+
+  @Test
+  void testFindPopulationCountsV2AndNullVersionsSeparately() {
+    Dataset dataset = createDataset();
+    insertMatch(createSubmittedDar(dataset, false), dataset.getDatasetId(), "v2");
+    insertMatch(createSubmittedDar(dataset, false), dataset.getDatasetId(), null);
+
+    MatchMigrationPopulation population = matchMigrationDAO.findPopulation();
+    assertEquals(2, population.affectedMatches());
+    assertEquals(1, population.versionV2());
+    assertEquals(1, population.versionNull());
+    // Both carry a dataset id already; only their stamps make them affected
+    assertEquals(0, population.missingDatasetId());
+  }
+
+  @Test
+  void testFindPopulationSeparatesArchivedPurposesFromResolvableOnes() {
+    Dataset dataset = createDataset();
+    insertMatch(createSubmittedDar(dataset, false), null, MatchAlgorithm.V1.getVersion());
+    insertMatch(createSubmittedDar(dataset, true), null, MatchAlgorithm.V1.getVersion());
+
+    MatchMigrationPopulation population = matchMigrationDAO.findPopulation();
+    assertEquals(2, population.affectedPurposes());
+    assertEquals(1, population.resolvablePurposes());
+    assertEquals(1, population.archivedOrMissingPurposes());
+  }
+
+  @Test
+  void testFindPopulationCountsPurposesHoldingMoreThanOneAffectedMatch() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+
+    MatchMigrationPopulation population = matchMigrationDAO.findPopulation();
+    assertEquals(2, population.affectedMatches());
+    assertEquals(1, population.affectedPurposes());
+    assertEquals(1, population.purposesWithMultipleAffectedMatches());
+  }
+
+  @Test
+  void testFindPopulationCountsExistingDuplicatePurposeDatasetPairs() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    // Two current rows on the same pair: nothing this migration created, but the uniqueness
+    // constraint would still refuse them
+    insertMatch(purposeId, dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+    insertMatch(purposeId, dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    MatchMigrationPopulation population = matchMigrationDAO.findPopulation();
+    assertEquals(0, population.affectedMatches());
+    assertEquals(1, population.duplicatePurposeDatasetPairs());
+    // Affected count is clear, but the pair collision still blocks
+    assertTrue(population.blocksConstraints());
+  }
+
+  @Test
+  void testResolvableAndUnresolvablePurposesPartitionTheAffectedSet() {
+    Dataset dataset = createDataset();
+    String resolvable = createSubmittedDar(dataset, false);
+    String archived = createSubmittedDar(dataset, true);
+    insertMatch(resolvable, null, MatchAlgorithm.V1.getVersion());
+    insertMatch(archived, null, MatchAlgorithm.V1.getVersion());
+
+    assertEquals(List.of(resolvable), matchMigrationDAO.findResolvablePurposes());
+    assertEquals(List.of(archived), matchMigrationDAO.findUnresolvablePurposes());
+  }
+
+  @Test
+  void testUnresolvablePurposesIncludesMatchesWithNoDarAtAll() {
+    // A match whose purpose has no data_access_request row: findByReferenceId returns null for it,
+    // so a reprocess would delete the rows and insert nothing
+    String orphaned = UUID.randomUUID().toString();
+    insertMatch(orphaned, null, MatchAlgorithm.V1.getVersion());
+
+    assertTrue(matchMigrationDAO.findResolvablePurposes().isEmpty());
+    assertEquals(List.of(orphaned), matchMigrationDAO.findUnresolvablePurposes());
+  }
+
+  @Test
+  void testSnapshotCapturesAffectedRowsAndTheirRationales() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    Integer affected = insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchDAO.insertRationale(affected, "legacy rationale");
+    insertMatch(
+        createSubmittedDar(dataset, false), dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    assertEquals(1, matchMigrationDAO.snapshotAffectedMatches());
+    assertEquals(1, matchMigrationDAO.snapshotAffectedRationales());
+    assertEquals(List.of(affected), snapshottedMatchIds());
+    assertEquals(List.of("legacy rationale"), snapshottedRationales(affected));
+  }
+
+  @Test
+  void testSnapshotIsRerunnableAndKeepsTheFirstCapture() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    Integer matchId = insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchDAO.insertRationale(matchId, "first");
+    matchMigrationDAO.snapshotAffectedMatches();
+    matchMigrationDAO.snapshotAffectedRationales();
+
+    // A second pass captures nothing new and leaves the original capture in place
+    assertEquals(0, matchMigrationDAO.snapshotAffectedMatches());
+    assertEquals(0, matchMigrationDAO.snapshotAffectedRationales());
+    assertEquals(List.of(matchId), snapshottedMatchIds());
+    assertEquals(List.of("first"), snapshottedRationales(matchId));
+  }
+
+  @Test
+  void testSnapshotSkipsRationalesOfMatchesItDidNotCapture() {
+    Dataset dataset = createDataset();
+    Integer current =
+        insertMatch(
+            createSubmittedDar(dataset, false),
+            dataset.getDatasetId(),
+            MatchAlgorithm.V5.getVersion());
+    matchDAO.insertRationale(current, "current rationale");
+
+    assertEquals(0, matchMigrationDAO.snapshotAffectedMatches());
+    assertEquals(0, matchMigrationDAO.snapshotAffectedRationales());
+  }
+
+  @Test
+  void testReconcileCountsARowStillPresentAsUnhandled() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchMigrationDAO.snapshotAffectedMatches();
+
+    SnapshotReconciliation reconciliation = matchMigrationDAO.reconcile();
+    assertEquals(1, reconciliation.snapshotted());
+    assertEquals(1, reconciliation.snapshottedRowsRemaining());
+    assertEquals(0, reconciliation.snapshottedRowsGone());
+    assertEquals(1, reconciliation.stillAffected());
+    // Resolvable, so it should have been reprocessed; nothing was skipped
+    assertEquals(0, reconciliation.unresolvableRows());
+    assertFalse(reconciliation.reconciles());
+  }
+
+  @Test
+  void testReconcileTreatsAReplacedRowAsHandled() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchMigrationDAO.snapshotAffectedMatches();
+
+    // Stands in for a reprocess: the old row goes, a replacement arrives under a new id
+    matchDAO.deleteMatchesByPurposeId(purposeId);
+    insertMatch(purposeId, dataset.getDatasetId(), MatchAlgorithm.V5.getVersion());
+
+    SnapshotReconciliation reconciliation = matchMigrationDAO.reconcile();
+    assertEquals(1, reconciliation.snapshottedRowsGone());
+    assertEquals(0, reconciliation.snapshottedRowsRemaining());
+    assertEquals(1, reconciliation.purposesHoldingMatches());
+    assertEquals(0, reconciliation.purposesHoldingNoMatches());
+    assertEquals(0, reconciliation.stillAffected());
+    assertTrue(reconciliation.reconciles());
+  }
+
+  @Test
+  void testReconcileTreatsAPurposeRebuiltToNothingAsHandled() {
+    Dataset dataset = createDataset();
+    String purposeId = createSubmittedDar(dataset, false);
+    insertMatch(purposeId, null, MatchAlgorithm.V1.getVersion());
+    matchMigrationDAO.snapshotAffectedMatches();
+
+    // A DAR with no dataset associations rebuilds to nothing, which deletes its rows
+    matchDAO.deleteMatchesByPurposeId(purposeId);
+
+    SnapshotReconciliation reconciliation = matchMigrationDAO.reconcile();
+    assertEquals(1, reconciliation.snapshottedRowsGone());
+    assertEquals(1, reconciliation.purposesHoldingNoMatches());
+    assertEquals(0, reconciliation.purposesHoldingMatches());
+    assertTrue(reconciliation.reconciles());
+  }
+
+  @Test
+  void testReconcileAcceptsSkippedRowsThatAreStillAffected() {
+    Dataset dataset = createDataset();
+    String archived = createSubmittedDar(dataset, true);
+    insertMatch(archived, null, MatchAlgorithm.V1.getVersion());
+    matchMigrationDAO.snapshotAffectedMatches();
+
+    // Never reprocessed, by design. The run is still complete: what remains is what it skipped.
+    SnapshotReconciliation reconciliation = matchMigrationDAO.reconcile();
+    assertEquals(1, reconciliation.snapshottedRowsRemaining());
+    assertEquals(1, reconciliation.unresolvableRows());
+    assertEquals(1, reconciliation.stillAffected());
+    // Still holds its original rows, which is why this counter is named for the state
+    assertEquals(1, reconciliation.purposesHoldingMatches());
+    assertTrue(reconciliation.reconciles());
+  }
+
+  private Integer insertMatch(String purposeId, Integer datasetId, String algorithmVersion) {
+    Match match = new Match();
+    match.setConsent("DUOS-" + randomInt(1, 999999));
+    match.setDatasetId(datasetId);
+    match.setPurpose(purposeId);
+    match.setMatch(true);
+    match.setFailed(false);
+    match.setAbstain(false);
+    match.setCreateDate(FIXED_DATE);
+    match.setAlgorithmVersion(algorithmVersion);
+    return matchDAO.insertMatch(match);
+  }
+
+  /** A submitted DAR carrying one dataset association, archived or not. */
+  private String createSubmittedDar(Dataset dataset, boolean archived) {
+    User user = createUser();
+    String darCode = "DAR-" + randomInt(1, 999999999);
+    Integer collectionId =
+        darCollectionDAO.insertDarCollection(darCode, user.getUserId(), new Date());
+    DataAccessRequestData data = new DataAccessRequestData();
+    data.setProjectTitle("Project Title: " + randomAlphabetic(20));
+    if (archived) {
+      data.setStatus("Archived");
+    }
+    String referenceId = UUID.randomUUID().toString();
+    Date now = new Date();
+    dataAccessRequestDAO.insertDataAccessRequest(
+        collectionId, referenceId, user.getUserId(), now, now, now, data, randomAlphabetic(10));
+    dataAccessRequestDAO.insertDARDatasetRelation(referenceId, dataset.getDatasetId());
+    return referenceId;
+  }
+
+  private static List<Integer> snapshottedMatchIds() {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery("SELECT match_id FROM match_migration_snapshot ORDER BY match_id")
+                .mapTo(Integer.class)
+                .list());
+  }
+
+  private static List<String> snapshottedRationales(Integer matchId) {
+    return jdbi.withHandle(
+        handle ->
+            handle
+                .createQuery(
+                    """
+                    SELECT rationale FROM match_migration_rationale_snapshot
+                    WHERE match_id = :matchId ORDER BY rationale
+                    """)
+                .bind("matchId", matchId)
+                .mapTo(String.class)
+                .list());
+  }
+
+  private Dataset createDataset() {
+    User user = createUser();
+    String name = "Name_" + randomAlphanumeric(20);
+    String objectId = "Object ID_" + randomAlphanumeric(20);
+    DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+    Integer id =
+        datasetDAO.insertDataset(
+            name, FIXED_TIMESTAMP, user.getUserId(), objectId, dataUse.toString(), null);
+    List<DatasetProperty> properties = new ArrayList<>();
+    DatasetProperty property = new DatasetProperty();
+    property.setDatasetId(id);
+    property.setPropertyKey(1);
+    property.setPropertyValue("Test_PropertyValue");
+    property.setCreateDate(FIXED_DATE);
+    properties.add(property);
+    datasetDAO.insertDatasetProperties(properties);
+    return datasetDAO.findDatasetById(id);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.consent.http.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
@@ -17,6 +18,7 @@ import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunRe
 import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunResult;
 import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
 import org.broadinstitute.consent.http.service.MatchMigrationService;
+import org.broadinstitute.consent.http.util.gson.GsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -70,7 +72,7 @@ class MatchMigrationResourceTest {
   @Test
   void testRun() {
     MatchMigrationRunResult result =
-        new MatchMigrationRunResult(
+        MatchMigrationRunResult.of(
             population(),
             population(),
             new MatchMigrationRunReport(409, 52, 405, 0, 0, 0, List.of(), List.of()),
@@ -92,11 +94,32 @@ class MatchMigrationResourceTest {
     assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
   }
 
+  /**
+   * Responses serialize with Gson, which reads fields and drops computed accessors. These three
+   * flags are the operator-facing gates, so they have to be components rather than methods.
+   */
+  @Test
+  void testRunResponseCarriesTheDerivedGates() {
+    MatchMigrationRunResult result =
+        MatchMigrationRunResult.of(
+            population(),
+            population(),
+            new MatchMigrationRunReport(409, 52, 405, 0, 0, 0, List.of(), List.of()),
+            reconciliation());
+    when(service.run()).thenReturn(result);
+    initResource();
+
+    String json = GsonUtil.getInstance().toJson(resource.run(duosUser).getEntity());
+    assertTrue(json.contains("\"readyForConstraints\""));
+    assertTrue(json.contains("\"reconciles\""));
+    assertTrue(json.contains("\"blocksConstraints\""));
+  }
+
   private static MatchMigrationPopulation population() {
-    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0);
+    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0, true);
   }
 
   private static SnapshotReconciliation reconciliation() {
-    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0);
+    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0, true);
   }
 }

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
@@ -70,6 +70,15 @@ class MatchMigrationResourceTest {
   }
 
   @Test
+  void testGetReconciliationHandlesAFailure() {
+    when(service.reconcile()).thenThrow(new IllegalStateException("boom"));
+    initResource();
+
+    Response response = resource.getReconciliation(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
   void testRun() {
     MatchMigrationRunResult result =
         MatchMigrationRunResult.of(

--- a/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/resources/MatchMigrationResourceTest.java
@@ -1,0 +1,102 @@
+package org.broadinstitute.consent.http.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import org.broadinstitute.consent.http.enumeration.UserRoles;
+import org.broadinstitute.consent.http.models.AuthUser;
+import org.broadinstitute.consent.http.models.DuosUser;
+import org.broadinstitute.consent.http.models.User;
+import org.broadinstitute.consent.http.models.UserRole;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationPopulation;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunReport;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunResult;
+import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
+import org.broadinstitute.consent.http.service.MatchMigrationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchMigrationResourceTest {
+
+  @Mock private MatchMigrationService service;
+
+  private final AuthUser authUser = new AuthUser("test");
+  private final List<UserRole> roles = List.of(UserRoles.Admin());
+  private final User user = new User(1, authUser.getEmail(), "Display Name", new Date(), roles);
+  private final DuosUser duosUser = new DuosUser(authUser, user);
+
+  private MatchMigrationResource resource;
+
+  private void initResource() {
+    resource = new MatchMigrationResource(service);
+  }
+
+  @Test
+  void testGetPopulation() {
+    when(service.findPopulation()).thenReturn(population());
+    initResource();
+
+    Response response = resource.getPopulation(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(population(), response.getEntity());
+  }
+
+  @Test
+  void testGetPopulationHandlesAFailure() {
+    when(service.findPopulation()).thenThrow(new IllegalStateException("boom"));
+    initResource();
+
+    Response response = resource.getPopulation(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  @Test
+  void testGetReconciliation() {
+    when(service.reconcile()).thenReturn(reconciliation());
+    initResource();
+
+    Response response = resource.getReconciliation(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(reconciliation(), response.getEntity());
+  }
+
+  @Test
+  void testRun() {
+    MatchMigrationRunResult result =
+        new MatchMigrationRunResult(
+            population(),
+            population(),
+            new MatchMigrationRunReport(409, 52, 405, 0, 0, 0, List.of(), List.of()),
+            reconciliation());
+    when(service.run()).thenReturn(result);
+    initResource();
+
+    Response response = resource.run(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.getStatus());
+    assertEquals(result, response.getEntity());
+  }
+
+  @Test
+  void testRunHandlesAFailure() {
+    when(service.run()).thenThrow(new IllegalStateException("boom"));
+    initResource();
+
+    Response response = resource.run(duosUser);
+    assertEquals(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, response.getStatus());
+  }
+
+  private static MatchMigrationPopulation population() {
+    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0);
+  }
+
+  private static SnapshotReconciliation reconciliation() {
+    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchMigrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchMigrationServiceTest.java
@@ -1,0 +1,208 @@
+package org.broadinstitute.consent.http.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.broadinstitute.consent.http.db.MatchMigrationDAO;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationPopulation;
+import org.broadinstitute.consent.http.models.matchmigration.MatchMigrationRunResult;
+import org.broadinstitute.consent.http.models.matchmigration.SnapshotReconciliation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchMigrationServiceTest {
+
+  @Mock private MatchMigrationDAO matchMigrationDAO;
+  @Mock private MatchService matchService;
+
+  private MatchMigrationService service;
+
+  private void initService() {
+    service = new MatchMigrationService(matchMigrationDAO, matchService);
+  }
+
+  /** The snapshot is what makes the run reversible, so nothing may be rebuilt before it exists. */
+  @Test
+  void testRunSnapshotsBeforeReprocessingAnything() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of("DAR-1"));
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    doNothing().when(matchService).reprocessMatchesForPurpose("DAR-1");
+    initService();
+
+    service.run();
+
+    InOrder inOrder = inOrder(matchMigrationDAO, matchService);
+    inOrder.verify(matchMigrationDAO).snapshotAffectedMatches();
+    inOrder.verify(matchMigrationDAO).snapshotAffectedRationales();
+    inOrder.verify(matchService).reprocessMatchesForPurpose("DAR-1");
+  }
+
+  /**
+   * An archived or missing DAR resolves to null, so a reprocess would delete its matches and insert
+   * nothing. The run must leave those rows alone and say which purposes it left.
+   */
+  @Test
+  void testRunNeverReprocessesAnUnresolvablePurpose() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of("DAR-archived"));
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    verify(matchService, never()).reprocessMatchesForPurpose("DAR-archived");
+    assertEquals(1, result.run().skipped());
+    assertEquals(List.of("DAR-archived"), result.run().skippedPurposeIds());
+    assertEquals(0, result.run().reprocessed());
+  }
+
+  @Test
+  void testRunRetriesAFailedPurposeOnceAndCountsItAsReprocessed() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of("DAR-flaky"));
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    doThrow(new IllegalStateException("transient"))
+        .doNothing()
+        .when(matchService)
+        .reprocessMatchesForPurpose("DAR-flaky");
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    verify(matchService, times(2)).reprocessMatchesForPurpose("DAR-flaky");
+    assertEquals(1, result.run().retried());
+    assertEquals(1, result.run().reprocessed());
+    assertEquals(0, result.run().failed());
+    assertTrue(result.run().failedPurposeIds().isEmpty());
+  }
+
+  @Test
+  void testRunReportsAPurposeThatFailedTwiceSoARerunCanBeScopedToIt() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of("DAR-broken"));
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    doThrow(new IllegalStateException("persistent"))
+        .when(matchService)
+        .reprocessMatchesForPurpose("DAR-broken");
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    verify(matchService, times(2)).reprocessMatchesForPurpose("DAR-broken");
+    assertEquals(1, result.run().failed());
+    assertEquals(List.of("DAR-broken"), result.run().failedPurposeIds());
+    assertEquals(0, result.run().reprocessed());
+  }
+
+  /** One purpose failing must not stop the ones after it. */
+  @Test
+  void testRunContinuesPastAFailedPurpose() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of("DAR-broken", "DAR-fine"));
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    doThrow(new IllegalStateException("persistent"))
+        .when(matchService)
+        .reprocessMatchesForPurpose("DAR-broken");
+    doNothing().when(matchService).reprocessMatchesForPurpose("DAR-fine");
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    verify(matchService).reprocessMatchesForPurpose("DAR-fine");
+    assertEquals(1, result.run().failed());
+    assertEquals(1, result.run().reprocessed());
+  }
+
+  @Test
+  void testRunIsNotReadyForConstraintsWhileRowsRemainUnaccountedFor() {
+    SnapshotReconciliation unreconciled =
+        new SnapshotReconciliation(409, 0, 409, 0, 405, 405, 0, 409);
+    stubPopulationAndReconciliation(blockedPopulation(), unreconciled);
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    assertFalse(result.reconciliation().reconciles());
+    assertFalse(result.readyForConstraints());
+  }
+
+  /** A clean reconciliation is not enough on its own: an existing pair collision still blocks. */
+  @Test
+  void testRunIsNotReadyForConstraintsWhileAPairCollisionRemains() {
+    MatchMigrationPopulation collision = new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+    stubPopulationAndReconciliation(collision, reconciled());
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    assertTrue(result.reconciliation().reconciles());
+    assertTrue(result.after().blocksConstraints());
+    assertFalse(result.readyForConstraints());
+  }
+
+  @Test
+  void testRunReportsTheSnapshotTotalsItCaptured() {
+    stubPopulationAndReconciliation(clearPopulation(), reconciled());
+    when(matchMigrationDAO.snapshotAffectedMatches()).thenReturn(409);
+    when(matchMigrationDAO.snapshotAffectedRationales()).thenReturn(52);
+    when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
+    when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
+    initService();
+
+    MatchMigrationRunResult result = service.run();
+
+    assertEquals(409, result.run().snapshottedMatches());
+    assertEquals(52, result.run().snapshottedRationales());
+  }
+
+  @Test
+  void testFindPopulationAndReconcileWriteNothing() {
+    when(matchMigrationDAO.findPopulation()).thenReturn(clearPopulation());
+    when(matchMigrationDAO.reconcile()).thenReturn(reconciled());
+    initService();
+
+    service.findPopulation();
+    service.reconcile();
+
+    verify(matchMigrationDAO, never()).snapshotAffectedMatches();
+    verify(matchMigrationDAO, never()).snapshotAffectedRationales();
+    verify(matchService, never()).reprocessMatchesForPurpose(any());
+  }
+
+  private void stubPopulationAndReconciliation(
+      MatchMigrationPopulation population, SnapshotReconciliation reconciliation) {
+    when(matchMigrationDAO.findPopulation()).thenReturn(population);
+    when(matchMigrationDAO.reconcile()).thenReturn(reconciliation);
+  }
+
+  private static MatchMigrationPopulation clearPopulation() {
+    return new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  }
+
+  private static MatchMigrationPopulation blockedPopulation() {
+    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0);
+  }
+
+  private static SnapshotReconciliation reconciled() {
+    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0);
+  }
+}

--- a/src/test/java/org/broadinstitute/consent/http/service/MatchMigrationServiceTest.java
+++ b/src/test/java/org/broadinstitute/consent/http/service/MatchMigrationServiceTest.java
@@ -131,7 +131,7 @@ class MatchMigrationServiceTest {
   @Test
   void testRunIsNotReadyForConstraintsWhileRowsRemainUnaccountedFor() {
     SnapshotReconciliation unreconciled =
-        new SnapshotReconciliation(409, 0, 409, 0, 405, 405, 0, 409);
+        new SnapshotReconciliation(409, 0, 409, 0, 405, 405, 0, 409, false);
     stubPopulationAndReconciliation(blockedPopulation(), unreconciled);
     when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
     when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
@@ -146,7 +146,8 @@ class MatchMigrationServiceTest {
   /** A clean reconciliation is not enough on its own: an existing pair collision still blocks. */
   @Test
   void testRunIsNotReadyForConstraintsWhileAPairCollisionRemains() {
-    MatchMigrationPopulation collision = new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+    MatchMigrationPopulation collision =
+        new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 1, true);
     stubPopulationAndReconciliation(collision, reconciled());
     when(matchMigrationDAO.findResolvablePurposes()).thenReturn(List.of());
     when(matchMigrationDAO.findUnresolvablePurposes()).thenReturn(List.of());
@@ -195,14 +196,14 @@ class MatchMigrationServiceTest {
   }
 
   private static MatchMigrationPopulation clearPopulation() {
-    return new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    return new MatchMigrationPopulation(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
   }
 
   private static MatchMigrationPopulation blockedPopulation() {
-    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0);
+    return new MatchMigrationPopulation(409, 405, 409, 0, 0, 409, 405, 0, 4, 0, true);
   }
 
   private static SnapshotReconciliation reconciled() {
-    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0);
+    return new SnapshotReconciliation(409, 409, 0, 0, 405, 405, 0, 0, true);
   }
 }


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-3942 — security risk: low

**Stacked on #3057** and targeting `km-dt-3942-match-dataset-id` so the diff shows only this phase. GitHub will retarget it to `develop` when #3057 merges. This needs #3057 deployed everywhere before the run is executed anywhere.

## Summary

Phase 2a: the snapshot tables and the admin surface that reprocesses the match rows still identifying their dataset by legacy text, so they rebuild carrying a real `dataset_id` at the current algorithm version.

Reprocesses rather than backfills. The legacy `consent` values are consent UUIDs whose dataset mapping was dropped in 2024, so no mapping can be derived without guessing — endorsed on review, and it is what the application already does whenever a DAR is edited.

Modelled on the Ticket 4 migration surface (`LegacyDataUseResource`/`LegacyDataUseService`) that DT-4009 retired, so retiring this one is the same clean delete.

### Release sequencing

The constraints are deliberately **not** in this PR. Liquibase applies changesets on deploy, so shipping them here would run them before any environment had cleared the rows they reject, and the precondition would halt the deploy. Three releases:

| Release | Contents | Gate to the next |
| --- | --- | --- |
| A (#3057) | Nullable `dataset_id`, dual write, dataset-correlated election join | Deployed everywhere |
| B (this PR) | Snapshot tables and the admin migration surface | `run` reports `readyForConstraints` |
| C | Non-null and `(purpose, dataset_id)` uniqueness constraints; retire the surface | Confirmed good in prod |

### What it does

**Snapshot** — `match_migration_snapshot` and `match_migration_rationale_snapshot`, created empty and populated when the run executes, because the affected set drains on its own as DARs are re-matched. No foreign key to `match_entity` by design: the run deletes the very rows captured, so a reference would either block the delete or cascade the evidence away. Inserts are `ON CONFLICT DO NOTHING`, so a re-run after a partial failure keeps the first, pre-migration capture instead of overwriting it with post-run state.

**Affected set** — defined by what the constraints will reject (no `dataset_id`, or a `v1`/`v2`/absent stamp) rather than by algorithm version alone. Versions are reported separately because the acceptance criteria count those populations, but they are not what selects the work.

**Skip guard** — `findByReferenceId` filters archived DARs, so a purpose whose DAR is archived or missing would rebuild to nothing and lose its rows. Those purposes are skipped and reported by id, never reprocessed.

**Restartable** — each purpose is rebuilt in its own transaction, one retry apiece, continuing past failures and reporting `failedPurposeIds` so a rerun can be scoped. Failures log the exception class, never the message, which can quote a DAR's free text.

**Endpoints**, all `@RolesAllowed(ADMIN)` and documented in OpenAPI:

- `GET /api/match/migration/dataset-id/population` — read-only, recounts the affected set
- `GET /api/match/migration/dataset-id/reconciliation` — read-only, for a later confirmation pass
- `POST /api/match/migration/dataset-id/run` — snapshots, then rebuilds; returns the population either side plus the reconciliation

Pre-deployment, post-deployment, and rollback validation is recorded under Ticket 5 of `docs/plans/data-use-primary-consistency-plan.md`, alongside the rest of the epic's design.

### Testing

28 new tests, all passing. 14 DAO tests run against real Postgres and cover the population counts, the archived/missing-DAR partitioning, snapshot idempotency, and each reconciliation invariant separately — a row still present, a row replaced under a new id, a purpose rebuilt to nothing, and a skipped row that is still affected. 9 service tests cover snapshot-before-rebuild ordering, the skip guard, retry-once, continuing past a failure, and both ways `readyForConstraints` can be refused. 5 resource tests cover the endpoints and their failure path. The 31 Phase 1 match tests still pass; spotless clean.

### Reviewer notes

- `readyForConstraints` also refuses on a pre-existing `(purpose, dataset_id)` collision, which this migration does not create and cannot fix. That is step 6 of the ticket, but it does mean the run can report "not ready" for something needing a separate decision.
- The skipped set has no owner yet. Production has zero archived-DAR purposes today, so it may stay empty — but any that appear keep a null `dataset_id` and would halt release C's precondition. Worth deciding with the run results rather than now: delete them, or exclude them with a partial constraint.
- `SnapshotReconciliation.purposesHoldingMatches` is named for the state, not the cause: a skipped purpose still holds its original rows and counts there without having been rebuilt. Called out because an operator reads these numbers.
- `findResolvablePurposes` returns an unbounded list. It is bounded in practice by the affected population — a few hundred ids, shrinking — so it is not paginated.
- `MatchMigrationDAO` repeats the archived-status condition from `DataAccessRequestDAO.findByReferenceId` rather than sharing it. The run has to predict that lookup exactly, so if it changes these queries should be revisited deliberately rather than silently following it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
